### PR TITLE
fix(upstream): pass UPSTREAM_PR_PAT to github-script steps

### DIFF
--- a/.github/workflows/upstream-merge.yml
+++ b/.github/workflows/upstream-merge.yml
@@ -107,6 +107,8 @@ jobs:
         if: steps.report.outputs.any_new == '1'
         uses: actions/github-script@v8
         with:
+          # PAT so pulls.create is allowed — GITHUB_TOKEN is blocked from creating PRs.
+          github-token: ${{ secrets.UPSTREAM_PR_PAT || github.token }}
           script: |
             const { owner, repo } = context.repo;
             const existing = await github.rest.pulls.list({
@@ -231,6 +233,8 @@ jobs:
           HAD_CONFLICTS: ${{ steps.merge.outputs.had_conflicts }}
           DATE: ${{ steps.merge.outputs.date }}
         with:
+          # PAT so pulls.create is allowed — GITHUB_TOKEN is blocked from creating PRs.
+          github-token: ${{ secrets.UPSTREAM_PR_PAT || github.token }}
           script: |
             const fs = require('fs');
             const { owner, repo } = context.repo;
@@ -290,6 +294,8 @@ jobs:
         if: steps.report.outputs.any_new == '0'
         uses: actions/github-script@v8
         with:
+          # PAT so pulls.create is allowed — GITHUB_TOKEN is blocked from creating PRs.
+          github-token: ${{ secrets.UPSTREAM_PR_PAT || github.token }}
           script: |
             const { owner, repo } = context.repo;
             const head = 'bot/upstream-merge';


### PR DESCRIPTION
Follow-up to #8. The drafted-PR run failed with GitHub Actions is not permitted to create or approve pull requests because the `actions/github-script` steps default to `GITHUB_TOKEN` (blocked from creating PRs) — the PAT was only wired to `checkout` (git push). This passes `github-token: secrets.UPSTREAM_PR_PAT` to the guard / create / close-stale script steps so `pulls.create` runs as the PAT.

After merge, re-dispatch to retry the draft-PR path.