### PR TITLE
ci(upstream): make committed conflicts an obvious, named gate

### DIFF
--- a/.github/workflows/conflict-check.yml
+++ b/.github/workflows/conflict-check.yml
@@ -1,0 +1,52 @@
+name: conflict-markers
+
+# Fast, explicit gate: fails a PR that contains committed merge-conflict markers. The upstream-merge
+# workflow deliberately COMMITS conflict markers into its draft PR (so the PR is always a complete unit),
+# which git/GitHub then see as ordinary text — the PR shows "no conflicts / ready to merge" even though it
+# must NOT be merged. This check is the clear, named signal that says exactly what is wrong, and where.
+# Make it a REQUIRED status check on develop so GitHub blocks the merge button. See docs/UPSTREAM_MERGES.md.
+
+on:
+  pull_request:
+
+jobs:
+  conflict-markers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Scan for unresolved conflict markers
+        shell: bash
+        run: |
+          set -uo pipefail
+          # Hunk-start markers (and the diff3 base marker). These never occur in real source/docs, so a
+          # plain "=======" line is intentionally NOT matched (it appears in Markdown / comment dividers).
+          pattern='^(<{7}|>{7}|\|{7})( |$)'
+          hits=$(git grep -nE "$pattern" -- . ':(exclude).github/workflows/conflict-check.yml' || true)
+
+          if [ -z "$hits" ]; then
+            echo "✅ No unresolved conflict markers." | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          count=$(printf '%s\n' "$hits" | wc -l | tr -d ' ')
+          {
+            echo "## ⛔ Unresolved merge-conflict markers ($count)"
+            echo ""
+            echo "This PR has committed conflict markers and **must not be merged** until they are resolved."
+            echo "GitHub's \"ready to merge\" / \"no conflicts\" is misleading here — the markers are plain text"
+            echo "inside the files, not a git-level conflict. Resolve them on the source branch, then this"
+            echo "check goes green."
+            echo ""
+            echo '```'
+            printf '%s\n' "$hits"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Inline red annotations on the exact lines (visible in the Files-changed tab).
+          while IFS=: read -r file line _; do
+            [ -n "$file" ] && echo "::error file=${file},line=${line}::Unresolved merge-conflict marker — resolve before merging"
+          done <<< "$hits"
+
+          echo "::error::Found $count conflict-marker line(s). See annotations and the job summary."
+          exit 1

--- a/.github/workflows/upstream-merge.yml
+++ b/.github/workflows/upstream-merge.yml
@@ -239,14 +239,19 @@ jobs:
             const fs = require('fs');
             const { owner, repo } = context.repo;
             const head = 'bot/upstream-merge';
-            const title = `Upstream merge → ${process.env.DATE}`;
+            const conflicts = process.env.HAD_CONFLICTS === '1';
+            const title = `${conflicts ? '⛔ CONFLICTS — DO NOT MERGE: ' : ''}Upstream merge → ${process.env.DATE}`;
 
             let body = fs.readFileSync(process.env.REPORT_PATH, 'utf8');
             if (process.env.HAD_CONFLICTS === '1') {
               let conf = '';
               try { conf = fs.readFileSync(process.env.CONFLICTS_PATH, 'utf8'); } catch (e) {}
-              body = '> ⚠️ **Conflict markers were committed** — this PR will not build until they are '
-                   + 'resolved on the `bot/upstream-merge` branch.\n\n'
+              body = '> # ⛔ DO NOT MERGE — unresolved conflict markers\n'
+                   + '> GitHub may show this as "ready to merge" / "no conflicts" — **ignore that.** '
+                   + 'It only means the branch fast-forwards into develop; the conflicts are committed '
+                   + '*inside* the files as markers. The **`conflict-markers`** check below is red and lists '
+                   + 'the exact `file:line`. Resolve them on the `bot/upstream-merge` branch (keep COMBO_BUILD '
+                   + 'blocks — see docs/UPSTREAM_MERGES.md) until that check goes green.\n\n'
                    + '<details><summary>conflicted files</summary>\n\n```\n' + conf + '```\n</details>\n\n'
                    + body;
             }


### PR DESCRIPTION
Follow-up to #8 / #9. Fixes the real problem from testing PR #10: **the PR showed "ready to merge" while it contained committed conflict markers**, and the only hint was a slow, cryptic `clang-format` failure.

## Changes
- **New `conflict-markers` gate** (`conflict-check.yml`, every PR): scans for committed conflict markers, fails fast with a clearly-named check, **inline red annotations on the exact `file:line`**, and a job summary listing every hit. Matches only hunk-start markers (`<<<<<<<` / `>>>>>>>` / `|||||||`) — not bare `=======` (avoids Markdown false positives).
- **`upstream-merge.yml`**: drafted PR title gets a `⛔ CONFLICTS — DO NOT MERGE:` prefix when markers were committed, and the body banner now says plainly that GitHub's "ready to merge" is misleading and the `conflict-markers` check is the real signal.

## Follow-up after merge (makes GitHub actually block it)
Add **branch protection on `develop` requiring the `conflict-markers` status check** so the merge button flips to *"Merging is blocked"* instead of green. I can set this via `gh api` on your go-ahead.

Note: the gate applies to **future** drafted PRs (the `bot/upstream-merge` branch is rebuilt off `develop` each run, so it carries the gate); existing PR #10 won't get it retroactively.