### PR TITLE
ci(build): gate the Windows build behind a fast conflict+format check

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -22,7 +22,39 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Fast gate so the ~40-min Windows build doesn't run on a PR that already has committed conflict
+  # markers or formatting errors. Mirrors conflict-check.yml + clang-format.yml (which remain the
+  # branch-protection required checks); this copy exists only to give the build a `needs:` dependency,
+  # since GitHub can't make this workflow depend on a job in another file. If the gate fails the build
+  # is skipped (reported as success — a skipped job never blocks); the standalone required checks still
+  # go red and block the merge. See docs/UPSTREAM_MERGES.md.
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 2
+      - name: Scan for conflict markers
+        shell: bash
+        run: |
+          set -uo pipefail
+          hits=$(git grep -nE '^(<{7}|>{7}|\|{7})( |$)' -- . \
+                 ':(exclude).github/workflows/build-artifacts.yml' \
+                 ':(exclude).github/workflows/conflict-check.yml' || true)
+          if [ -n "$hits" ]; then
+            echo "::error::Unresolved conflict markers — skipping the build until resolved:"
+            printf '%s\n' "$hits"
+            exit 1
+          fi
+          echo "No conflict markers."
+      - name: clang-format (clang-format-14)
+        run: |
+          sudo apt-get update && sudo apt-get install -y clang-format-14
+          ./run-clang-format.sh
+          git diff --exit-code
+
   build-artifacts:
+    needs: gate
     # Pin to VS 2022 image — matches the "Visual Studio 17 2022" generator below (see build-windows.yml).
     runs-on: windows-2022
     steps:


### PR DESCRIPTION
Defers the ~40-min Windows `build-artifacts` build until the cheap checks pass, so a PR with committed conflict markers or formatting errors doesn't waste it.

**How:** adds a fast ubuntu `gate` job (conflict-marker scan + `clang-format-14`) and makes the windows build `needs: gate`. GitHub can't make one workflow depend on a job in another file, so the gate duplicates the cheap checks; the standalone `conflict-markers` / `clang-format` workflows stay as the branch-protection required checks.

**Safety:** if the gate fails, the build job is skipped — and a skipped job [reports success and never blocks a merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks). The red standalone required checks still block the merge, so nothing slips through.

Applies to PRs going forward (a PR's checks come from its own branch). Builds on this PR, so `gate` → build runs here as a live test.