### PR TITLE
ci(pr-artifacts): grant PR-write so artifact links can post

### DIFF
--- a/.github/workflows/pr-artifacts.yml
+++ b/.github/workflows/pr-artifacts.yml
@@ -10,6 +10,13 @@ on:
     types:
       - completed
 
+# The repo's default workflow token is read-only, so pr-section can't edit the PR body
+# ("Resource not accessible by integration"). Grant just this workflow PR write (least privilege;
+# workflow_run is a trusted context). contents:read keeps actions/checkout-style reads working.
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   pr-artifacts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes `pr-artifacts` failing to attach the build download links to PRs.

## Root cause
The build *did* succeed and the artifact uploaded, and `pr-artifacts` found the PR (#16) correctly — but the `garrettjoecox/pr-section` step failed with **`HttpError: Resource not accessible by integration`**. The repo's default workflow token permission is **read-only** (`default_workflow_permissions: read`) and `pr-artifacts.yml` had no `permissions:` block, so its `GITHUB_TOKEN` couldn't edit the PR body.

## Fix
Add a least-privilege `permissions:` block (`pull-requests: write`) to this workflow only — no need to loosen the repo-wide default. `workflow_run` is a trusted context, so the token can hold write.

## Note
Must be on `develop` to take effect (`workflow_run` always uses the default-branch copy of the workflow). After merge, re-trigger a build on a PR (push a commit or re-run build-artifacts) and the links should attach.