### PR TITLE
MM toast notifications + cross-world fill skill-item fix

### DIFF
--- a/combo/CMakeLists.txt
+++ b/combo/CMakeLists.txt
@@ -91,61 +91,29 @@ add_dependencies(ComboShip
 
 # Windows-specific settings
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    # ComboShip: build the exe straight into the shared runtime dir (x64/<config>), matching how the
+    # game DLLs (soh/2ship/libultraship/comboui) set their own output dir. x64/<config> is then the
+    # SINGLE deploy location — the exe and every DLL already land here, so there is no second copy in
+    # the per-target build tree (build/x64/combo/<config>) to go stale and cause a stale-DLL launch.
     set_target_properties(ComboShip PROPERTIES
         OUTPUT_NAME "ComboShip"
+        RUNTIME_OUTPUT_DIRECTORY_DEBUG   "${CMAKE_SOURCE_DIR}/x64/Debug"
+        RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_SOURCE_DIR}/x64/Release"
     )
-    
-    # Copy ComboShip.exe, game DLLs, and libultraship.dll to Combo/x64/Debug and to ComboShip's build dir.
-    # The PORT/custom asset archives (soh/soh.o2r, mm/2ship.o2r) are produced by the GenerateSohOtr /
-    # Generate2ShipOtr targets (extract_assets.py --norom — NO ROM needed; they pack the tracked
-    # assets/custom tree). They are gitignored as large generated binaries, so they exist on a dev
-    # machine that has run those targets but are absent on the compile-only CI gate, which runs neither.
-    # Their copy is therefore guarded by an EXISTS check below (separate POST_BUILD block) so that gate
-    # does not fail. The ROM-extracted archives (oot.o2r, mm.o2r) are the user's to generate at first launch.
+
+    # The exe and all game DLLs already land in x64/<config> (their own output dirs), so only the asset
+    # tree and the PORT/custom .o2r archives need deploying. $<TARGET_FILE_DIR:ComboShip> == x64/<config>,
+    # so this is config-correct for Debug AND Release.
+    #
+    # Extractor assets (flat structure matching CallZapd expectations). ComboShip runs BOTH the OOT (soh)
+    # and MM (2ship) extractors, so merge both games' extractor + xml dirs into one assets/ tree.
+    # Clear the destination assets/ FIRST: copy_directory merges and never deletes, so a file
+    # renamed/removed upstream (e.g. mm object_rs -> object_rsn) would leave a STALE .xml that ZAPD then
+    # fails on ("Raw data size: 0x0", reached EOF). Clearing makes the source tree authoritative each
+    # build. (The user's ROM/port archives live in the dir root, NOT under assets/, so this is safe.)
+    # See docs/merges/2026-06-20.md.
     add_custom_command(TARGET ComboShip POST_BUILD
-        # Copy ComboShip.exe to x64/Debug
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            $<TARGET_FILE:ComboShip>
-            ${CMAKE_SOURCE_DIR}/x64/Debug/ComboShip.exe
-        # Copy game DLLs to x64/Debug
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            $<TARGET_FILE:soh>
-            ${CMAKE_SOURCE_DIR}/x64/Debug/soh.dll
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            $<TARGET_FILE:2ship>
-            ${CMAKE_SOURCE_DIR}/x64/Debug/2ship.dll
-        # Copy shared engine DLL to x64/Debug
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            $<TARGET_FILE:libultraship>
-            ${CMAKE_SOURCE_DIR}/x64/Debug/libultraship.dll
-        # Copy combo UI DLL to x64/Debug
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            $<TARGET_FILE:comboui>
-            ${CMAKE_SOURCE_DIR}/x64/Debug/comboui.dll
-        # Also copy DLLs to ComboShip's build directory for local testing
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            $<TARGET_FILE:soh>
-            $<TARGET_FILE_DIR:ComboShip>
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            $<TARGET_FILE:2ship>
-            $<TARGET_FILE_DIR:ComboShip>
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            $<TARGET_FILE:libultraship>
-            $<TARGET_FILE_DIR:ComboShip>
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            $<TARGET_FILE:comboui>
-            $<TARGET_FILE_DIR:ComboShip>
-        # Extractor assets (flat structure matching CallZapd expectations). ComboShip runs BOTH
-        # the OOT (soh) and MM (2ship) extractors, so merge both games' extractor + xml dirs into
-        # one assets/ tree.
-        # ComboShip: clear the destination assets/ FIRST. copy_directory merges and never deletes, so
-        # a file renamed/removed upstream (e.g. mm object_rs -> object_rsn) leaves a STALE .xml that
-        # ZAPD then tries to extract and fails on ("Raw data size: 0x0", reached EOF). Clearing makes
-        # the source tree authoritative each build. (The user's ROM/port archives live in the dir root,
-        # NOT under assets/, so this is safe.) See docs/merges/2026-06-20.md.
         COMMAND ${CMAKE_COMMAND} -E rm -rf $<TARGET_FILE_DIR:ComboShip>/assets
-        COMMAND ${CMAKE_COMMAND} -E rm -rf ${CMAKE_SOURCE_DIR}/x64/Debug/assets
-        # --- next to the exe (config-correct: covers Debug AND Release build dirs) ---
         COMMAND ${CMAKE_COMMAND} -E copy_directory
             ${CMAKE_SOURCE_DIR}/soh/assets/extractor
             $<TARGET_FILE_DIR:ComboShip>/assets
@@ -158,19 +126,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         COMMAND ${CMAKE_COMMAND} -E copy_directory
             ${CMAKE_SOURCE_DIR}/mm/assets/xml
             $<TARGET_FILE_DIR:ComboShip>/assets/xml
-        # --- legacy x64/Debug runtime dir (both games) ---
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-            ${CMAKE_SOURCE_DIR}/soh/assets/extractor
-            ${CMAKE_SOURCE_DIR}/x64/Debug/assets
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-            ${CMAKE_SOURCE_DIR}/soh/assets/xml
-            ${CMAKE_SOURCE_DIR}/x64/Debug/assets/xml
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-            ${CMAKE_SOURCE_DIR}/mm/assets/extractor
-            ${CMAKE_SOURCE_DIR}/x64/Debug/assets
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-            ${CMAKE_SOURCE_DIR}/mm/assets/xml
-            ${CMAKE_SOURCE_DIR}/x64/Debug/assets/xml
     )
 
     # PORT/custom .o2r deploy — guarded so a missing archive doesn't fail the build (see comment above).
@@ -181,8 +136,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         add_custom_command(TARGET ComboShip POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_if_different
                 ${CMAKE_SOURCE_DIR}/soh/soh.o2r $<TARGET_FILE_DIR:ComboShip>/soh.o2r
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                ${CMAKE_SOURCE_DIR}/soh/soh.o2r ${CMAKE_SOURCE_DIR}/x64/Debug/soh.o2r
         )
     else()
         message(STATUS "ComboShip: soh/soh.o2r not found — skipping .o2r deploy (run GenerateSohOtr to produce it).")
@@ -191,8 +144,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         add_custom_command(TARGET ComboShip POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_if_different
                 ${CMAKE_SOURCE_DIR}/mm/2ship.o2r $<TARGET_FILE_DIR:ComboShip>/2ship.o2r
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                ${CMAKE_SOURCE_DIR}/mm/2ship.o2r ${CMAKE_SOURCE_DIR}/x64/Debug/2ship.o2r
         )
     else()
         message(STATUS "ComboShip: mm/2ship.o2r not found — skipping .o2r deploy (run Generate2ShipOtr to produce it).")

--- a/combo/gui/ComboTrackerVisibility.cpp
+++ b/combo/gui/ComboTrackerVisibility.cpp
@@ -1,10 +1,22 @@
 // combo/gui/ComboTrackerVisibility.cpp
 //
-// ComboShip-owned: makes the Check/Item tracker popouts "follow" the active game. Only the
-// foreground game's tracker windows are shown; the other game's are hidden. This is both the
-// feature the user asked for (a tracker that switches OOT<->MM) AND a correctness requirement:
-// the single shared libultraship Gui draws EVERY registered window each frame, and a background
-// game's DrawElement would run against that DLL's stale per-module ImGui context.
+// ComboShip-owned: makes per-game GUI windows "follow" the active game. Only the foreground game's
+// windows participate in the shared Gui's draw loop; the other game's are suppressed. This covers
+// the Check/Item tracker popouts AND the toast/notification window. It is both the feature the user
+// asked for (UI that switches OOT<->MM) AND a correctness requirement: the single shared libultraship
+// Gui draws EVERY registered window each frame, and a background game's Draw/UpdateElement would run
+// against that DLL's stale per-module ImGui context.
+//
+// Trackers and notifications use DIFFERENT levers:
+//   - Trackers honor GuiWindow visibility, so toggling Show()/Hide() (+ the CVar) gates their Draw().
+//   - Notification::Window OVERRIDES Draw() and ignores IsVisible(), and GuiElement::Update() runs
+//     UpdateElement() unconditionally. So Hide() does NOT stop a notification window. The only reliable
+//     lever is map presence: a RemoveGuiWindow'd window is skipped by the draw loop entirely (both
+//     Update and Draw). We re-add the SAME already-initialized object on the way back (never a fresh
+//     one), which avoids the 0xCD re-registration crash the resident-window model guards against
+//     (see soh/soh/OTRGlobals.cpp:1753 / :2741). We hold it as a weak_ptr so the window stays owned
+//     solely by its own DLL (its mNotificationWindow member) — no cross-DLL shared_ptr, no shutdown
+//     dtor-order hazard.
 //
 // Lives in comboui.dll because it links libultraship (CVar API + the shared Gui) and stays mapped
 // for the whole process. The launcher (combo/ComboShip.cpp) calls the exports at each game
@@ -15,6 +27,7 @@
 // the duplicate-name rejection in Gui::AddGuiWindow while keeping the visible title identical).
 
 #include <libultraship/libultraship.h> // Ship::Context / Gui + CVarGet/SetInteger
+#include <memory>                      // std::weak_ptr (notification-window handle)
 
 namespace {
 
@@ -59,6 +72,40 @@ void SetTracker(const TrackerWin& w, bool visible) {
     }
 }
 
+// Notification windows: OOT registers the plain name; MM appends "##MM" (BenGui.cpp). Indexed by
+// game: 0 = OOT, 1 = MM. These are gated by Gui-map presence, NOT visibility — see the file header.
+const char* const kNotificationWin[2] = {
+    "Notifications Window",     // OOT (soh)
+    "Notifications Window##MM", // MM (2ship)
+};
+
+// weak_ptr handles so the windows stay owned solely by their own game DLL (their mNotificationWindow
+// member keeps them alive); we only need a handle to re-add the backgrounded one later.
+std::weak_ptr<Ship::GuiWindow> sNotif[2];
+
+// Keep only the foreground game's notification window in the shared Gui's draw loop.
+void SetForegroundNotification(int fg) {
+    auto ctx = Ship::Context::GetInstance();
+    if (!ctx || !ctx->GetWindow() || !ctx->GetWindow()->GetGui()) {
+        return;
+    }
+    auto gui = ctx->GetWindow()->GetGui();
+    const int bg = fg ^ 1;
+
+    // Background game: capture a handle (so we can re-add it on return) and drop it from the draw loop.
+    if (auto win = gui->GetGuiWindow(kNotificationWin[bg])) {
+        sNotif[bg] = win;
+        gui->RemoveGuiWindow(kNotificationWin[bg]);
+    }
+    // Foreground game: re-add the SAME (already-initialized) object if it was previously removed and is
+    // not currently present. Init() on re-add is a guarded no-op; no fresh window is ever created.
+    if (!gui->GetGuiWindow(kNotificationWin[fg])) {
+        if (auto win = sNotif[fg].lock()) {
+            gui->AddGuiWindow(win);
+        }
+    }
+}
+
 } // namespace
 
 // Called by the launcher whenever a game becomes the foreground game (0 = OOT, 1 = MM).
@@ -82,6 +129,10 @@ extern "C" __declspec(dllexport) void ComboUI_OnForegroundGame(int game) {
         }
         SetTracker(kTrackers[fg][i], sIntent[fg][i] != 0);
     }
+
+    // Notification window follows the active game too (so MM's toasts show only while MM is foreground
+    // and OOT's only while OOT is). Independent of the tracker intent above.
+    SetForegroundNotification(fg);
 }
 
 // Called by the launcher just before shutdown teardown. Restores both games' tracker CVars to the

--- a/docs/UPSTREAM_MERGES.md
+++ b/docs/UPSTREAM_MERGES.md
@@ -878,6 +878,35 @@ context. The user wants the popout trackers to follow the active game (OOT↔MM)
 The active-game gating is also what keeps the two games' identically-titled inner `ImGui::Begin("Item
 Tracker")` / `ImGui::Begin("Check Tracker")` calls from ever running in the same frame.
 
+## Toast/notification window: collision fix + active-game gating (issue #28, 2026-06-22)
+
+**Why:** Same class of bug as the trackers above. Both soh and mm already have a near-identical
+notification (toast) system, and both register their window under the identical name
+`"Notifications Window"`. The single shared libultraship `Gui::AddGuiWindow` **rejects duplicates**, and
+OOT boots first, so MM's notification window was silently dropped — MM toasts (item pickups, the
+ComboShip "Sent to Hyrule" cross-world send, Anchor events) never appeared in the combined build, even
+though the emitters exist and work in standalone MM. The user wants the active game's toasts to show.
+
+**Vendored (one line, `COMBO_BUILD`-guarded):**
+- `mm/2s2h/BenGui/BenGui.cpp` — MM's notification window registration appends `COMBO_MM_TRACKER_SUFFIX`
+  (`"##MM"`) to its name, exactly like the tracker windows. Map-key only; the name isn't displayed
+  (`Notification::Window::Draw` titles its ImGui windows `notification#<id>`). No change to MM's
+  notification behavior. Non-combo builds get the empty suffix (unchanged).
+
+**Combo-owned:**
+- `combo/gui/ComboTrackerVisibility.cpp` — `ComboUI_OnForegroundGame` now also gates the notification
+  window. Unlike trackers, `Notification::Window` overrides `Draw()` and ignores `IsVisible()` (and
+  `GuiElement::Update()` runs `UpdateElement()` unconditionally), so `Show()/Hide()` does NOT suppress
+  it. Instead the background game's window is `RemoveGuiWindow`'d (dropped from the draw loop entirely,
+  stopping both `Draw` and `UpdateElement`) and the foreground game's is re-added — the SAME
+  already-initialized object (a `weak_ptr` handle; the window stays owned by its game DLL's
+  `mNotificationWindow` member, so no cross-DLL ownership / shutdown-dtor hazard, and no fresh window
+  is created → no 0xCD re-registration crash). No CVar/intent bookkeeping (notifications have no user
+  open/close toggle), so `ComboUI_RestoreTrackerIntent` is unchanged.
+
+The "Sent to Hyrule" toast itself was already implemented (`mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp`,
+`Rando_SendForeignCheck`); this change only makes MM's window survive registration so it can show.
+
 ## Cross-world Link's Pocket placement (2026-06-21)
 
 Link's Pocket is a rando-only OOT check with no vanilla item, so it's absent from the cross-world

--- a/docs/UPSTREAM_MERGES.md
+++ b/docs/UPSTREAM_MERGES.md
@@ -907,6 +907,30 @@ though the emitters exist and work in standalone MM. The user wants the active g
 The "Sent to Hyrule" toast itself was already implemented (`mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp`,
 `Rando_SendForeignCheck`); this change only makes MM's window survive registration so it can show.
 
+## Cross-world pool: inject settings-added skill items (2026-06-22)
+
+**Why:** The cross-world dump (`SOH_DumpRandoStaticData`) builds the combined fill's item pool from each
+check's **vanilla** item (`loc->GetVanillaItem()`). That silently omits every item the *settings ADD* to
+the pool — most importantly the shuffled "skill" items: `RG_OPEN_CHEST`, `RG_SPEAK_*`, `RG_CLIMB`,
+`RG_CRAWL` (when `RSK_SHUFFLE_OPEN_CHEST` / `_SPEAK` / `_CLIMB` / `_CRAWL` are on). Those grant the logic
+flags `CAN_OPEN_CHEST` / `CAN_SPEAK_*` etc. — and **every chest, deku scrub, and shop check gates on
+them** (e.g. `logic.cpp` chest access = `CheckRandoInf(RAND_INF_CAN_OPEN_CHEST)`). With the items absent
+from the pool, the oracle never grants the flags, so all chests/scrubs/shops are logically unreachable
+(OOT showed 145/470 reachable with a "full" inventory), and the assumed fill dead-ends. Standalone SoH
+works because it fills from the real `GenerateItemPool()`, which adds these items; our combined fill took
+a vanilla-per-check shortcut that drops them.
+
+**Vendored (`COMBO_BUILD`-guarded, `soh/soh/OTRGlobals.cpp`):** after the per-check dump loop, inject the
+enabled skill items into the emitted pool, overwriting an equal number of junk slots so items stay 1:1
+with checks. Swim/Grab need no injection (they map to Progressive Scale/Strength, already carried by the
+vanilla pool). Verified: OOT reachable 145→460, seeds 1234–1238 generate (5/5).
+
+**Known limitation / follow-up:** this is targeted at the skill items. Other settings-added items (Mask
+Quest, Roc's Feather, Skeleton Key, Triforce Hunt, …) are still omitted by the vanilla-per-check pool and
+would hit the same gap if enabled. The robust fix is to source the cross-world pool from the real
+`GenerateItemPool()` (and reconcile the fill's item==check accounting + fixed placements) rather than
+per-check vanilla items.
+
 ## Cross-world Link's Pocket placement (2026-06-21)
 
 Link's Pocket is a rando-only OOT check with no vanilla item, so it's absent from the cross-world

--- a/mm/2s2h/BenGui/BenGui.cpp
+++ b/mm/2s2h/BenGui/BenGui.cpp
@@ -208,7 +208,12 @@ void SetupGuiElements() {
         "gWindows.Timesplits.Settings", "Time Splits Settings Window", ImVec2(567, 97));
     gui->AddGuiWindow(mTimesplitsSettingsWindow);
 
-    mNotificationWindow = std::make_shared<Notification::Window>("gWindows.Notifications", "Notifications Window");
+    // ComboShip: suffix the registered name so MM's notification window does not collide with OOT's
+    // identically-named "Notifications Window" in the shared Gui (AddGuiWindow rejects duplicates,
+    // which would drop MM's window). comboui gates which one draws per active game. Standalone =
+    // empty suffix (unchanged). See combo/gui/ComboTrackerVisibility.cpp + docs/UPSTREAM_MERGES.md.
+    mNotificationWindow = std::make_shared<Notification::Window>("gWindows.Notifications",
+                                                                 "Notifications Window" COMBO_MM_TRACKER_SUFFIX);
     gui->AddGuiWindow(mNotificationWindow);
     mNotificationWindow->Show();
 

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -3167,6 +3167,52 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoStaticData(void) {
                                { "vanillaItem", vigName },
                                { "advancement", Rando::StaticData::RetrieveItem(vanillaRG).IsAdvancement() } });
         }
+
+#ifdef COMBO_BUILD
+        // ComboShip: the loop above emits each check's VANILLA item, which MISSES the items the SETTINGS
+        // ADD to the pool — the shuffled "skill" items (Open Chest, Speak *, Climb, Crawl). They are not
+        // the vanilla item of any check, so without them the cross-world fill can never grant
+        // CAN_OPEN_CHEST / CAN_SPEAK_* etc., and EVERY chest/scrub/shop is logically unreachable ->
+        // generation dead-ends. Inject the enabled skill items into the pool, overwriting an equal
+        // number of junk checks so items stay 1:1 with checks. (Swim/Grab map to Progressive
+        // Scale/Strength, which the vanilla pool already carries, so they need no injection.)
+        {
+            std::vector<RandomizerGet> skills;
+            if (ctx->GetOption(RSK_SHUFFLE_OPEN_CHEST))
+                skills.push_back(RG_OPEN_CHEST);
+            if (ctx->GetOption(RSK_SHUFFLE_CLIMB))
+                skills.push_back(RG_CLIMB);
+            if (ctx->GetOption(RSK_SHUFFLE_CRAWL))
+                skills.push_back(RG_CRAWL);
+            if (ctx->GetOption(RSK_SHUFFLE_SPEAK)) {
+                skills.push_back(RG_SPEAK_DEKU);
+                skills.push_back(RG_SPEAK_GERUDO);
+                skills.push_back(RG_SPEAK_GORON);
+                skills.push_back(RG_SPEAK_HYLIAN);
+                skills.push_back(RG_SPEAK_KOKIRI);
+                skills.push_back(RG_SPEAK_ZORA);
+            }
+            size_t si = 0;
+            for (auto& c : checks) {
+                if (si >= skills.size())
+                    break;
+                if (c.value("advancement", true))
+                    continue; // only overwrite a junk slot
+                const std::string& sn = Rando::StaticData::RetrieveItem(skills[si]).GetName().GetEnglish();
+                if (sn.empty()) {
+                    ++si;
+                    continue;
+                }
+                c["vanillaItem"] = sn;
+                c["advancement"] = true;
+                ++si;
+            }
+            if (si < skills.size()) {
+                SPDLOG_WARN("[ComboShip] SOH_DumpRandoStaticData: injected only {}/{} skill items (too few junk slots)",
+                            si, skills.size());
+            }
+        }
+#endif
         usedPool = true;
     } catch (const std::exception& e) {
         SPDLOG_WARN("[ComboShip] SOH_DumpRandoStaticData: RegionTable_Init/GenerateLocationPool threw ({}); "


### PR DESCRIPTION
Two related fixes from this branch.

### MM toast notifications (issue #28)
MM already shipped a notification system identical to SoH's, but in the combined build both games registered the window under the same name `"Notifications Window"` and `Gui::AddGuiWindow` rejects duplicates, so MM's was silently dropped.
- `mm/2s2h/BenGui/BenGui.cpp`: register MM's notification window with the `##MM` suffix (COMBO_BUILD-guarded) so both coexist.
- `combo/gui/ComboTrackerVisibility.cpp`: gate the notification window by active game (remove/re-add from the shared Gui's draw loop on transition), so only the foreground game's toasts draw. "Sent to Hyrule" was already implemented; this just lets MM's window survive registration.

### Single x64 build output
`combo/CMakeLists.txt`: ComboShip.exe now builds straight into `x64/<config>` like the DLLs; dropped the duplicate copies in the per-target build tree that went stale on per-target rebuilds.

### Cross-world fill: include shuffled-skill items
The cross-world dump built the fill's item pool from each check's vanilla item, omitting every item the settings ADD to the pool — notably the shuffled skill items (Open Chest, Speak, Climb, Crawl). Without them the oracle never granted `CAN_OPEN_CHEST` / `CAN_SPEAK_*`, so every chest/scrub/shop was logically unreachable and generation dead-ended (OOT 145/470 reachable with a full inventory).
- `soh/soh/OTRGlobals.cpp`: inject the enabled skill items into the dumped pool, overwriting junk slots to keep items 1:1 with checks. OOT reachable 145→460; seeds 1234–1238 generate (5/5).

Follow-ups noted in `docs/UPSTREAM_MERGES.md`: source the pool from the real `GenerateItemPool()` (covers Mask Quest / Roc's Feather / Skeleton Key / Triforce Hunt too), and enforce the OOT→MM portal gate as (region, age).

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/7805378009.zip)
<!--- section:artifacts:end -->