### PR TITLE
Combo randomizer file-select UX + consolidated shareable spoiler

### DIFF
--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -270,10 +270,12 @@ typedef void (*FnSetGenerateCb)(void (*)(int));
 typedef void (*FnApplyPlacements)(const char*);
 typedef void (*FnMMInitRandoSave)(int, const char*);
 typedef void (*FnSetComboRandoSeed)(uint64_t);
+typedef void (*FnSetComboSeedHash)(uint32_t);
 static FnSetGenerateCb SOH_SetOnComboGenerateCallback = nullptr;
 static FnApplyPlacements SOH_ApplyRandoPlacements = nullptr;
 static FnMMInitRandoSave MM_InitRandoSaveFile = nullptr;
 static FnSetComboRandoSeed SOH_SetComboRandoSeed = nullptr;
+static FnSetComboSeedHash SOH_SetComboSeedHash = nullptr;
 
 // ComboShip: window-driven generate request (threaded, progress-reporting)
 typedef void (*FnSetGenReqCb)(void (*)(const char*, ComboRando::ComboGenProgress*));
@@ -687,6 +689,15 @@ static void RunComboFill(std::string inputSeed, ComboRando::ComboGenProgress* pr
             SOH_SetSeedGenerated(1);
         }
 
+        // ComboShip: the OOT file-select seed-hash icons must identify input-seed + settings. Fold the
+        // two static dumps (which reflect each game's live CVar settings) into the value so different
+        // settings yield different icons; same seed+settings -> matching icons across players. Must run
+        // AFTER SOH_ApplyRandoPlacements (which ItemResets) so the hash isn't wiped.
+        if (SOH_SetComboSeedHash) {
+            uint32_t displaySeed = ComboHash((inputSeed + sohDump + mmDump).c_str());
+            SOH_SetComboSeedHash(displaySeed);
+        }
+
         g_PendingMMPlacements = mmApply.dump();
         std::cout << "[ComboShip] RunComboFill: MM placements stashed\n";
 
@@ -1087,6 +1098,7 @@ int main(int argc, char** argv) {
     SOH_ApplyRandoPlacements = (FnApplyPlacements)GetSym(sohModule, "SOH_ApplyRandoPlacements");
     SOH_GetForcedPlacements = (FnGetForced)GetSym(sohModule, "SOH_GetForcedPlacements");
     SOH_SetComboRandoSeed = (FnSetComboRandoSeed)GetSym(sohModule, "SOH_SetComboRandoSeed");
+    SOH_SetComboSeedHash = (FnSetComboSeedHash)GetSym(sohModule, "SOH_SetComboSeedHash");
     SOH_SetOnComboGenerateRequestCallback = (FnSetGenReqCb)GetSym(sohModule, "SOH_SetOnComboGenerateRequestCallback");
     SOH_SetSeedGenerated = (FnSetSeedGenerated)GetSym(sohModule, "SOH_SetSeedGenerated");
     MM_BootForCombo = (FnVoidArgless)GetSym(mmModule, "MM_BootForCombo");

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -278,12 +278,27 @@ static FnSetComboRandoSeed SOH_SetComboRandoSeed = nullptr;
 static FnSetComboSeedHash SOH_SetComboSeedHash = nullptr;
 
 // ComboShip: window-driven generate request (threaded, progress-reporting)
-typedef void (*FnSetGenReqCb)(void (*)(const char*, ComboRando::ComboGenProgress*));
+typedef void (*FnSetGenReqCb)(void (*)(const char*));
 typedef void (*FnSetSeedGenerated)(uint8_t);
+typedef void (*FnSetComboProgressPtr)(const ComboRando::ComboGenProgress*);
+typedef void (*FnSetComboFinalizeCb)(int (*)());
 static FnSetGenReqCb SOH_SetOnComboGenerateRequestCallback = nullptr;
 static FnSetSeedGenerated SOH_SetSeedGenerated = nullptr;
+static FnSetComboProgressPtr SOH_SetComboProgressPtr = nullptr;
+static FnSetComboFinalizeCb SOH_SetOnComboFinalizeCallback = nullptr;
 
 static std::atomic<bool> g_GenerateBusy{ false };
+
+// ComboShip: non-blocking generation. The heavy fill runs on g_GenerateThread; the main thread
+// keeps rendering + playing music + showing progress, and runs the gSaveContext-mutating apply
+// itself via Combo_PollFinalize (see the file-select poll). g_ComboProgress is the single source
+// of truth, shared read-only with soh.dll via SOH_SetComboProgressPtr.
+static std::thread g_GenerateThread;
+static ComboRando::ComboGenProgress g_ComboProgress;
+static std::atomic<bool> g_ComboPendingFinalize{ false }; // worker succeeded, main-thread apply not yet run
+// Main-thread finalize inputs stashed by the worker (consumed by Combo_FinalizeGenerate).
+static std::string g_FinalizeOotApply;
+static uint32_t g_FinalizeDisplaySeed = 0;
 
 // ---------- ComboShip-owned Anchor connection (Phase 1) ----------
 // The persistent TCP socket + receive thread live HERE, in the launcher, so the online connection
@@ -558,6 +573,7 @@ static void RunComboFill(std::string inputSeed, ComboRando::ComboGenProgress* pr
             progress->SetError(msg);
             progress->success.store(false);
             progress->done.store(true);
+            progress->running.store(false);
         }
         std::cerr << "[ComboShip] RunComboFill: " << msg << "\n";
         g_GenerateBusy.store(false);
@@ -681,32 +697,35 @@ static void RunComboFill(std::string inputSeed, ComboRando::ComboGenProgress* pr
                 mmApply[cn] = ComboRando::kForeignSentinelNameMM;
         }
 
-        if (SOH_ApplyRandoPlacements) {
-            SOH_ApplyRandoPlacements(ootApply.dump().c_str());
-            std::cout << "[ComboShip] RunComboFill: OOT placements applied (" << foreignArr.size()
-                      << " foreign markers)\n";
-        } else if (SOH_SetSeedGenerated) {
-            SOH_SetSeedGenerated(1);
-        }
-
-        // ComboShip: the OOT file-select seed-hash icons must identify input-seed + settings. Fold the
-        // two static dumps (which reflect each game's live CVar settings) into the value so different
-        // settings yield different icons; same seed+settings -> matching icons across players. Must run
-        // AFTER SOH_ApplyRandoPlacements (which ItemResets) so the hash isn't wiped.
-        if (SOH_SetComboSeedHash) {
-            uint32_t displaySeed = ComboHash((inputSeed + sohDump + mmDump).c_str());
-            SOH_SetComboSeedHash(displaySeed);
-        }
-
+        // ComboShip: the gSaveContext-mutating apply (SOH_ApplyRandoPlacements) and the seed-hash set
+        // MUST run on the main thread — the worker only computes. Stash their inputs for
+        // Combo_FinalizeGenerate, which the main-thread file-select poll runs once it sees done.
+        // The OOT seed-hash folds in input-seed + both settings dumps so the icons identify seed and
+        // settings (same seed+settings -> matching icons across players).
+        g_FinalizeOotApply = ootApply.dump();
+        g_FinalizeDisplaySeed = ComboHash((inputSeed + sohDump + mmDump).c_str());
         g_PendingMMPlacements = mmApply.dump();
-        std::cout << "[ComboShip] RunComboFill: MM placements stashed\n";
+        std::cout << "[ComboShip] RunComboFill: placements computed; main-thread finalize pending\n";
 
         if (progress) {
             progress->seed.store(masterSeed);
+            // The reproducible token is the (resolved) input seed string, not masterSeed: paste it
+            // back into the Seed field + same settings to reproduce. For a blank input this is the
+            // concrete random string chosen above.
+            std::strncpy(progress->seedStr, inputSeed.c_str(), sizeof(progress->seedStr) - 1);
+            progress->seedStr[sizeof(progress->seedStr) - 1] = '\0';
             progress->foreignCount.store(static_cast<int>(foreignArr.size()));
+            // Per-game contributed check counts = size of each settings-scoped dump pool.
+            try {
+                progress->ootCheckCount.store(
+                    static_cast<int>(nlohmann::json::parse(sohDump).value("checks", nlohmann::json::array()).size()));
+                progress->mmCheckCount.store(
+                    static_cast<int>(nlohmann::json::parse(mmDump).value("checks", nlohmann::json::array()).size()));
+            } catch (...) {}
             progress->success.store(true);
             progress->done.store(true);
         }
+        g_ComboPendingFinalize.store(true);
     } catch (const std::exception& e) {
         fail((std::string("post-fill exception: ") + e.what()).c_str());
         return;
@@ -986,6 +1005,55 @@ static void Combo_OnGenerateRequest(const char* inputSeed, ComboRando::ComboGenP
     RunComboFill(std::string(inputSeed ? inputSeed : ""), progress);
 }
 
+// ComboShip: UI-driven (non-blocking) generate — registered as the generate-request callback and
+// invoked on the main thread from SOH_TriggerComboGenerate. Spawns the worker so the main loop keeps
+// rendering + playing music + animating progress. The previous worker is always finished by now
+// (reentry is gated on RandoGenerating in soh + g_GenerateBusy here), but join it to recycle the
+// std::thread object. The gSaveContext apply happens later on the main thread (Combo_PollFinalize).
+static void Combo_OnGenerateThreaded(const char* inputSeed) {
+    // Reject if a worker is running OR a finalize is still pending (apply not yet run on main thread).
+    if (g_ComboPendingFinalize.load() || g_GenerateBusy.exchange(true)) {
+        std::cerr << "[ComboShip] generate already in progress — ignoring duplicate request\n";
+        return;
+    }
+    if (g_GenerateThread.joinable())
+        g_GenerateThread.join(); // recycle the finished previous worker's thread object
+    g_ComboProgress.Reset();
+    g_ComboProgress.done.store(false);
+    g_ComboProgress.running.store(true);
+    std::string seed(inputSeed ? inputSeed : "");
+    // RunComboFill clears g_GenerateBusy when it finishes; the finalize gate then blocks re-trigger
+    // until the main-thread apply runs. Call RunComboFill directly (busy is already held).
+    g_GenerateThread = std::thread([seed]() { RunComboFill(seed, &g_ComboProgress); });
+}
+
+// ComboShip: main-thread finalize — the gSaveContext-mutating apply + seed-hash set. Runs from
+// Combo_PollFinalize on the main thread once the worker has stashed its result. NEVER call from the
+// worker thread (that race crashed the prior threaded attempt).
+static void Combo_FinalizeGenerate() {
+    if (SOH_ApplyRandoPlacements) {
+        SOH_ApplyRandoPlacements(g_FinalizeOotApply.c_str());
+        std::cout << "[ComboShip] Combo_FinalizeGenerate: OOT placements applied\n";
+    } else if (SOH_SetSeedGenerated) {
+        SOH_SetSeedGenerated(1);
+    }
+    if (SOH_SetComboSeedHash)
+        SOH_SetComboSeedHash(g_FinalizeDisplaySeed);
+    g_ComboProgress.running.store(false);
+}
+
+// ComboShip: poll callback the file-select loop calls each frame on the main thread. Runs the
+// pending finalize (apply) when the worker has succeeded. Returns 1 once generation is fully
+// resolved (finalized or failed) so the caller can clear RandoGenerating; 0 while still working.
+static int Combo_PollFinalize() {
+    if (g_ComboPendingFinalize.exchange(false)) {
+        Combo_FinalizeGenerate();
+        return 1;
+    }
+    // No pending finalize: resolved iff the worker is done and not still running.
+    return (g_ComboProgress.done.load() && !g_GenerateBusy.load()) ? 1 : 0;
+}
+
 static void Combo_OnOOTSaveInit(int fileNum) {
     if (MM_InitRandoSaveFile && !g_PendingMMPlacements.empty()) {
         std::cout << "[ComboShip] Creating RANDO MM save for OOT slot " << fileNum << std::endl;
@@ -1101,6 +1169,8 @@ int main(int argc, char** argv) {
     SOH_SetComboSeedHash = (FnSetComboSeedHash)GetSym(sohModule, "SOH_SetComboSeedHash");
     SOH_SetOnComboGenerateRequestCallback = (FnSetGenReqCb)GetSym(sohModule, "SOH_SetOnComboGenerateRequestCallback");
     SOH_SetSeedGenerated = (FnSetSeedGenerated)GetSym(sohModule, "SOH_SetSeedGenerated");
+    SOH_SetComboProgressPtr = (FnSetComboProgressPtr)GetSym(sohModule, "SOH_SetComboProgressPtr");
+    SOH_SetOnComboFinalizeCallback = (FnSetComboFinalizeCb)GetSym(sohModule, "SOH_SetOnComboFinalizeCallback");
     MM_BootForCombo = (FnVoidArgless)GetSym(mmModule, "MM_BootForCombo");
     MM_Deinit = (FnVoidArgless)GetSym(mmModule, "MM_Deinit");
     SOH_ResumeForeground = (FnVoidArgless)GetSym(sohModule, "SOH_ResumeForeground");
@@ -1360,9 +1430,15 @@ int main(int argc, char** argv) {
     // ComboShip: register the window-driven generate-request handler.
     // Generation is window-driven; Sram_InitSave only forces QUEST_RANDOMIZER.
     if (SOH_SetOnComboGenerateRequestCallback) {
-        SOH_SetOnComboGenerateRequestCallback(Combo_OnGenerateRequest);
-        std::cout << "[ComboShip] Combo generate-request handler registered." << std::endl;
+        SOH_SetOnComboGenerateRequestCallback(Combo_OnGenerateThreaded);
+        std::cout << "[ComboShip] Combo generate-request handler registered (threaded)." << std::endl;
     }
+    // Share the single progress struct with soh.dll (read-only) and register the main-thread
+    // finalize poll the file-select loop drives.
+    if (SOH_SetComboProgressPtr)
+        SOH_SetComboProgressPtr(&g_ComboProgress);
+    if (SOH_SetOnComboFinalizeCallback)
+        SOH_SetOnComboFinalizeCallback(Combo_PollFinalize);
 
     // ComboShip: env-gated headless generate — COMBO_AUTOGEN_SEED=<seed> runs the cross-world
     // fill once at startup (timed) so fill changes are verifiable without driving the UI.
@@ -1489,6 +1565,14 @@ int main(int argc, char** argv) {
     // under the loader lock and deadlocks.
     // std::cerr (unbuffered) progress markers: spdlog is shut down by ~Context partway through this
     // sequence, and a late crash otherwise leaves no trace of how far teardown got.
+
+    // Join the generate worker before unloading any game DLL it calls into — a still-joinable
+    // std::thread would std::terminate() at static destruction, and the worker must not run past
+    // the DLLs it touches.
+    if (g_GenerateThread.joinable()) {
+        std::cerr << "[ComboShip] shutdown: joining generate worker" << std::endl;
+        g_GenerateThread.join();
+    }
 
     // Stop the Anchor receive thread first: it calls into soh.dll exports, so it must be joined
     // while soh.dll is still mapped and before SOH_Deinit tears Anchor down.

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -193,6 +193,16 @@ static FnVoidArgless MM_PrepareForTransition = nullptr;
 typedef const char* (*FnDumpData)(void);
 static FnDumpData SOH_DumpRandoStaticData = nullptr;
 static FnDumpData MM_DumpRandoStaticData = nullptr;
+static FnDumpData SOH_DumpRandoSettings = nullptr; // {cvar:value} OOT rando settings snapshot
+static FnDumpData MM_DumpRandoSettings = nullptr;  // {cvar:value} MM rando settings snapshot
+// Reload/remember-seed: restore settings + run the pool prep before re-applying saved placements.
+typedef void (*FnVoidV)(void);
+typedef void (*FnTakeStr)(const char*);
+typedef void (*FnSetReloadCb)(int (*)(const char*));
+static FnVoidV SOH_PrepRandoContext = nullptr;
+static FnTakeStr SOH_RestoreRandoSettings = nullptr;
+static FnTakeStr MM_RestoreRandoSettings = nullptr;
+static FnSetReloadCb SOH_SetOnComboReloadCallback = nullptr;
 
 // ComboShip: OOT forced placements (Link's Pocket etc.) the static dump can't carry — see
 // SOH_GetForcedPlacements. Seed-parameterized so the pick is deterministic per generated seed.
@@ -259,10 +269,12 @@ static FnDeleteSaveFile MM_DeleteSaveFile = nullptr;
 static void DeleteForeignSaveFromOOT(int slot) {
     if (MM_DeleteSaveFile)
         MM_DeleteSaveFile(slot);
+    ComboRando::CleanSlotFiles(slot); // also remove the slot's consolidated seed file
 }
 static void DeleteForeignSaveFromMM(int slot) {
     if (SOH_DeleteSaveFile)
         SOH_DeleteSaveFile(slot);
+    ComboRando::CleanSlotFiles(slot);
 }
 
 // ComboShip: placement injection exports
@@ -299,6 +311,10 @@ static std::atomic<bool> g_ComboPendingFinalize{ false }; // worker succeeded, m
 // Main-thread finalize inputs stashed by the worker (consumed by Combo_FinalizeGenerate).
 static std::string g_FinalizeOotApply;
 static uint32_t g_FinalizeDisplaySeed = 0;
+// Consolidated spoiler JSON for the just-generated seed + its hash string (NN-NN-NN-NN-NN). The
+// worker writes the pending file from it; Combo_OnOOTSaveInit writes the per-slot file at Start.
+static std::string g_ConsolidatedJson;
+static std::string g_ConsolidatedHashStr;
 
 // ---------- ComboShip-owned Anchor connection (Phase 1) ----------
 // The persistent TCP socket + receive thread live HERE, in the launcher, so the online connection
@@ -562,8 +578,10 @@ static int g_PendingMMFileNum = -1;
 static std::string g_PendingMMPlacements;
 
 // Forward decl: defined later, called from RunComboFill on every successful in-game generation.
+// playthroughOut (optional) receives the structured sphere playthrough for the consolidated file.
 static void WriteComboPlaythrough(const std::string& spoilerJson, const ComboRando::OracleFns& ootOracle,
-                                  const ComboRando::OracleFns& mmOracle, const std::string& seedLabel);
+                                  const ComboRando::OracleFns& mmOracle, const std::string& seedLabel,
+                                  nlohmann::json* playthroughOut = nullptr);
 
 // ComboShip: worker that runs the combined-logic fill (or no-logic fallback) on a background
 // thread, reports progress via the ComboGenProgress struct, and stashes placements.
@@ -602,6 +620,7 @@ static void RunComboFill(std::string inputSeed, ComboRando::ComboGenProgress* pr
 
     std::string spoiler;
     bool usedCombinedFill = false;
+    nlohmann::json playthroughJson = nlohmann::json::array(); // structured sphere playthrough (combined-fill only)
 
     if (Combo_SOH_Rando_Reset && Combo_SOH_Rando_SetOwnedItems && Combo_SOH_Rando_GetReachableChecks &&
         Combo_SOH_Rando_PlaceItem && Combo_MM_Rando_Reset && Combo_MM_Rando_SetOwnedItems &&
@@ -628,7 +647,7 @@ static void RunComboFill(std::string inputSeed, ComboRando::ComboGenProgress* pr
             // ComboShip: write the sphere-by-sphere playthrough log. Replays reachability via the
             // oracles BEFORE SOH_ApplyRandoPlacements restores the live OOT context, so it can't
             // corrupt the generated seed. Restores MM itself.
-            WriteComboPlaythrough(result.spoilerJson, ootOracle, mmOracle, inputSeed);
+            WriteComboPlaythrough(result.spoilerJson, ootOracle, mmOracle, inputSeed, &playthroughJson);
         } else {
             Combo_MM_Rando_Restore();
             fail((std::string("combined fill failed: ") + result.error).c_str());
@@ -642,12 +661,11 @@ static void RunComboFill(std::string inputSeed, ComboRando::ComboGenProgress* pr
         std::cout << "[ComboShip] RunComboFill: using no-logic fallback (seed=" << masterSeed << ")\n";
     }
 
-    const int kCanonicalSlot = 0;
     try {
         std::error_code ec;
-        std::filesystem::create_directories("saves/combo", ec);
-        // ComboShip: the full placement record now lives in slot0.playthrough.txt (its "Full
-        // placement" section supersedes the old slot0.spoiler.json), so no separate file here.
+        std::filesystem::create_directories(ComboRando::ConsolidatedDir(), ec);
+        // ComboShip: all per-seed data (placements, foreign, settings, structured playthrough) is
+        // assembled into one consolidated spoiler below and written to the pending file.
 
         auto j = nlohmann::json::parse(spoiler);
         auto foreignArr = j.value("foreign", nlohmann::json::array());
@@ -682,8 +700,6 @@ static void RunComboFill(std::string inputSeed, ComboRando::ComboGenProgress* pr
             }
         }
 
-        ComboRando::WriteForeignFromAnnotations(kCanonicalSlot, foreignArr);
-
         nlohmann::json ootApply = j.value("oot", nlohmann::json::object());
         nlohmann::json mmApply = j.value("mm", nlohmann::json::object());
         for (const auto& fm : foreignArr) {
@@ -702,10 +718,62 @@ static void RunComboFill(std::string inputSeed, ComboRando::ComboGenProgress* pr
         // Combo_FinalizeGenerate, which the main-thread file-select poll runs once it sees done.
         // The OOT seed-hash folds in input-seed + both settings dumps so the icons identify seed and
         // settings (same seed+settings -> matching icons across players).
+        uint32_t displaySeed = ComboHash((inputSeed + sohDump + mmDump).c_str());
         g_FinalizeOotApply = ootApply.dump();
-        g_FinalizeDisplaySeed = ComboHash((inputSeed + sohDump + mmDump).c_str());
+        g_FinalizeDisplaySeed = displaySeed;
         g_PendingMMPlacements = mmApply.dump();
-        std::cout << "[ComboShip] RunComboFill: placements computed; main-thread finalize pending\n";
+
+        // ComboShip: file_hash = the 5 icon indexes the file-select shows, derived from displaySeed
+        // exactly as OOT's GenerateHash (decimal padded to 10, five 2-digit pairs). Doubles as the
+        // per-slot filename suffix (NN-NN-NN-NN-NN).
+        std::string seedDigits = std::to_string(displaySeed);
+        while (seedDigits.size() < 10)
+            seedDigits = "0" + seedDigits;
+        nlohmann::json fileHashArr = nlohmann::json::array();
+        g_ConsolidatedHashStr.clear();
+        for (int i = 0; i < 5; ++i) {
+            int v = std::stoi(seedDigits.substr(i * 2, 2));
+            fileHashArr.push_back(v);
+            char b[4];
+            std::snprintf(b, sizeof(b), "%02d", v);
+            if (i)
+                g_ConsolidatedHashStr += "-";
+            g_ConsolidatedHashStr += b;
+        }
+
+        // ComboShip: assemble the single consolidated spoiler — the shareable artifact + the runtime
+        // foreign source + remember/drop/hint data. Settings are CVar snapshots so a dropped seed
+        // reproduces on any machine. Written now to the pending file (remembered); bound to a per-slot
+        // file at Start (Combo_OnOOTSaveInit).
+        auto parseOrEmpty = [](FnDumpData fn) -> nlohmann::json {
+            if (!fn)
+                return nlohmann::json::object();
+            try {
+                return nlohmann::json::parse(fn());
+            } catch (...) {
+                return nlohmann::json::object();
+            }
+        };
+        nlohmann::json consolidated;
+        consolidated["fileType"] = "ComboShipRandomizer";
+        consolidated["version"] = 1;
+        consolidated["seed"] = inputSeed;
+        consolidated["masterSeed"] = masterSeed;
+        consolidated["displaySeed"] = displaySeed;
+        consolidated["file_hash"] = fileHashArr;
+        consolidated["oot"] = { { "settings", parseOrEmpty(SOH_DumpRandoSettings) }, { "placements", ootApply } };
+        consolidated["mm"] = { { "settings", parseOrEmpty(MM_DumpRandoSettings) }, { "placements", mmApply } };
+        consolidated["foreign"] = ComboRando::BuildForeignArray(foreignArr);
+        consolidated["playthrough"] = playthroughJson;
+        g_ConsolidatedJson = consolidated.dump(2);
+
+        // Write the pending (unbound) file so the seed is remembered and Start-able without regenerating.
+        {
+            std::ofstream pf(ComboRando::PendingPath(), std::ios::trunc);
+            if (pf.is_open())
+                pf << g_ConsolidatedJson;
+        }
+        std::cout << "[ComboShip] RunComboFill: placements computed; consolidated pending seed written\n";
 
         if (progress) {
             progress->seed.store(masterSeed);
@@ -803,7 +871,8 @@ static int RunComboGenTest(int numSeeds, uint32_t seedBase) {
 // sphere-collect. Ends by restoring the MM oracle's pre-generation snapshot (it drives MM here).
 // Called both from the env-gated entry below and from RunComboFill on every in-game generation.
 static void WriteComboPlaythrough(const std::string& spoilerJson, const ComboRando::OracleFns& ootOracle,
-                                  const ComboRando::OracleFns& mmOracle, const std::string& seedLabel) {
+                                  const ComboRando::OracleFns& mmOracle, const std::string& seedLabel,
+                                  nlohmann::json* playthroughOut) {
     using namespace ComboRando; // GameId / GAME_OOT / GAME_MM
     // Endgame signals the oracles actually emit:
     //   OOT — top of Ganon's Tower (all four trials cleared) reachable AND the Ganon's Castle Boss Key
@@ -900,13 +969,22 @@ static void WriteComboPlaythrough(const std::string& spoilerJson, const ComboRan
         }
         log << "Sphere " << sphere << "  (Ganon=" << (canGanon ? "Y" : "n") << " Majora=" << (canMajora ? "Y" : "n")
             << ", +" << newly.size() << " items)\n";
+        // ComboShip: structured sphere for the consolidated file (drives the "Get a hint" feature).
+        nlohmann::json sphereSteps = nlohmann::json::array();
         for (auto& p : newly) {
             std::string key = (p.checkGame == GAME_OOT ? "oot:" : "mm:") + p.check;
             collected.insert(key);
             (p.itemGame == GAME_OOT ? ownedOot : ownedMm).push_back(p.item);
+            if (playthroughOut)
+                sphereSteps.push_back({ { "game", p.checkGame == GAME_OOT ? "oot" : "mm" },
+                                        { "check", p.check },
+                                        { "item", p.item },
+                                        { "foreign", p.checkGame != p.itemGame } });
             log << "    [" << (p.checkGame == GAME_OOT ? "OOT" : "MM ") << "] " << p.check << "  <-  " << p.item
                 << (p.checkGame != p.itemGame ? (p.itemGame == GAME_OOT ? "  (OOT item)" : "  (MM item)") : "") << "\n";
         }
+        if (playthroughOut)
+            playthroughOut->push_back({ { "sphere", sphere }, { "steps", std::move(sphereSteps) } });
     }
     // ComboShip: true "ever reachable" sets — give each oracle the FULL placed-item set and ask
     // what's reachable. Reachability is monotonic, so full inventory yields the maximal set. Differs
@@ -948,17 +1026,19 @@ static void WriteComboPlaythrough(const std::string& spoilerJson, const ComboRan
     emitGame(GAME_OOT, "OOT", everReachOot);
     emitGame(GAME_MM, "MM", everReachMm);
 
-    std::error_code ec;
-    std::filesystem::create_directories("saves/combo", ec);
-    std::string path = "saves/combo/slot0.playthrough.txt";
-    {
-        std::ofstream f(path, std::ios::trunc);
+    // ComboShip: in-game generation folds the playthrough into the consolidated spoiler JSON
+    // (playthroughOut), so the standalone text log is redundant there and no longer written. The
+    // env-gated COMBO_PLAYTHROUGH debug tool passes no playthroughOut and still gets the .txt.
+    if (!playthroughOut) {
+        std::error_code ec;
+        std::filesystem::create_directories("saves/combo", ec);
+        std::ofstream f("saves/combo/slot0.playthrough.txt", std::ios::trunc);
         f << log.str();
+        std::cout << "[PLAYTHROUGH] full sphere log -> saves/combo/slot0.playthrough.txt\n";
     }
 
     std::cout << "[PLAYTHROUGH] seed '" << seedLabel << "' - " << (beatableSphere >= 0 ? "BEATABLE" : "NOT beatable")
-              << (beatableSphere >= 0 ? (" at sphere " + std::to_string(beatableSphere)) : "")
-              << "; full sphere log -> " << path << "\n";
+              << (beatableSphere >= 0 ? (" at sphere " + std::to_string(beatableSphere)) : "") << "\n";
     std::cout << "[PLAYTHROUGH] collected " << collected.size() << " items across "
               << (beatableSphere >= 0 ? beatableSphere : kMaxSpheres) << " spheres before the win\n";
 }
@@ -1054,7 +1134,107 @@ static int Combo_PollFinalize() {
     return (g_ComboProgress.done.load() && !g_GenerateBusy.load()) ? 1 : 0;
 }
 
+// ComboShip: reload a consolidated seed file (the remembered pending file when path is null/empty, or
+// a dropped file) and make it playable WITHOUT regenerating. Runs synchronously on the MAIN thread
+// (called from the file-select), so the gSaveContext-mutating apply is safe. Restores both games'
+// settings, runs the pool prep, re-applies the saved OOT placements + seed-hash, stashes the MM
+// placements, and keeps the consolidated JSON in memory so "Start Randomizer" writes the per-slot
+// file. Returns 1 on success. The hash string is recomputed from displaySeed for the per-slot name.
+static int Combo_OnReloadRequest(const char* path) {
+    if (g_GenerateBusy.load() || g_ComboPendingFinalize.load())
+        return 0; // a generation is in flight — don't race it
+    std::string file = (path && path[0]) ? std::string(path) : ComboRando::PendingPath().string();
+    std::ifstream in(file);
+    if (!in.is_open())
+        return 0;
+    try {
+        nlohmann::json j;
+        in >> j;
+        if (j.value("fileType", std::string()) != "ComboShipRandomizer")
+            return 0;
+        uint32_t masterSeed = j.value("masterSeed", 0u);
+        uint32_t displaySeed = j.value("displaySeed", 0u);
+        auto oot = j.value("oot", nlohmann::json::object());
+        auto mm = j.value("mm", nlohmann::json::object());
+        std::string ootSettings = oot.value("settings", nlohmann::json::object()).dump();
+        std::string ootPlacements = oot.value("placements", nlohmann::json::object()).dump();
+        std::string mmSettings = mm.value("settings", nlohmann::json::object()).dump();
+        std::string mmPlacements = mm.value("placements", nlohmann::json::object()).dump();
+
+        // OOT: restore settings -> seed RNG -> prep settings-scoped pool -> apply placements -> hash.
+        if (SOH_RestoreRandoSettings)
+            SOH_RestoreRandoSettings(ootSettings.c_str());
+        if (SOH_SetComboRandoSeed)
+            SOH_SetComboRandoSeed(masterSeed);
+        if (SOH_PrepRandoContext)
+            SOH_PrepRandoContext();
+        if (SOH_ApplyRandoPlacements)
+            SOH_ApplyRandoPlacements(ootPlacements.c_str());
+        if (SOH_SetComboSeedHash)
+            SOH_SetComboSeedHash(displaySeed);
+
+        // MM: restore settings (MM_InitRandoSaveFile reads CVars) + stash placements for the MM save.
+        if (MM_RestoreRandoSettings)
+            MM_RestoreRandoSettings(mmSettings.c_str());
+        g_PendingMMPlacements = mmPlacements;
+
+        // Keep the loaded seed so Start binds it to the chosen slot; recompute the hash-icon filename.
+        g_ConsolidatedJson = j.dump(2);
+        g_FinalizeDisplaySeed = displaySeed;
+        // Make this the remembered pending seed (so a dropped seed survives a restart before Start).
+        {
+            std::error_code ec;
+            std::filesystem::create_directories(ComboRando::ConsolidatedDir(), ec);
+            std::ofstream pf(ComboRando::PendingPath(), std::ios::trunc);
+            if (pf.is_open())
+                pf << g_ConsolidatedJson;
+        }
+        std::string d = std::to_string(displaySeed);
+        while (d.size() < 10)
+            d = "0" + d;
+        g_ConsolidatedHashStr.clear();
+        for (int i = 0; i < 5; ++i) {
+            char b[4];
+            std::snprintf(b, sizeof(b), "%02d", std::stoi(d.substr(i * 2, 2)));
+            if (i)
+                g_ConsolidatedHashStr += "-";
+            g_ConsolidatedHashStr += b;
+        }
+        // Populate the shared progress so the comboui Generate panel shows the remembered seed
+        // (seed string, per-game check counts, cross-game count) just like a fresh generation.
+        g_ComboProgress.Reset();
+        std::string seedStr = j.value("seed", std::string());
+        std::strncpy(g_ComboProgress.seedStr, seedStr.c_str(), sizeof(g_ComboProgress.seedStr) - 1);
+        g_ComboProgress.seedStr[sizeof(g_ComboProgress.seedStr) - 1] = '\0';
+        g_ComboProgress.seed.store(masterSeed);
+        g_ComboProgress.ootCheckCount.store(static_cast<int>(oot.value("placements", nlohmann::json::object()).size()));
+        g_ComboProgress.mmCheckCount.store(static_cast<int>(mm.value("placements", nlohmann::json::object()).size()));
+        g_ComboProgress.foreignCount.store(static_cast<int>(j.value("foreign", nlohmann::json::array()).size()));
+        g_ComboProgress.success.store(true);
+        g_ComboProgress.done.store(true);
+        g_ComboProgress.running.store(false);
+
+        std::cout << "[ComboShip] reloaded combo seed from " << file << "\n";
+        return 1;
+    } catch (const std::exception& e) {
+        std::cerr << "[ComboShip] reload failed: " << e.what() << "\n";
+        return 0;
+    }
+}
+
 static void Combo_OnOOTSaveInit(int fileNum) {
+    // ComboShip: bind the pending consolidated seed to this slot — the runtime foreign source +
+    // shareable per-slot file (save{fileNum}-Randomizer-<hash>.json). Clean any stale file for the
+    // slot first (a prior seed generated into this slot).
+    if (!g_ConsolidatedJson.empty()) {
+        std::error_code ec;
+        std::filesystem::create_directories(ComboRando::ConsolidatedDir(), ec);
+        ComboRando::CleanSlotFiles(fileNum);
+        std::ofstream sf(ComboRando::SlotWritePath(fileNum, g_ConsolidatedHashStr), std::ios::trunc);
+        if (sf.is_open())
+            sf << g_ConsolidatedJson;
+        std::cout << "[ComboShip] wrote consolidated seed file for slot " << fileNum << std::endl;
+    }
     if (MM_InitRandoSaveFile && !g_PendingMMPlacements.empty()) {
         std::cout << "[ComboShip] Creating RANDO MM save for OOT slot " << fileNum << std::endl;
         MM_InitRandoSaveFile(fileNum, g_PendingMMPlacements.c_str());
@@ -1161,6 +1341,12 @@ int main(int argc, char** argv) {
     MM_PrepareForTransition = (FnVoidArgless)GetSym(mmModule, "MM_PrepareForTransition");
     SOH_DumpRandoStaticData = (FnDumpData)GetSym(sohModule, "SOH_DumpRandoStaticData");
     MM_DumpRandoStaticData = (FnDumpData)GetSym(mmModule, "MM_DumpRandoStaticData");
+    SOH_DumpRandoSettings = (FnDumpData)GetSym(sohModule, "SOH_DumpRandoSettings");
+    MM_DumpRandoSettings = (FnDumpData)GetSym(mmModule, "MM_DumpRandoSettings");
+    SOH_PrepRandoContext = (FnVoidV)GetSym(sohModule, "SOH_PrepRandoContext");
+    SOH_RestoreRandoSettings = (FnTakeStr)GetSym(sohModule, "SOH_RestoreRandoSettings");
+    MM_RestoreRandoSettings = (FnTakeStr)GetSym(mmModule, "MM_RestoreRandoSettings");
+    SOH_SetOnComboReloadCallback = (FnSetReloadCb)GetSym(sohModule, "SOH_SetOnComboReloadCallback");
     MM_InitRandoSaveFile = (FnMMInitRandoSave)GetSym(mmModule, "MM_InitRandoSaveFile");
     SOH_SetOnComboGenerateCallback = (FnSetGenerateCb)GetSym(sohModule, "SOH_SetOnComboGenerateCallback");
     SOH_ApplyRandoPlacements = (FnApplyPlacements)GetSym(sohModule, "SOH_ApplyRandoPlacements");
@@ -1439,6 +1625,8 @@ int main(int argc, char** argv) {
         SOH_SetComboProgressPtr(&g_ComboProgress);
     if (SOH_SetOnComboFinalizeCallback)
         SOH_SetOnComboFinalizeCallback(Combo_PollFinalize);
+    if (SOH_SetOnComboReloadCallback)
+        SOH_SetOnComboReloadCallback(Combo_OnReloadRequest);
 
     // ComboShip: env-gated headless generate — COMBO_AUTOGEN_SEED=<seed> runs the cross-world
     // fill once at startup (timed) so fill changes are verifiable without driving the UI.

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -750,9 +750,7 @@ static void RunComboFill(std::string inputSeed, ComboRando::ComboGenProgress* pr
                 return nlohmann::json::object();
             try {
                 return nlohmann::json::parse(fn());
-            } catch (...) {
-                return nlohmann::json::object();
-            }
+            } catch (...) { return nlohmann::json::object(); }
         };
         nlohmann::json consolidated;
         consolidated["fileType"] = "ComboShipRandomizer";

--- a/combo/gui/ComboGenProgress.h
+++ b/combo/gui/ComboGenProgress.h
@@ -15,7 +15,12 @@ struct ComboGenProgress {
     std::atomic<bool> success{ false };
     std::atomic<uint32_t> seed{ 0 };
     std::atomic<int> foreignCount{ 0 };
+    std::atomic<int> ootCheckCount{ 0 }; // checks OOT contributed to the combined pool
+    std::atomic<int> mmCheckCount{ 0 };  // checks MM contributed to the combined pool
     char error[256] = { 0 };
+    // Resolved input seed string (the reproducible token to paste back into the Seed field). For a
+    // blank input this is the concrete random string actually used. Written before done; read after.
+    char seedStr[128] = { 0 };
     void Reset() {
         phase = 0;
         placed = 0;
@@ -23,7 +28,10 @@ struct ComboGenProgress {
         success = false;
         seed = 0;
         foreignCount = 0;
+        ootCheckCount = 0;
+        mmCheckCount = 0;
         error[0] = '\0';
+        seedStr[0] = '\0';
     }
     void SetError(const char* m) {
         if (!m) {

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -121,13 +121,20 @@ struct HubEntry {
     }
 };
 
+// ComboShip: tracker sidebars (Item/Entrance/Check Tracker) belong in the per-game Ship/2Ship
+// tabs, not the Shared rando hub. Identified by name across both games (all contain "Tracker").
+static bool IsTrackerSidebar(const char* name) {
+    return name && std::strstr(name, "Tracker") != nullptr;
+}
+
 // Append one entry per sidebar of the game's section whose sectionLabel == wantSection.
 // Skips (no-op) if the game isn't loaded or the section isn't present — defensive.
 // `skip` is a deny-list of sidebar names to omit (e.g. sidebars that are OOT-specific and
-// therefore live only in the Ship of Harkinian tab, not here in Shared).
+// therefore live only in the Ship of Harkinian tab, not here in Shared). `skipTrackers` omits
+// tracker sidebars (they live in the per-game tabs).
 void AppendSectionEntries(std::vector<HubEntry>& out, const char* groupLabel, HubEntry::Kind kind,
                           const ComboRando::GameMenu& game, const char* wantSection,
-                          const std::vector<std::string>& skip = {}) {
+                          const std::vector<std::string>& skip = {}, bool skipTrackers = false) {
     if (!game.loaded || !game.menu)
         return;
     const CwMenu* m = game.menu;
@@ -139,6 +146,8 @@ void AppendSectionEntries(std::vector<HubEntry>& out, const char* groupLabel, Hu
             const CwSidebar& side = sec.sidebars[sb];
             const char* nm = (side.sidebarName && side.sidebarName[0]) ? side.sidebarName : "Section";
             if (std::find(skip.begin(), skip.end(), nm) != skip.end())
+                continue;
+            if (skipTrackers && IsTrackerSidebar(nm))
                 continue;
             HubEntry e;
             e.label = nm;
@@ -175,14 +184,16 @@ void ComboMenu::DrawSharedPanel() {
     }
     {
         std::vector<HubEntry> e;
-        AppendSectionEntries(e, "OOT Randomizer", HubEntry::OOT_RANDO, model.Oot(), "Randomizer");
+        // Trackers live in the Ship of Harkinian tab, not here.
+        AppendSectionEntries(e, "OOT Randomizer", HubEntry::OOT_RANDO, model.Oot(), "Randomizer", {}, true);
         if (!e.empty())
             groups.push_back({ "OOT Randomizer", std::move(e) });
     }
     {
         std::vector<HubEntry> e;
         // Display label "MM Randomizer"; the MM menu's own section name is still "Rando".
-        AppendSectionEntries(e, "MM Randomizer", HubEntry::MM_RANDO, model.Mm(), "Rando");
+        // Trackers live in the 2 Ship 2 Harkinian tab, not here.
+        AppendSectionEntries(e, "MM Randomizer", HubEntry::MM_RANDO, model.Mm(), "Rando", {}, true);
         if (!e.empty())
             groups.push_back({ "MM Randomizer", std::move(e) });
     }
@@ -258,10 +269,11 @@ void ComboMenu::DrawSharedPanel() {
 // with that sidebar's widgets on the right. The game DLLs no longer draw their own tabs.
 //
 // ComboShip presentation filter (combo-owned; the exported CwMenu is UNCHANGED):
-//   Both games' randomizer sections are surfaced in the Shared tab ("OOT Randomizer" / "MM Rando"),
-//   so we drop them from the per-game tabs to avoid duplication: OOT's "Randomizer" and MM's "Rando".
-//   OOT additionally trims "Settings" to its game-specific sidebars ("Mod Menu", "Presets"); the rest
-//   of Settings is shared. MM is otherwise rendered unfiltered.
+//   Both games' randomizer *settings* are surfaced in the Shared tab ("OOT Randomizer" / "MM
+//   Randomizer"). The per-game tabs keep the rando section ("Randomizer" / "Rando") but trim it to
+//   just the tracker sidebars (Item/Entrance/Check Tracker) — the rest of the rando settings stay
+//   in Shared. OOT additionally trims "Settings" to its game-specific sidebars ("Mod Menu",
+//   "Presets"); the rest of Settings is shared. MM is otherwise rendered unfiltered.
 void ComboMenu::DrawGamePanel(const char* gameKey) {
     auto& model = ComboMenuModel::Get();
     model.EnsureLoaded();
@@ -273,29 +285,25 @@ void ComboMenu::DrawGamePanel(const char* gameKey) {
     }
     const CwMenu* m = game.menu;
 
-    auto sectionDropped = [&](const char* label) -> bool {
-        if (!label)
-            return false;
-        // Each game's randomizer section lives in the Shared tab; drop it from the per-game tab.
-        return isOot ? strcmp(label, "Randomizer") == 0 : strcmp(label, "Rando") == 0;
-    };
     auto sidebarShown = [&](const char* section, const char* sidebar) -> bool {
         if (isOot && section && strcmp(section, "Settings") == 0) {
             return sidebar && (strcmp(sidebar, "Mod Menu") == 0 || strcmp(sidebar, "Presets") == 0);
         }
+        // The rando section's settings live in the Shared tab; here we surface only its trackers.
+        const char* randoSec = isOot ? "Randomizer" : "Rando";
+        if (section && strcmp(section, randoSec) == 0)
+            return IsTrackerSidebar(sidebar);
         return true;
     };
 
     // (activeHeader, activeSidebar) for this game; persists across frames.
     auto& nav = mGameNav[gameKey];
 
-    // Resolve the active section: prior pick if still present, else the first non-dropped section.
+    // Resolve the active section: prior pick if still present, else the first section.
     const CwSection* activeSec = nullptr;
     const CwSection* firstSec = nullptr;
     for (int s = 0; s < m->sectionCount; ++s) {
         const CwSection& sec = m->sections[s];
-        if (sectionDropped(sec.sectionLabel))
-            continue;
         if (!firstSec)
             firstSec = &sec;
         if (sec.sectionLabel && nav.first == sec.sectionLabel)
@@ -313,8 +321,6 @@ void ComboMenu::DrawGamePanel(const char* gameKey) {
     bool firstHdr = true;
     for (int s = 0; s < m->sectionCount; ++s) {
         const CwSection& sec = m->sections[s];
-        if (sectionDropped(sec.sectionLabel))
-            continue;
         if (!firstHdr)
             ImGui::SameLine();
         firstHdr = false;

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -10,6 +10,9 @@
 #include <algorithm>
 #include <cstring>
 #include <cstdio>
+#include <fstream>
+#include <unordered_set>
+#include "rando/CrossForeign.h" // ComboRando::SlotReadPath for the active seed's playthrough
 #ifdef _WIN32
 #include <windows.h>
 #endif
@@ -20,9 +23,14 @@ namespace {
 typedef void (*FnTriggerGenerate)(void);
 typedef const ComboRando::ComboGenProgress* (*FnGetProgress)(void);
 typedef unsigned char (*FnIsOnFileSelect)(void);
+typedef const char* (*FnGetStr)(void);
+typedef int (*FnGetInt)(void);
 FnTriggerGenerate sTrigger = nullptr;
 FnGetProgress sGetProgress = nullptr;
 FnIsOnFileSelect sIsOnFileSelect = nullptr;
+FnGetInt sGetFileNum = nullptr;     // SOH_GetActiveFileNum (soh.dll)
+FnGetStr sSohObtained = nullptr;    // Combo_SOH_GetObtainedChecks (soh.dll)
+FnGetStr sMmObtained = nullptr;     // Combo_MM_GetObtainedChecks (2ship.dll)
 void ResolveComboGenSyms() {
 #ifdef _WIN32
     HMODULE h = GetModuleHandleA("soh.dll");
@@ -34,6 +42,15 @@ void ResolveComboGenSyms() {
         sGetProgress = (FnGetProgress)GetProcAddress(h, "SOH_GetComboGenProgress");
     if (!sIsOnFileSelect)
         sIsOnFileSelect = (FnIsOnFileSelect)GetProcAddress(h, "SOH_IsOnFileSelect");
+    if (!sGetFileNum)
+        sGetFileNum = (FnGetInt)GetProcAddress(h, "SOH_GetActiveFileNum");
+    if (!sSohObtained)
+        sSohObtained = (FnGetStr)GetProcAddress(h, "Combo_SOH_GetObtainedChecks");
+    if (!sMmObtained) {
+        HMODULE mm = GetModuleHandleA("2ship.dll");
+        if (mm)
+            sMmObtained = (FnGetStr)GetProcAddress(mm, "Combo_MM_GetObtainedChecks");
+    }
 #endif
 }
 } // namespace
@@ -457,6 +474,78 @@ void ComboMenu::DrawComboPanel() {
                 ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "Error: %s", p->error);
             }
         }
+    }
+
+    DrawHintSection();
+}
+
+// ComboShip: sphere "Get a hint" helper. When a combo save is active, loads that seed's playthrough
+// from its per-slot consolidated file and, comparing against the checks obtained in BOTH games,
+// reveals the next not-yet-collected step's location (one more per click). Low-spoiler: location only.
+void ComboMenu::DrawHintSection() {
+    int fn = sGetFileNum ? sGetFileNum() : -1;
+    if (fn < 0)
+        return; // no save loaded — hints are an in-game helper
+
+    // (Re)load the active seed's playthrough when the slot changes.
+    if (fn != mHintFileNum) {
+        mHintFileNum = fn;
+        mHintsRevealed = 0;
+        mHintSteps.clear();
+        try {
+            auto path = ComboRando::SlotReadPath(fn);
+            if (!path.empty()) {
+                std::ifstream in(path);
+                nlohmann::json j;
+                in >> j;
+                for (auto& sph : j.value("playthrough", nlohmann::json::array()))
+                    for (auto& st : sph.value("steps", nlohmann::json::array()))
+                        mHintSteps.emplace_back(st.value("game", std::string()), st.value("check", std::string()));
+            }
+        } catch (...) {}
+    }
+
+    ImGui::Separator();
+    ImGui::TextUnformatted("Sphere Hints");
+    if (mHintSteps.empty()) {
+        ImGui::TextDisabled("No playthrough available for this seed.");
+        return;
+    }
+
+    // Obtained checks across BOTH games (active live + dormant from in-RAM save state).
+    std::unordered_set<std::string> obtained;
+    auto addFrom = [&](FnGetStr fn2) {
+        if (!fn2)
+            return;
+        try {
+            for (auto& n : nlohmann::json::parse(fn2()))
+                obtained.insert(n.get<std::string>());
+        } catch (...) {}
+    };
+    addFrom(sSohObtained);
+    addFrom(sMmObtained);
+
+    // Not-yet-collected steps, in playthrough (sphere) order.
+    std::vector<const std::pair<std::string, std::string>*> uncollected;
+    for (const auto& s : mHintSteps)
+        if (!obtained.count(s.second))
+            uncollected.push_back(&s);
+
+    if (uncollected.empty()) {
+        ImGui::TextDisabled("All playthrough checks collected.");
+        return;
+    }
+
+    if (ImGui::Button("Get a hint") && mHintsRevealed < (int)uncollected.size())
+        mHintsRevealed++;
+    ImGui::SameLine();
+    if (ImGui::SmallButton("Reset hints"))
+        mHintsRevealed = 0;
+
+    int show = mHintsRevealed > (int)uncollected.size() ? (int)uncollected.size() : mHintsRevealed;
+    for (int i = 0; i < show; ++i) {
+        const auto& s = *uncollected[i];
+        ImGui::BulletText("[%s] %s", s.first == "oot" ? "OOT" : "MM", s.second.c_str());
     }
 }
 

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -28,9 +28,9 @@ typedef int (*FnGetInt)(void);
 FnTriggerGenerate sTrigger = nullptr;
 FnGetProgress sGetProgress = nullptr;
 FnIsOnFileSelect sIsOnFileSelect = nullptr;
-FnGetInt sGetFileNum = nullptr;     // SOH_GetActiveFileNum (soh.dll)
-FnGetStr sSohObtained = nullptr;    // Combo_SOH_GetObtainedChecks (soh.dll)
-FnGetStr sMmObtained = nullptr;     // Combo_MM_GetObtainedChecks (2ship.dll)
+FnGetInt sGetFileNum = nullptr;  // SOH_GetActiveFileNum (soh.dll)
+FnGetStr sSohObtained = nullptr; // Combo_SOH_GetObtainedChecks (soh.dll)
+FnGetStr sMmObtained = nullptr;  // Combo_MM_GetObtainedChecks (2ship.dll)
 void ResolveComboGenSyms() {
 #ifdef _WIN32
     HMODULE h = GetModuleHandleA("soh.dll");

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -15,15 +15,25 @@
 #endif
 
 namespace {
-// Generate trigger (soh.dll export); runs synchronously on the calling thread.
-typedef void (*FnTriggerGenerate)(const char*, ComboRando::ComboGenProgress*);
+// soh.dll exports: trigger combo generation (non-blocking; spawns the launcher worker), read the
+// shared progress, and gate generation to the file-select screen.
+typedef void (*FnTriggerGenerate)(void);
+typedef const ComboRando::ComboGenProgress* (*FnGetProgress)(void);
+typedef unsigned char (*FnIsOnFileSelect)(void);
 FnTriggerGenerate sTrigger = nullptr;
-FnTriggerGenerate ResolveTrigger() {
+FnGetProgress sGetProgress = nullptr;
+FnIsOnFileSelect sIsOnFileSelect = nullptr;
+void ResolveComboGenSyms() {
 #ifdef _WIN32
     HMODULE h = GetModuleHandleA("soh.dll");
-    return h ? (FnTriggerGenerate)GetProcAddress(h, "SOH_TriggerComboGenerate") : nullptr;
-#else
-    return nullptr;
+    if (!h)
+        return;
+    if (!sTrigger)
+        sTrigger = (FnTriggerGenerate)GetProcAddress(h, "SOH_TriggerComboGenerate");
+    if (!sGetProgress)
+        sGetProgress = (FnGetProgress)GetProcAddress(h, "SOH_GetComboGenProgress");
+    if (!sIsOnFileSelect)
+        sIsOnFileSelect = (FnIsOnFileSelect)GetProcAddress(h, "SOH_IsOnFileSelect");
 #endif
 }
 } // namespace
@@ -380,63 +390,73 @@ void ComboMenu::DrawGamePanel(const char* gameKey) {
     ImGui::EndChild();
 }
 void ComboMenu::DrawComboPanel() {
+    ResolveComboGenSyms();
     ImGui::TextWrapped("Generate a cross-world randomizer seed spanning OOT and MM. "
                        "You must Generate before starting a new file.");
     ImGui::Separator();
+
+    // Seed field -> shared CVar the generator reads (same source the native file-select
+    // "Generate a new seed" option uses).
     ImGui::SetNextItemWidth(260.0f);
-    ImGui::InputTextWithHint("Seed", "(blank = random)", mSeedBuf, sizeof(mSeedBuf));
+    if (ImGui::InputTextWithHint("Seed", "(blank = random)", mSeedBuf, sizeof(mSeedBuf))) {
+        CVarSetString("gGeneral.ComboSeed", mSeedBuf);
+    }
     ImGui::SameLine();
 
-    const bool busy = mProgress.running.load();
-    if (busy)
+    const ComboRando::ComboGenProgress* p = sGetProgress ? sGetProgress() : nullptr;
+    const bool running = p && p->running.load();
+    // Generation may only run at the OOT file-select screen, so the worker can't race a live game
+    // tick (the prior off-thread crash class).
+    const bool onFileSelect = sIsOnFileSelect && sIsOnFileSelect();
+    const bool canGenerate = sTrigger && onFileSelect && !running;
+
+    if (!canGenerate)
         ImGui::BeginDisabled();
     if (ImGui::Button("Generate")) {
-        if (!sTrigger)
-            sTrigger = ResolveTrigger();
-        if (sTrigger) {
-            // Arm the one-frame defer: show "Generating…" this frame so the user sees
-            // feedback before the synchronous (blocking) fill runs next frame.
-            mProgress.Reset();
-            mProgress.done.store(false);
-            mProgress.running.store(true);
-            mStatusLine.clear();
-            mGeneratePending = true;
-        } else {
-            mStatusLine = "Generate unavailable (SOH_TriggerComboGenerate not found).";
-        }
+        CVarSetString("gGeneral.ComboSeed", mSeedBuf);
+        sTrigger(); // non-blocking: launcher spawns the worker; the main loop keeps running
     }
-    if (busy)
+    if (!canGenerate)
         ImGui::EndDisabled();
 
-    // One-frame defer: if a generate was requested last frame, fire it now (blocks until done).
-    if (mGeneratePending) {
-        mGeneratePending = false;
-        sTrigger(mSeedBuf, &mProgress); // synchronous — blocks this frame; sets done on return
+    if (!sTrigger) {
+        ImGui::TextUnformatted("Generate unavailable (soh.dll export not found).");
+    } else if (!onFileSelect && !running) {
+        ImGui::TextDisabled("Available on the file-select screen.");
     }
 
-    // Latch the result once the (synchronous) fill finishes. Branch on success, not just done —
-    // a done&&!success covers both real errors and a rejected duplicate, so the UI never hangs.
-    if (mProgress.done.load() && mProgress.running.load()) {
-        if (mProgress.success.load()) {
-            char buf[160];
-            snprintf(buf, sizeof(buf), "Done: seed 0x%X - %d cross-world placements", mProgress.seed.load(),
-                     mProgress.foreignCount.load());
-            mStatusLine = buf;
-        } else {
-            mStatusLine = std::string("Error: ") + mProgress.error;
+    // Live progress + result, polled from the launcher-owned progress each frame.
+    if (p) {
+        if (running) {
+            int placed = p->placed.load();
+            int total = p->total.load();
+            float frac = total > 0 ? (float)placed / (float)total : 0.0f;
+            ImGui::TextUnformatted(ComboGenProgress::PhaseLabel(p->phase.load()));
+            ImGui::ProgressBar(frac, ImVec2(360.0f, 0.0f));
+            ImGui::Text("%d / %d", placed, total);
+        } else if (p->done.load()) {
+            if (p->success.load()) {
+                // Show the reproducible seed token (the input string, not the internal masterSeed
+                // hash). Paste it into the Seed field + same settings to reproduce — shareable
+                // without sharing a save file.
+                ImGui::Text("Seed: %s", p->seedStr);
+                ImGui::SameLine();
+                if (ImGui::SmallButton("Copy")) {
+                    ImGui::SetClipboardText(p->seedStr);
+                }
+                ImGui::SameLine();
+                if (ImGui::SmallButton("Reuse")) {
+                    std::strncpy(mSeedBuf, p->seedStr, sizeof(mSeedBuf) - 1);
+                    mSeedBuf[sizeof(mSeedBuf) - 1] = '\0';
+                    CVarSetString("gGeneral.ComboSeed", mSeedBuf);
+                }
+                ImGui::Text("OOT checks: %d", p->ootCheckCount.load());
+                ImGui::Text("MM checks: %d", p->mmCheckCount.load());
+                ImGui::Text("Cross-game placements: %d", p->foreignCount.load());
+            } else {
+                ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "Error: %s", p->error);
+            }
         }
-        mProgress.running.store(false);
-    }
-
-    if (mProgress.running.load()) {
-        int placed = mProgress.placed.load();
-        int total = mProgress.total.load();
-        float frac = total > 0 ? (float)placed / (float)total : 0.0f;
-        ImGui::TextUnformatted(ComboGenProgress::PhaseLabel(mProgress.phase.load()));
-        ImGui::ProgressBar(frac, ImVec2(360.0f, 0.0f));
-        ImGui::Text("%d / %d", placed, total);
-    } else if (!mStatusLine.empty()) {
-        ImGui::TextUnformatted(mStatusLine.c_str());
     }
 }
 

--- a/combo/gui/ComboMenu.h
+++ b/combo/gui/ComboMenu.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <map>
 #include <utility>
+#include <vector>
 #include "gui/ComboGenProgress.h"
 
 namespace ComboRando {
@@ -31,8 +32,14 @@ class ComboMenu final : public Ship::GuiWindow {
     void DrawSharedPanel();                  // left-panel hub: engine + OOT Rando + MM Rando + Combo
     void DrawGamePanel(const char* gameKey); // renders from the C-ABI model (ComboMenuModel + RenderWidget)
     void DrawComboPanel();                   // cross-world Generate (seed + button + progress)
+    void DrawHintSection();                  // sphere "Get a hint" helper, when a seed save is active
 
     char mSeedBuf[128] = { 0 };
+    // Sphere-hint state: the active seed's playthrough (game, checkName) in sphere order, cached by
+    // save slot; mHintsRevealed = how many of the not-yet-collected steps the player has revealed.
+    int mHintFileNum = -1;
+    int mHintsRevealed = 0;
+    std::vector<std::pair<std::string, std::string>> mHintSteps;
     ComboGenProgress mProgress; // worker (in the exe) writes; this polls. Pointer handed across DLL.
     std::string mStatusLine;
     bool mGeneratePending = false; // one-frame defer: show "Generating…" before blocking fill

--- a/combo/rando/CrossForeign.h
+++ b/combo/rando/CrossForeign.h
@@ -1,14 +1,15 @@
 // combo/rando/CrossForeign.h
-// ComboShip: cross-world foreign-item marker map — shared by soh.dll, 2ship.dll, ComboShip.exe.
-// One JSON file per canonical OOT slot records which checks (in each game) hold an item that
-// belongs to the OTHER game. At pickup, the check's own game places a sentinel item; the
-// pickup code consults this map to learn the real foreign item + its destination game, then
-// delivers it immediately into that game's resident save (see issue #3; the old JSON CrossMailbox
-// stash + per-frame drain was replaced by immediate cross-DLL grant).
+// ComboShip: cross-world foreign-item lookup — shared by soh.dll, 2ship.dll, ComboShip.exe.
+// The consolidated per-slot spoiler file (saves/combo/save{N}-Randomizer-<hash>.json, written at
+// save creation) records, in its "foreign" array, which checks (in each game) hold an item that
+// belongs to the OTHER game. At pickup, the check's own game places a sentinel item; the pickup
+// code consults this array to learn the real foreign item + its destination game, then delivers it
+// immediately into that game's resident save (see issue #3). Both games resolve the file by
+// gSaveContext.fileNum, so a save and its consolidated file share one slot number.
 //
-// Schema (saves/combo/slot{N}.foreign.json):
-//   { "oot": { "<checkName>": {"itemGame":"mm","itemName":"RI_DEKU_MASK","displayName":"Deku Mask"} },
-//     "mm":  { "<checkName>": {"itemGame":"oot","itemName":"Hookshot","displayName":"Hookshot"} } }
+// "foreign" array element:
+//   { "checkGame":"oot|mm", "checkName":"<RC name>", "itemGame":"oot|mm",
+//     "itemName":"<item key in itemGame's namespace>", "displayName":"<human name + (MM)/(OOT)>" }
 //
 // Note: itemName is in the DESTINATION game's namespace (the item's home game), since that is the
 // game that ultimately grants it. OOT uses English item names; MM uses RI_* spoiler names.
@@ -44,82 +45,113 @@ inline GameId KeyToGameId(const std::string& s) {
     return s == "mm" ? GAME_MM : GAME_OOT;
 }
 
-inline std::filesystem::path ForeignPath(int canonicalSlot) {
-    return std::filesystem::path("saves") / "combo" / ("slot" + std::to_string(canonicalSlot) + ".foreign.json");
+inline std::filesystem::path ConsolidatedDir() {
+    return std::filesystem::path("Randomizer");
 }
 
-// Build and atomically write the per-slot foreign map from the combined spoiler's "foreign" array
-// (each element: {checkGame, checkName, itemGame, itemName, [displayName]}).
-inline bool WriteForeignFromAnnotations(int canonicalSlot, const nlohmann::json& foreignArray) {
-    nlohmann::json out;
-    out["oot"] = nlohmann::json::object();
-    out["mm"] = nlohmann::json::object();
+// Pending (unbound) seed written at Generate; remembered so the player can Start without regenerating.
+inline std::filesystem::path PendingPath() {
+    return ConsolidatedDir() / "Last-Generated-Randomizer.json";
+}
+
+// Per-slot consolidated file written when a save is created in slot N. Both the runtime foreign
+// source (read by either game via gSaveContext.fileNum) and the shareable artifact.
+inline std::filesystem::path SlotWritePath(int slot, const std::string& hashStr) {
+    return ConsolidatedDir() / ("save" + std::to_string(slot) + "-Randomizer-" + hashStr + ".json");
+}
+
+inline bool HasSlotPrefix(const std::string& name, const std::string& prefix) {
+    return name.size() > 5 && name.compare(0, prefix.size(), prefix) == 0 &&
+           name.compare(name.size() - 5, 5, ".json") == 0;
+}
+
+// Resolve slot N's consolidated file by prefix (newest match). Empty if none.
+inline std::filesystem::path SlotReadPath(int slot) {
+    std::error_code ec;
+    auto dir = ConsolidatedDir();
+    const std::string prefix = "save" + std::to_string(slot) + "-Randomizer-";
+    std::filesystem::path best;
+    std::filesystem::file_time_type bestTime{};
+    if (std::filesystem::exists(dir, ec)) {
+        for (const auto& e : std::filesystem::directory_iterator(dir, ec)) {
+            std::error_code ec2;
+            if (!e.is_regular_file(ec2))
+                continue;
+            const std::string name = e.path().filename().string();
+            if (HasSlotPrefix(name, prefix)) {
+                auto t = e.last_write_time(ec2);
+                if (best.empty() || t > bestTime) {
+                    best = e.path();
+                    bestTime = t;
+                }
+            }
+        }
+    }
+    return best;
+}
+
+// Remove any existing consolidated file(s) for slot N (stale seed from a prior generate in that slot).
+inline void CleanSlotFiles(int slot) {
+    std::error_code ec;
+    auto dir = ConsolidatedDir();
+    const std::string prefix = "save" + std::to_string(slot) + "-Randomizer-";
+    if (!std::filesystem::exists(dir, ec))
+        return;
+    for (const auto& e : std::filesystem::directory_iterator(dir, ec)) {
+        std::error_code ec2;
+        if (!e.is_regular_file(ec2))
+            continue;
+        if (HasSlotPrefix(e.path().filename().string(), prefix))
+            std::filesystem::remove(e.path(), ec2);
+    }
+}
+
+// Tag a spoiler "foreign" array's displayNames with their home-game suffix for the consolidated file.
+// Every display surface (shops, hints, trackers, toasts) reads displayName, so tag once here.
+inline nlohmann::json BuildForeignArray(const nlohmann::json& foreignArray) {
+    nlohmann::json out = nlohmann::json::array();
     for (const auto& fm : foreignArray) {
         std::string checkGame = fm.value("checkGame", "");
         std::string checkName = fm.value("checkName", "");
         if (checkGame.empty() || checkName.empty())
             continue;
-        std::string itemName = fm.value("itemName", "");
         std::string itemGame = fm.value("itemGame", "");
+        std::string itemName = fm.value("itemName", "");
         std::string displayName = fm.value("displayName", itemName);
-        // ComboShip: tag foreign items with their home game — every display surface (shops, NPC
-        // hints, trackers, toasts) reads this displayName, so one tag here covers them all.
-        // Only tag known games (a malformed marker keeps its untagged name).
-        if (!displayName.empty() && (itemGame == "mm" || itemGame == "oot")) {
+        if (!displayName.empty() && (itemGame == "mm" || itemGame == "oot"))
             displayName += (itemGame == "mm") ? " (MM)" : " (OOT)";
-        }
-        out[checkGame][checkName] = {
-            { "itemGame", itemGame },
-            { "itemName", itemName },
-            { "displayName", displayName },
-        };
+        out.push_back({ { "checkGame", checkGame },
+                        { "checkName", checkName },
+                        { "itemGame", itemGame },
+                        { "itemName", itemName },
+                        { "displayName", displayName } });
     }
-
-    std::error_code ec;
-    auto path = ForeignPath(canonicalSlot);
-    std::filesystem::create_directories(path.parent_path(), ec);
-    auto tmp = path;
-    tmp += ".tmp";
-    {
-        std::ofstream f(tmp, std::ios::trunc);
-        if (!f.is_open())
-            return false;
-        f << out.dump(2);
-        if (!f.good()) {
-            f.close();
-            std::filesystem::remove(tmp, ec);
-            return false;
-        }
-    }
-    std::filesystem::rename(tmp, path, ec); // atomic on same volume
-    return !ec;
+    return out;
 }
 
-// Load one game's foreign-check section, keyed by check name. Returns empty on missing/corrupt file
-// (never throws across the channel).
-inline std::unordered_map<std::string, ForeignItem> LoadForeignForGame(int canonicalSlot, GameId checkGame) {
+// Load one game's foreign-check section from slot N's consolidated file, keyed by check name.
+// Returns empty on missing/corrupt file (never throws across the channel). Per-slot file is
+// authoritative (written at save creation by fileNum) — no cross-slot fallback.
+inline std::unordered_map<std::string, ForeignItem> LoadForeignForGame(int slot, GameId checkGame) {
     std::unordered_map<std::string, ForeignItem> map;
-    std::ifstream in(ForeignPath(canonicalSlot));
-    // ComboShip: the foreign map is generated once per seed into canonical slot 0, but the runtime
-    // looks it up by the save's fileNum. A seed played in any OOT/MM file slot shares that one map,
-    // so fall back to slot 0 when the per-slot file is absent (e.g. a save in File 2/3). Prefers a
-    // per-slot file if one ever exists. Without this, non-slot-0 saves see no foreign items at all
-    // (sentinel name + placeholder model in shops/trackers).
-    if (!in.is_open() && canonicalSlot != 0)
-        in.open(ForeignPath(0));
+    auto path = SlotReadPath(slot);
+    if (path.empty())
+        return map;
+    std::ifstream in(path);
     if (!in.is_open())
         return map;
     try {
         nlohmann::json j;
         in >> j;
-        const auto& section = j.value(GameIdToKey(checkGame), nlohmann::json::object());
-        for (auto it = section.begin(); it != section.end(); ++it) {
-            const auto& v = it.value();
+        const std::string key = GameIdToKey(checkGame);
+        for (const auto& fm : j.value("foreign", nlohmann::json::array())) {
+            if (fm.value("checkGame", "") != key)
+                continue;
             ForeignItem fi;
-            fi.itemGame = KeyToGameId(v.value("itemGame", ""));
-            fi.itemName = v.value("itemName", "");
-            fi.displayName = v.value("displayName", fi.itemName);
-            map.emplace(it.key(), std::move(fi));
+            fi.itemGame = KeyToGameId(fm.value("itemGame", ""));
+            fi.itemName = fm.value("itemName", "");
+            fi.displayName = fm.value("displayName", fi.itemName);
+            map.emplace(fm.value("checkName", ""), std::move(fi));
         }
     } catch (...) { /* corrupt -> treat as empty */
     }

--- a/docs/UPSTREAM_MERGES.md
+++ b/docs/UPSTREAM_MERGES.md
@@ -1060,3 +1060,34 @@ byte-intact via the `#else`).
 **On future merges:** if upstream changes the quest enum or the carousel wrap logic, re-check that
 the locked `MIN_QUEST == MAX_QUEST == QUEST_RANDOMIZER` still resolves to Randomizer on every L/R
 path (incl. the Master-Quest-absent skip loop).
+
+## Non-blocking combo generation: worker thread + file-select driven (2026-06-27)
+
+**Why:** combo generation ran synchronously on the render thread, freezing the game (no music, no
+progress) for its whole duration. Stock SoH stays responsive by running the fill on a worker thread
+while the main loop keeps running (it polls `RandoGenerating` in `FileChoose_UpdateRandomizer`,
+swaps to gallop music, draws "Generating…", plays a fanfare). Combo couldn't naively copy that: its
+fill calls into the single-threaded game DLLs (dumps, oracles, and the `gSaveContext`-mutating
+apply), and a prior whole-pipeline-off-thread attempt crashed.
+
+**Design:** split the pipeline. The launcher (`combo/ComboShip.cpp`) runs dump→fill→playthrough on a
+worker thread (`g_GenerateThread`) and stashes the result; the `gSaveContext` **apply** runs on the
+main thread via `Combo_FinalizeGenerate`, polled each frame from the file-select loop. Generation is
+hard-gated to the file-select screen so the worker can't race a live game tick. The launcher owns the
+single `ComboGenProgress` and shares a read-only pointer with soh.
+
+**Vendored `soh` deviations:**
+- `OTRGlobals.cpp`/`.h`: new combo exports `SOH_TriggerComboGenerate` (now arg-less; reads the
+  `gGeneral.ComboSeed` CVar, gates on + sets `RandoGenerating`), `SOH_SetComboProgressPtr` /
+  `SOH_GetComboGenProgress` / `SOH_GetComboGenPercent`, `SOH_SetOnComboFinalizeCallback` /
+  `SOH_PollComboFinalize`, and `SOH_IsOnFileSelect` (matches `gGameState->main == FileChoose_Main`,
+  since `::init` is cleared after init). The generate-request callback type changed to
+  `void(*)(const char*)`.
+- `z_file_choose.c` (`COMBO_BUILD`-guarded): `RSM_GENERATE_RANDOMIZER` → `SOH_TriggerComboGenerate`;
+  `RSM_OPEN_RANDOMIZER_SETTINGS` → open the comboui menu (`gOpenWindows.Menu`); the
+  `FileChoose_UpdateRandomizer` "generating" branch polls `SOH_PollComboFinalize` and clears
+  `RandoGenerating` when done; a "Generating… XX%" line is drawn from `SOH_GetComboGenPercent`.
+
+**On future merges:** if upstream restructures the file-select randomizer menu (`RSM_*` actions) or
+`FileChoose_UpdateRandomizer`, re-apply the two action repoints + the finalize poll. If `GameState`'s
+`main` field or `FileChoose_Main` moves, re-check `SOH_IsOnFileSelect`.

--- a/docs/UPSTREAM_MERGES.md
+++ b/docs/UPSTREAM_MERGES.md
@@ -1091,3 +1091,31 @@ single `ComboGenProgress` and shares a read-only pointer with soh.
 **On future merges:** if upstream restructures the file-select randomizer menu (`RSM_*` actions) or
 `FileChoose_UpdateRandomizer`, re-apply the two action repoints + the finalize poll. If `GameState`'s
 `main` field or `FileChoose_Main` moves, re-check `SOH_IsOnFileSelect`.
+
+## Consolidated combo spoiler: share/drop + remember-seed + sphere hints (2026-06-28)
+
+**Why:** combo generation scattered per-seed data (`slot{N}.foreign.json`, `slot0.playthrough.txt`)
+and kept the result only in memory — no sharing, no remembering, regenerate every session. Now one
+consolidated `Randomizer/save{N}-Randomizer-<hash>.json` (+ a `Randomizer/Last-Generated-Randomizer.json`
+pending file) holds everything (both games' settings, placements, foreign map, structured playthrough,
+hash); it's the runtime foreign source, the remembered seed, the shareable drag-drop artifact, and the
+hint data. Mostly combo-owned (`combo/ComboShip.cpp`, `combo/rando/CrossForeign.h`,
+`combo/gui/ComboMenu.*`, `ComboGenProgress.h`). Vendored deviations:
+
+- **`soh` `OTRGlobals.cpp`/`.h`** — new combo exports: `SOH_DumpRandoSettings`/`SOH_RestoreRandoSettings`
+  (CVar-block snapshot/restore so a dropped seed reproduces cross-machine), `SOH_PrepRandoContext`
+  (refactored out of `SOH_DumpRandoStaticData`'s prep so reload/drop can build the settings-scoped pool
+  before re-applying placements — the dump now calls it), `SOH_RequestComboReload`/
+  `SOH_SetOnComboReloadCallback` (launcher reload seam), `SOH_GetActiveFileNum`, and
+  `Combo_SOH_GetObtainedChecks` (hint state).
+- **`soh` `randomizer.cpp`** — `Rando_HandleSpoilerDrop` also accepts `fileType=="ComboShipRandomizer"`
+  (sets `CVAR_GENERAL("ComboDroppedFile")`); the SoH spoiler path is unchanged.
+- **`soh` `z_file_choose.c`** (`COMBO_BUILD`) — `FileChoose_UpdateRandomizer` reloads a dropped combo
+  file (priority) or the remembered pending seed (first frame) via `SOH_RequestComboReload`.
+- **`mm` `BenPort.cpp`** — `MM_DumpRandoSettings`/`MM_RestoreRandoSettings` (MM options are CVar-backed;
+  restore runs before `MM_InitRandoSaveFile`) and `Combo_MM_GetObtainedChecks` (hint state).
+
+**On future merges:** the apply/prep must stay main-thread (the worker only computes). If upstream
+changes the rando settings/option CVar scheme, re-check the dump/restore. If the spoiler-drop handler
+or `FileChoose_UpdateRandomizer` is restructured, re-apply the combo `fileType` accept + the reload
+routing.

--- a/docs/UPSTREAM_MERGES.md
+++ b/docs/UPSTREAM_MERGES.md
@@ -1018,3 +1018,45 @@ written once per seed to canonical slot 0 but looked up at runtime by `gSaveCont
 `LoadForeignForGame` falls back to slot 0 when the per-slot file is absent so saves in File 2/3
 still resolve foreign items (names + models). The immediate-delivery grant targets the resident
 save by `fileNum` directly, so it is unaffected.
+
+## File-select seed-hash icons for combo seeds (issue #32, 2026-06-23)
+
+**Why:** stock SoH draws five item icons on the file-select as a visual seed hash so players can
+match seeds/spoiler logs. The combo build showed five Deku Nuts (or an identical set every seed):
+the combo generator owns generation and never runs OOT's `Playthrough_Init`, which is where vanilla
+calls `GenerateHash()` to fill `Rando::Context::hashIconIndexes` — so the array stayed all-zero.
+Scope is OOT only: combo boots into OOT's file-select and enters MM via transition, so MM's
+file-select is never shown (MM's `finalSeed = 0` gap in `MM_InitRandoSaveFile` is a known follow-up).
+
+**Change (vendored `soh`, minimal):** new export `SOH_SetComboSeedHash(uint32_t)` in
+`OTRGlobals.cpp` (just after `SOH_ApplyRandoPlacements`) calls `ctx->SetHash(...)` + `GenerateHash()`
+— mirrors stock `playthrough.cpp:64-73`. Added `#include ".../3drando/spoiler_log.hpp"` for the
+declaration. Persistence/render are stock-wired (`SaveManager` copies into `fileMetaInfo.seedHash`;
+`z_file_choose.c` renders it).
+
+**Change (combo-owned, `ComboShip.cpp`):** `RunComboFill` computes a settings-aware display hash
+`ComboHash(inputSeed + sohDump + mmDump)` and passes it to the new export *after*
+`SOH_ApplyRandoPlacements` (which `ItemReset`s). Folding both static dumps in makes the icons
+identify seed **and** settings: each dump is built from its game's live CVars and carries only the
+settings-scoped pool, so OOT *and* MM shuffle/starting-item settings both vary the icons. Accepted
+limitation (symmetric): a logic-only setting that doesn't change the shuffled pool (e.g. tricks)
+won't change the dump, so won't change the icons.
+
+**On future merges:** if upstream restructures `GenerateHash`/`SetHash` or the file-select hash
+render, re-point the new export; the combo-side hash derivation is independent.
+
+## File-select quest menu locked to Randomizer (2026-06-27)
+
+**Why:** the combo build drives a randomizer through OOT's normal save flow; showing the Normal /
+Master Quest / Boss Rush quest options on file-select is confusing since they're never the intent.
+
+**Change (vendored `soh`, one COMBO_BUILD-guarded block):** in
+`soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c`, the `MIN_QUEST`/`MAX_QUEST` macros
+(which seed `questType` at init and bound the L/R carousel wrap) are redefined to `QUEST_RANDOMIZER`
+under `COMBO_BUILD`. The carousel therefore starts on Randomizer and every L/R wrap lands back on it,
+so the other quests are unreachable — no draw/branch code was deleted (the non-combo build is
+byte-intact via the `#else`).
+
+**On future merges:** if upstream changes the quest enum or the carousel wrap logic, re-check that
+the locked `MIN_QUEST == MAX_QUEST == QUEST_RANDOMIZER` still resolves to Randomizer on every L/R
+path (incl. the Master-Quest-absent skip loop).

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -2835,6 +2835,34 @@ extern "C" __declspec(dllexport) void MM_GetExtractionProgress(unsigned long lon
 // CVars actually shuffle are emitted, so the cross-world fill sees the same pool MM's own generator
 // would. Recomputes every call since the result depends on live CVar state. Caller MUST invoke this
 // after SOH_Init() returns (so the shared Context, logger, and CVars exist).
+// ComboShip: snapshot every MM rando option as {cvar: value} for the consolidated spoiler, so a
+// dropped/reloaded seed reproduces MM's settings on any machine (MM options are CVar-backed;
+// MM_InitRandoSaveFile reads these CVars, so MM_RestoreRandoSettings writes them back before save
+// creation). Mirrors the option walk MM_DumpRandoStaticData uses.
+extern "C" __declspec(dllexport) const char* MM_DumpRandoSettings(void) {
+    static std::string cached;
+    nlohmann::json j = nlohmann::json::object();
+    for (auto& [id, opt] : Rando::StaticData::Options) {
+        if (opt.cvar && opt.cvar[0])
+            j[opt.cvar] = (int)CVarGetInteger(opt.cvar, opt.defaultValue);
+    }
+    cached = j.dump();
+    return cached.c_str();
+}
+
+// ComboShip: restore MM rando settings from a {cvar:value} snapshot. The reload/drop path calls this
+// BEFORE MM_InitRandoSaveFile (which reads these CVars), so a dropped seed builds its MM save with the
+// author's settings rather than the local ones.
+extern "C" __declspec(dllexport) void MM_RestoreRandoSettings(const char* json) {
+    if (!json)
+        return;
+    try {
+        auto j = nlohmann::json::parse(json);
+        for (auto it = j.begin(); it != j.end(); ++it)
+            CVarSetInteger(it.key().c_str(), it.value().get<int>());
+    } catch (...) {}
+}
+
 extern "C" __declspec(dllexport) const char* MM_DumpRandoStaticData(void) {
     static std::string cached;
 
@@ -3355,6 +3383,19 @@ static const std::unordered_map<std::string, RandoCheckId>& Combo_MM_CheckNameTo
         return m;
     }();
     return map;
+}
+
+// ComboShip: JSON array of MM rando checks the player has obtained, for the sphere-hint system.
+// Reads RANDO_SAVE_CHECKS (in the MM save); safe to call while MM is dormant.
+extern "C" __declspec(dllexport) const char* Combo_MM_GetObtainedChecks(void) {
+    static std::string cached;
+    nlohmann::json out = nlohmann::json::array();
+    for (const auto& [name, id] : Combo_MM_CheckNameToCheckId()) {
+        if (RANDO_SAVE_CHECKS[id].obtained)
+            out.push_back(name);
+    }
+    cached = out.dump();
+    return cached.c_str();
 }
 
 extern "C" __declspec(dllexport) void Combo_MM_Rando_SetOwnedItems(const char* itemNamesJson) {

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -67,6 +67,15 @@ bool Rando_HandleSpoilerDrop(char* filePath) {
         nlohmann::json json;
         stream >> json;
 
+#ifdef COMBO_BUILD
+        // ComboShip: a dropped consolidated combo spoiler — route it to the combo reload path (see
+        // FileChoose_UpdateRandomizer) rather than SoH's ParseSpoiler. Only flag it here.
+        if (json.value("fileType", std::string()) == "ComboShipRandomizer") {
+            CVarSetString(CVAR_GENERAL("ComboDroppedFile"), filePath);
+            return true;
+        }
+#endif
+
         if (json.contains("version") && json.contains("finalSeed")) {
             CVarSetString(CVAR_GENERAL("RandomizerDroppedFile"), filePath);
             CVarSetInteger(CVAR_GENERAL("RandomizerNewFileDropped"), 1);

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -3105,6 +3105,50 @@ extern "C" __declspec(dllexport) void SOH_SetComboRandoSeed(uint64_t seed) {
 }
 #endif
 
+// ComboShip: snapshot every OOT rando option as {cvarName: value}. The combo orchestrator stores
+// this in the consolidated spoiler so a dropped/reloaded seed reproduces the exact settings on any
+// machine (OOT options are CVar-backed; SOH_RestoreRandoSettings writes them back).
+extern "C" __declspec(dllexport) const char* SOH_DumpRandoSettings(void) {
+    static std::string cached;
+    nlohmann::json j = nlohmann::json::object();
+    for (const auto& opt : Rando::Settings::GetInstance()->GetAllOptions()) {
+        const std::string& cv = opt.GetCVarName();
+        if (!cv.empty())
+            j[cv] = static_cast<int>(opt.GetOptionIndex());
+    }
+    cached = j.dump();
+    return cached.c_str();
+}
+
+// ComboShip: restore OOT rando settings from a {cvarName:value} snapshot (written by
+// SOH_DumpRandoSettings into the consolidated spoiler). Used by the reload/drop path so a seed plays
+// with its own settings; SOH_PrepRandoContext then pushes them into the Context via SetAllToContext.
+extern "C" __declspec(dllexport) void SOH_RestoreRandoSettings(const char* json) {
+    if (!json)
+        return;
+    try {
+        auto j = nlohmann::json::parse(json);
+        for (auto it = j.begin(); it != j.end(); ++it)
+            CVarSetInteger(it.key().c_str(), it.value().get<int>());
+    } catch (...) {}
+}
+
+// ComboShip: the settings-scoped pool prep that SOH_ApplyRandoPlacements depends on (ItemReset
+// iterates allLocations). On generation this runs inside SOH_DumpRandoStaticData; the reload/drop
+// path (which skips the fill) must run it explicitly before applying saved placements.
+extern "C" __declspec(dllexport) void SOH_PrepRandoContext(void) {
+    try {
+        auto ctx = OTRGlobals::Instance->gRandoContext;
+        Rando::Settings::GetInstance()->SetAllToContext();
+        ctx->GetLogic()->Reset();
+        ctx->FinalizeSettings({}, {});
+        RegionTable_Init();
+        ctx->GenerateLocationPool();
+    } catch (const std::exception& e) {
+        SPDLOG_ERROR("[ComboShip] SOH_PrepRandoContext: {}", e.what());
+    } catch (...) {}
+}
+
 // ComboShip: coherent OOT rando dump for the combo generator. Runs the headless prep sequence
 // (GetLogic()->Reset, FinalizeSettings, RegionTable_Init, GenerateLocationPool) so ctx->allLocations
 // holds the real shuffled-check set for the current settings, then dumps those checks + their vanilla
@@ -3121,16 +3165,10 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoStaticData(void) {
     try {
         auto ctx = OTRGlobals::Instance->gRandoContext;
 
-        // Headless prep: reset logic state, finalize current settings, build region tables,
-        // then fill allLocations with only the checks the current settings shuffle.
-        // ComboShip: copy the player's chosen CVar settings into the Context FIRST (mirrors
-        // GenerateRandomizer), so the scoped pool, the fill's reachability, and the later
-        // Randomizer_InitSaveFile all honor the menu choices.
-        Rando::Settings::GetInstance()->SetAllToContext();
-        ctx->GetLogic()->Reset();
-        ctx->FinalizeSettings({}, {});
-        RegionTable_Init();
-        ctx->GenerateLocationPool();
+        // Headless prep (settings -> context, reset, region tables, settings-scoped pool). Shared
+        // with the reload/drop path via SOH_PrepRandoContext so allLocations holds only the checks
+        // the current settings shuffle, honoring the menu choices.
+        SOH_PrepRandoContext();
 
 #ifdef COMBO_BUILD
         // ComboShip: a non-shuffled shop slot holds a vanilla RG_BUY_* item (placed by
@@ -3389,6 +3427,44 @@ extern "C" __declspec(dllexport) void SOH_SetOnComboFinalizeCallback(int (*cb)()
 // main-thread apply; returns nonzero once generation is fully resolved (finalized or failed).
 extern "C" __declspec(dllexport) int SOH_PollComboFinalize(void) {
     return gComboFinalizeCallback ? gComboFinalizeCallback() : 1;
+}
+
+// ComboShip: reload a consolidated seed file so it's playable without regenerating (remember-seed +
+// drag-drop). The launcher does the work on the calling (main) thread; path null/empty = the
+// remembered pending file. Returns 1 if a seed was loaded.
+static int (*gComboReloadCallback)(const char*) = nullptr;
+extern "C" __declspec(dllexport) void SOH_SetOnComboReloadCallback(int (*cb)(const char*)) {
+    gComboReloadCallback = cb;
+}
+extern "C" __declspec(dllexport) int SOH_RequestComboReload(const char* path) {
+    return gComboReloadCallback ? gComboReloadCallback(path) : 0;
+}
+
+// ComboShip: the active save slot (combo seed key), or -1 if none. Used by the comboui hint system to
+// find the loaded seed's per-slot consolidated file.
+extern "C" __declspec(dllexport) int SOH_GetActiveFileNum(void) {
+    return (gSaveContext.fileNum == 0xFF) ? -1 : (int)gSaveContext.fileNum;
+}
+
+// ComboShip: JSON array of OOT rando checks the player has obtained, for the sphere-hint system
+// (which step is "done"). Reads the live rando Context; safe to call while OOT is dormant.
+extern "C" __declspec(dllexport) const char* Combo_SOH_GetObtainedChecks(void) {
+    static std::string cached;
+    nlohmann::json out = nlohmann::json::array();
+    auto ctx = OTRGlobals::Instance->gRandoContext;
+    if (ctx) {
+        for (int i = 0; i < RC_MAX; ++i) {
+            RandomizerCheck rc = static_cast<RandomizerCheck>(i);
+            Rando::ItemLocation* loc = ctx->GetItemLocation(rc);
+            if (loc && loc->HasObtained()) {
+                Rando::Location* sl = Rando::StaticData::GetLocation(rc);
+                if (sl && !sl->GetName().empty())
+                    out.push_back(sl->GetName());
+            }
+        }
+    }
+    cached = out.dump();
+    return cached.c_str();
 }
 
 // Trigger combo generation. Gated on RandoGenerating so a second press during generation is a no-op;

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -32,6 +32,7 @@
 #include "Enhancements/audio/AudioCollection.h"
 #include "Enhancements/debugconsole.h"
 #include "Enhancements/randomizer/randomizer.h"
+#include "Enhancements/randomizer/3drando/spoiler_log.hpp" // ComboShip: GenerateHash() for seed-hash icons
 #include "Enhancements/randomizer/randomizer_entrance_tracker.h"
 #include "Enhancements/randomizer/randomizer_check_tracker.h"
 #include "Enhancements/randomizer/static_data.h"
@@ -3324,6 +3325,19 @@ extern "C" __declspec(dllexport) void SOH_ApplyRandoPlacements(const char* json)
     } catch (const std::exception& e) {
         SPDLOG_ERROR("[ComboShip] SOH_ApplyRandoPlacements: exception: {}", e.what());
     } catch (...) { SPDLOG_ERROR("[ComboShip] SOH_ApplyRandoPlacements: unknown exception"); }
+}
+
+// ComboShip: set the file-select seed-hash icons. The combo generator owns generation and never
+// runs OOT's Playthrough_Init (which normally calls GenerateHash), so hashIconIndexes would stay
+// all-zero -> five Deku Nuts. The combo orchestrator passes a settings-aware hash value here (after
+// SOH_ApplyRandoPlacements, which ItemResets). GenerateHash() fills hashIconIndexes from the string,
+// then SaveManager persists it into the save's meta on creation, exactly as stock SoH.
+extern "C" __declspec(dllexport) void SOH_SetComboSeedHash(uint32_t hashValue) {
+    auto ctx = OTRGlobals::Instance->gRandoContext;
+    if (!ctx)
+        return;
+    ctx->SetHash(std::to_string(hashValue));
+    GenerateHash();
 }
 
 // ComboShip: generate callback — fired by Sram_InitSave before save creation, giving the combo

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -3144,9 +3144,8 @@ extern "C" __declspec(dllexport) void SOH_PrepRandoContext(void) {
         ctx->FinalizeSettings({}, {});
         RegionTable_Init();
         ctx->GenerateLocationPool();
-    } catch (const std::exception& e) {
-        SPDLOG_ERROR("[ComboShip] SOH_PrepRandoContext: {}", e.what());
-    } catch (...) {}
+    } catch (const std::exception& e) { SPDLOG_ERROR("[ComboShip] SOH_PrepRandoContext: {}", e.what()); } catch (...) {
+    }
 }
 
 // ComboShip: coherent OOT rando dump for the combo generator. Runs the headless prep sequence

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -3349,21 +3349,68 @@ extern "C" __declspec(dllexport) void SOH_SetOnComboGenerateCallback(void (*cb)(
     gComboGenerateCallback = cb;
 }
 
-// ComboShip: window-driven generate request — the UI calls SOH_TriggerComboGenerate with a seed
-// string and a progress struct; soh.dll forwards to the combo handler, which runs the fill on a
-// worker thread. The save-time gComboGenerateCallback is retained as a symbol but no longer
-// invoked (generation is now fully window-driven).
+// ComboShip: window-driven generate request — the UI (comboui Generate button or the native
+// file-select "Generate a new seed" option) calls SOH_TriggerComboGenerate; soh.dll forwards to the
+// launcher handler, which runs the fill on a WORKER THREAD so the main loop keeps rendering + playing
+// music + showing progress. The launcher owns the single ComboGenProgress and shares a read-only
+// pointer here via SOH_SetComboProgressPtr; the main-thread apply is driven via SOH_PollComboFinalize.
 #include "gui/ComboGenProgress.h"
-extern "C" void (*gComboGenerateRequestCallback)(const char*, ComboRando::ComboGenProgress*) = nullptr;
+extern "C" void (*gComboGenerateRequestCallback)(const char*) = nullptr;
+static const ComboRando::ComboGenProgress* gComboProgressPtr = nullptr;
+static int (*gComboFinalizeCallback)() = nullptr;
 
-extern "C" __declspec(dllexport) void SOH_SetOnComboGenerateRequestCallback(void (*cb)(const char*,
-                                                                                       ComboRando::ComboGenProgress*)) {
+extern "C" __declspec(dllexport) void SOH_SetOnComboGenerateRequestCallback(void (*cb)(const char*)) {
     gComboGenerateRequestCallback = cb;
 }
 
-extern "C" __declspec(dllexport) void SOH_TriggerComboGenerate(const char* seed, ComboRando::ComboGenProgress* p) {
-    if (gComboGenerateRequestCallback)
-        gComboGenerateRequestCallback(seed, p);
+extern "C" __declspec(dllexport) void SOH_SetComboProgressPtr(const ComboRando::ComboGenProgress* p) {
+    gComboProgressPtr = p;
+}
+
+extern "C" __declspec(dllexport) const ComboRando::ComboGenProgress* SOH_GetComboGenProgress(void) {
+    return gComboProgressPtr;
+}
+
+// C-friendly progress percent (0-100) for the native file-select screen (which is C and can't read
+// the C++ atomics directly).
+extern "C" __declspec(dllexport) int SOH_GetComboGenPercent(void) {
+    if (!gComboProgressPtr)
+        return 0;
+    int total = gComboProgressPtr->total.load();
+    int placed = gComboProgressPtr->placed.load();
+    return total > 0 ? static_cast<int>((100LL * placed) / total) : 0;
+}
+
+extern "C" __declspec(dllexport) void SOH_SetOnComboFinalizeCallback(int (*cb)()) {
+    gComboFinalizeCallback = cb;
+}
+
+// Called every frame on the main thread from the file-select loop. Runs the launcher's pending
+// main-thread apply; returns nonzero once generation is fully resolved (finalized or failed).
+extern "C" __declspec(dllexport) int SOH_PollComboFinalize(void) {
+    return gComboFinalizeCallback ? gComboFinalizeCallback() : 1;
+}
+
+// Trigger combo generation. Gated on RandoGenerating so a second press during generation is a no-op;
+// reads the seed from the shared CVar (written by the comboui seed field). Sets RandoGenerating=1 so
+// the file-select loop swaps to gallop music + shows progress; the finalize poll clears it.
+extern "C" __declspec(dllexport) void SOH_TriggerComboGenerate(void) {
+    if (CVarGetInteger(CVAR_GENERAL("RandoGenerating"), 0) != 0)
+        return; // already generating
+    if (!gComboGenerateRequestCallback)
+        return;
+    const char* seed = CVarGetString(CVAR_GENERAL("ComboSeed"), "");
+    CVarSetInteger(CVAR_GENERAL("RandoGenerating"), 1);
+    gComboGenerateRequestCallback(seed);
+}
+
+// ComboShip: true when the active OOT gamestate is the file-select screen. The combo Generate action
+// is gated to this so the worker can't race a live game tick (the prior off-thread crash class).
+// GameState::init is cleared after init runs, so match on ::main (set to FileChoose_Main for the
+// state's lifetime by FileChoose_Init).
+extern "C" void FileChoose_Main(GameState* thisx);
+extern "C" __declspec(dllexport) uint8_t SOH_IsOnFileSelect(void) {
+    return (gPlayState == NULL && gGameState != NULL && gGameState->main == (GameStateFunc)FileChoose_Main) ? 1 : 0;
 }
 
 extern "C" __declspec(dllexport) void SOH_SetSeedGenerated(uint8_t g) {

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -131,6 +131,8 @@ void SOH_TriggerComboGenerate(void);
 int SOH_PollComboFinalize(void);
 int SOH_GetComboGenPercent(void);
 uint8_t SOH_IsOnFileSelect(void);
+// Reload a consolidated seed file (null/empty path = the remembered pending file). Returns 1 if loaded.
+int SOH_RequestComboReload(const char* path);
 GetItemEntry ItemTable_Retrieve(int16_t getItemID);
 GetItemEntry ItemTable_RetrieveEntry(s16 modIndex, s16 getItemID);
 void EntranceTracker_SetCurrentGrottoID(s16 entranceIndex);

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -126,6 +126,11 @@ uint8_t Randomizer_IsSpoilerLoaded();
 void Randomizer_SetSpoilerLoaded(bool spoilerLoaded);
 uint8_t Randomizer_GenerateRandomizer();
 void Randomizer_ShowRandomizerMenu();
+// ComboShip: combo (cross-world) generation, driven from the file-select randomizer screen.
+void SOH_TriggerComboGenerate(void);
+int SOH_PollComboFinalize(void);
+int SOH_GetComboGenPercent(void);
+uint8_t SOH_IsOnFileSelect(void);
 GetItemEntry ItemTable_Retrieve(int16_t getItemID);
 GetItemEntry ItemTable_RetrieveEntry(s16 modIndex, s16 getItemID);
 void EntranceTracker_SetCurrentGrottoID(s16 entranceIndex);

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -25,8 +25,16 @@
 #include "soh/ResourceManagerHelpers.h"
 #include "soh/ShipUtils.h"
 
+#ifdef COMBO_BUILD
+// ComboShip: the combo build is randomizer-only. Lock the quest-select carousel to the Randomizer
+// option so Normal / Master Quest / Boss Rush are never shown or selectable (init seeds questType
+// from MIN_QUEST; L/R wrap between MIN_QUEST..MAX_QUEST and so stay on Randomizer).
+#define MIN_QUEST QUEST_RANDOMIZER
+#define MAX_QUEST QUEST_RANDOMIZER
+#else
 #define MIN_QUEST (ResourceMgr_GameHasOriginal() ? QUEST_NORMAL : QUEST_MASTER)
 #define MAX_QUEST QUEST_BOSSRUSH
+#endif
 
 void Sram_InitDebugSave(void);
 void Sram_InitBossRushSave();

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -382,6 +382,13 @@ void FileChoose_UpdateRandomizer() {
         generating = 0;
         return;
     } else if (generating) {
+#ifdef COMBO_BUILD
+        // ComboShip: drive the main-thread apply each frame while the worker runs. When it reports the
+        // generation fully resolved, clear RandoGenerating so the branch above fires the fanfare/error.
+        if (SOH_PollComboFinalize()) {
+            CVarSetInteger(CVAR_GENERAL("RandoGenerating"), 0);
+        }
+#endif
         return;
     }
 
@@ -826,11 +833,24 @@ void FileChoose_UpdateRandomizerMenu(GameState* thisx) {
                 Sfx_PlaySfxCentered(NA_SE_SY_OCARINA_ERROR);
             }
         } else if (this->randomizerIndex == RSM_GENERATE_RANDOMIZER) {
+#ifdef COMBO_BUILD
+            // ComboShip: run the cross-world combo generator (worker thread) instead of OOT's. Sets
+            // RandoGenerating so the loop below swaps to gallop music + shows progress; the finalize
+            // poll applies the result on the main thread.
+            SOH_TriggerComboGenerate();
+#else
             Randomizer_GenerateRandomizer();
+#endif
         } else if (this->randomizerIndex == RSM_OPEN_RANDOMIZER_SETTINGS) {
             Audio_PlaySoundGeneral(NA_SE_SY_FSEL_DECIDE_L, &gSfxDefaultPos, 4, &gSfxDefaultFreqAndVolScale,
                                    &gSfxDefaultFreqAndVolScale, &gSfxDefaultReverb);
+#ifdef COMBO_BUILD
+            // ComboShip: open the shared comboui settings menu (combo settings live there, not in
+            // OOT's stock rando ImGui menu).
+            CVarSetInteger("gOpenWindows.Menu", 1);
+#else
             Randomizer_ShowRandomizerMenu();
+#endif
         }
     }
 }
@@ -1849,6 +1869,15 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
         if (generating) {
             Interface_DrawTextLine(this->state.gfxCtx, SohFileSelect_GetSettingText(RSM_GENERATING, language), 70,
                                    (80 + 64), 255, 255, 255, textAlpha, 0.8f, true);
+#ifdef COMBO_BUILD
+            // ComboShip: live combo-generation progress (worker thread keeps the main loop running).
+            {
+                char comboPct[16];
+                snprintf(comboPct, sizeof(comboPct), "%d%%", SOH_GetComboGenPercent());
+                Interface_DrawTextLine(this->state.gfxCtx, comboPct, 70, (80 + 80), 255, 255, 255, textAlpha, 0.8f,
+                                       true);
+            }
+#endif
         }
 
         // If no randomizer is generated and "start randomizer" is selected, show text to explain why user can't start

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -392,6 +392,23 @@ void FileChoose_UpdateRandomizer() {
         return;
     }
 
+#ifdef COMBO_BUILD
+    // ComboShip: load a remembered or dropped combo seed so "Start Randomizer" works without
+    // regenerating. A dropped combo spoiler (flagged by Rando_HandleSpoilerDrop) takes priority and
+    // overrides the remembered pending seed; otherwise, on the first frame with nothing loaded, reload
+    // the remembered pending seed (no-op if none).
+    static u8 sComboReloadTried = 0;
+    const char* comboDrop = CVarGetString(CVAR_GENERAL("ComboDroppedFile"), "");
+    if (!Ship_IsCStringEmpty(comboDrop)) {
+        Sfx_PlaySfxCentered(SOH_RequestComboReload(comboDrop) ? NA_SE_SY_CORRECT_CHIME : NA_SE_SY_ERROR);
+        CVarSetString(CVAR_GENERAL("ComboDroppedFile"), "");
+        sComboReloadTried = 1;
+    } else if (!sComboReloadTried && !Randomizer_IsSeedGenerated() && !Randomizer_IsSpoilerLoaded()) {
+        sComboReloadTried = 1;
+        SOH_RequestComboReload(NULL);
+    }
+#endif
+
     if (!SpoilerFileExists(CVarGetString(CVAR_GENERAL("SpoilerLog"), "")) &&
         !CVarGetInteger(CVAR_RANDOMIZER_SETTING("DontGenerateSpoiler"), 0)) {
         CVarSetString(CVAR_GENERAL("SpoilerLog"), "");


### PR DESCRIPTION
## Summary
Randomizer file-select / generation UX for the combo build, plus a consolidated, shareable seed file.

- **Seed-hash icons + Randomizer-only quest (#32):** the five file-select hash icons now derive from the input seed + both games' settings (varied and reproducible across players, instead of always Deku Nuts); the quest carousel is locked to the Randomizer option.
- **Tracker tabs (#41):** the Item / Entrance / Check Tracker widgets moved from the Shared tab into each game's *Ship of Harkinian* / *2 Ship 2 Harkinian* → Randomizer section.
- **Non-blocking generation:** the cross-world fill runs on a worker thread, so the game no longer freezes — gallop music plays and a live "Generating… XX%" shows. The `gSaveContext`-mutating apply runs on the main thread, and generation is gated to the file-select screen.
- **Consolidated shareable spoiler:** generation writes one `Randomizer/save{N}-Randomizer-<hash>.json` per seed (both games' settings, placements, foreign map, structured playthrough, hash). It is the runtime foreign source (replaces `slot{N}.foreign.json`) and powers:
  - **Remember last seed** — Start without regenerating; survives a restart.
  - **Drag-and-drop** — drop a combo spoiler to load that exact seed (cross-machine via the carried settings).
  - **Sphere hints** — a comboui "Get a hint" button reveals the next uncollected step's location, comparing the playthrough against checks obtained in both games.
  - Drops the redundant `slot0.playthrough.txt` (folded into the JSON).

Vendored `soh`/`mm` deviations are documented in `docs/UPSTREAM_MERGES.md`.

## Testing
Built Debug (`soh`, `2ship`, `comboui`, `ComboShip`); verified in-game: icon variation by seed/settings, tracker placement, non-blocking generation with music + progress, remember-seed across restart, drag-and-drop load, and hints reflecting both games' collected checks.

## Notes
- Known deferred bug (separate): the rando-save "different version of SoH" warning is an `s16` overflow of the pin-derived minor version — cosmetic, fix tracked.


<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/7930938119.zip)
<!--- section:artifacts:end -->