### PR TITLE
Live-apply combo-menu settings + fix save-version overflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,12 @@ file(READ "${COMBO_PINS}" COMBO_PINS_JSON)
 string(JSON COMBO_SOH_SHA GET "${COMBO_PINS_JSON}" upstreams soh mergedSha)
 string(JSON COMBO_MM_SHA  GET "${COMBO_PINS_JSON}" upstreams mm  mergedSha)
 
-# first 4 hex of each pin -> 0..0xFFFF, fits the u16 gBuildVersion fields exactly
+# first 4 hex of each pin, masked to 15 bits -> 0..0x7FFF: fits the SIGNED s16 save-version fields
+# (unmasked 0..0xFFFF wrapped negative and .bak'd every save); still changes per merge for the gate.
 string(SUBSTRING "${COMBO_SOH_SHA}" 0 4 COMBO_SOH_HEX)
 string(SUBSTRING "${COMBO_MM_SHA}"  0 4 COMBO_MM_HEX)
-math(EXPR COMBO_MINOR "0x${COMBO_SOH_HEX}")
-math(EXPR COMBO_PATCH "0x${COMBO_MM_HEX}")
+math(EXPR COMBO_MINOR "0x${COMBO_SOH_HEX} & 0x7FFF")
+math(EXPR COMBO_PATCH "0x${COMBO_MM_HEX} & 0x7FFF")
 
 # short SHAs for the human-readable label / package name
 string(SUBSTRING "${COMBO_SOH_SHA}" 0 7 COMBO_SOH_SHORT)

--- a/combo/gui/ComboMenuModel.cpp
+++ b/combo/gui/ComboMenuModel.cpp
@@ -54,8 +54,8 @@ void ComboMenuModel::EnsureLoaded() {
                  "SOH_MenuDrawCustom", "SOH_MenuApplyCVarChange");
     }
     if (!mMm.loaded) {
-        LoadGame(mMm, "2ship.dll", "MM_ExportMenu", "MM_MenuInvokeCallback", "MM_MenuEvalDisabled",
-                 "MM_MenuDrawCustom", "MM_MenuApplyCVarChange");
+        LoadGame(mMm, "2ship.dll", "MM_ExportMenu", "MM_MenuInvokeCallback", "MM_MenuEvalDisabled", "MM_MenuDrawCustom",
+                 "MM_MenuApplyCVarChange");
     }
 
     if (mOot.loaded && mMm.loaded) {

--- a/combo/gui/ComboMenuModel.cpp
+++ b/combo/gui/ComboMenuModel.cpp
@@ -12,7 +12,7 @@ ComboMenuModel& ComboMenuModel::Get() {
 }
 
 void ComboMenuModel::LoadGame(GameMenu& g, const char* dll, const char* exportSym, const char* invokeSym,
-                              const char* evalSym, const char* drawSym) {
+                              const char* evalSym, const char* drawSym, const char* applySym) {
 #ifdef _WIN32
     HMODULE h = GetModuleHandleA(dll); // already LoadLibrary'd by the exe — mirror ResolveDraw
     if (!h) {
@@ -22,6 +22,7 @@ void ComboMenuModel::LoadGame(GameMenu& g, const char* dll, const char* exportSy
     g.invokeCallback = (Fn_MenuInvokeCallback)GetProcAddress(h, invokeSym);
     g.evalDisabled = (Fn_MenuEvalDisabled)GetProcAddress(h, evalSym);
     g.drawCustom = (Fn_MenuDrawCustom)GetProcAddress(h, drawSym);
+    g.applyCVarChange = (Fn_MenuApplyCVar)GetProcAddress(h, applySym); // optional — not in loaded check
 
     // ExportMenu may build the menu lazily (MM does so on ActivateMenu), so it can return
     // null until the game has eager-booted. Re-call it each retry until it yields a menu.
@@ -36,6 +37,7 @@ void ComboMenuModel::LoadGame(GameMenu& g, const char* dll, const char* exportSy
     (void)invokeSym;
     (void)evalSym;
     (void)drawSym;
+    (void)applySym;
     // Non-Windows: exports are resolved via the OS dynamic loader elsewhere; leave unresolved.
 #endif
 }
@@ -49,11 +51,11 @@ void ComboMenuModel::EnsureLoaded() {
     // so a later frame can pick it up; we only latch mLoaded once BOTH have loaded.
     if (!mOot.loaded) {
         LoadGame(mOot, "soh.dll", "SOH_ExportMenu", "SOH_MenuInvokeCallback", "SOH_MenuEvalDisabled",
-                 "SOH_MenuDrawCustom");
+                 "SOH_MenuDrawCustom", "SOH_MenuApplyCVarChange");
     }
     if (!mMm.loaded) {
         LoadGame(mMm, "2ship.dll", "MM_ExportMenu", "MM_MenuInvokeCallback", "MM_MenuEvalDisabled",
-                 "MM_MenuDrawCustom");
+                 "MM_MenuDrawCustom", "MM_MenuApplyCVarChange");
     }
 
     if (mOot.loaded && mMm.loaded) {

--- a/combo/gui/ComboMenuModel.h
+++ b/combo/gui/ComboMenuModel.h
@@ -17,6 +17,7 @@ struct GameMenu {
     Fn_MenuInvokeCallback invokeCallback = nullptr;
     Fn_MenuEvalDisabled evalDisabled = nullptr;
     Fn_MenuDrawCustom drawCustom = nullptr;
+    Fn_MenuApplyCVar applyCVarChange = nullptr; // optional; live-applies a changed CVar via ShipInit
     bool loaded = false;
 };
 
@@ -36,7 +37,7 @@ class ComboMenuModel {
 
   private:
     void LoadGame(GameMenu& g, const char* dll, const char* exportSym, const char* invokeSym, const char* evalSym,
-                  const char* drawSym);
+                  const char* drawSym, const char* applySym);
     GameMenu mOot, mMm;
     bool mLoaded = false;
 };

--- a/combo/gui/ComboWidgetRender.cpp
+++ b/combo/gui/ComboWidgetRender.cpp
@@ -238,6 +238,13 @@ void RenderWidget(const CwWidget& w, const GameMenu& game) {
         game.invokeCallback(w.index);
     }
 
+    // 5) re-apply the changed CVar live: re-run the owning game's ShipInit func(s) registered for it,
+    // mirroring what the games' native UIWidgets do. Without this, enhancements/settings toggled in
+    // the combo menu only take effect on the next ShipInit::InitAll (game boot / new save).
+    if (changed && w.cvar && w.cvar[0] && game.applyCVarChange) {
+        game.applyCVarChange(w.cvar);
+    }
+
     if (disabled) {
         ImGui::EndDisabled();
     }

--- a/combo/menu/ComboMenuABI.h
+++ b/combo/menu/ComboMenuABI.h
@@ -87,6 +87,7 @@ typedef const CwMenu* (*Fn_ExportMenu)(void);
 typedef void (*Fn_MenuInvokeCallback)(int32_t index);
 typedef int32_t (*Fn_MenuEvalDisabled)(int32_t index, const char** outReason);
 typedef void (*Fn_MenuDrawCustom)(int32_t index);
+typedef void (*Fn_MenuApplyCVar)(const char* cvar); // re-run the game's ShipInit for a changed CVar
 
 #ifdef __cplusplus
 }

--- a/docs/UPSTREAM_MERGES.md
+++ b/docs/UPSTREAM_MERGES.md
@@ -1119,3 +1119,12 @@ hint data. Mostly combo-owned (`combo/ComboShip.cpp`, `combo/rando/CrossForeign.
 changes the rando settings/option CVar scheme, re-check the dump/restore. If the spoiler-drop handler
 or `FileChoose_UpdateRandomizer` is restructured, re-apply the combo `fileType` accept + the reload
 routing.
+
+## Live-apply settings changed from the combo menu (2026-06-28)
+
+**Why:** the games' native UIWidgets call `ShipInit::Init(cvar)` after a widget change to re-run the
+enhancement registered for that CVar; comboui only set the CVar, so combo-menu changes didn't apply
+until the next `ShipInit::InitAll` (game boot / new save). New exports `SOH_MenuApplyCVarChange` /
+`MM_MenuApplyCVarChange` (OTRGlobals.cpp / BenPort.cpp) run `ShipInit::Init(cvar)`; the comboui menu
+model + `ComboWidgetRender` call them after each change. Fixes #27. **On future merges:** if the
+native UIWidgets stop using `ShipInit::Init`-on-change, revisit.

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -3600,6 +3600,14 @@ extern "C" __declspec(dllexport) void MM_MenuInvokeCallback(int32_t i) {
     }
 }
 
+// ComboShip: re-run the ShipInit func(s) registered for this CVar, mirroring 2Ship's native UIWidgets
+// after a widget change — so settings/enhancements changed via the combo menu apply live instead of
+// only on the next ShipInit::InitAll (MM boot / new save).
+extern "C" __declspec(dllexport) void MM_MenuApplyCVarChange(const char* cvar) {
+    if (cvar && cvar[0])
+        ShipInit::Init(cvar);
+}
+
 extern "C" __declspec(dllexport) int32_t MM_MenuEvalDisabled(int32_t i, const char** outReason) {
     ComboMenuContext::UseSharedImGuiContext();
     auto menu = Combo_EnsureBenMenu();

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -2809,6 +2809,14 @@ extern "C" __declspec(dllexport) void SOH_MenuInvokeCallback(int32_t i) {
         menu->InvokeCallbackByIndex(i);
 }
 
+// ComboShip: re-run the ShipInit func(s) registered for this CVar, mirroring what soh's native
+// UIWidgets does after a widget change. Without this, settings changed via the combo menu only take
+// effect on the next ShipInit::InitAll (game boot / new save) — enhancements wouldn't apply live.
+extern "C" __declspec(dllexport) void SOH_MenuApplyCVarChange(const char* cvar) {
+    if (cvar && cvar[0])
+        ShipInit::Init(cvar);
+}
+
 extern "C" __declspec(dllexport) int32_t SOH_MenuEvalDisabled(int32_t i, const char** outReason) {
     ComboMenuContext::UseSharedImGuiContext();
     auto menu = SohGui::GetSohMenu();


### PR DESCRIPTION
## Summary
Two MM/combo settings fixes.

- **Settings apply live from the combo menu.** The games' native UIWidgets call `ShipInit::Init(cvar)` after a widget change to re-run the enhancement registered for that CVar; comboui only set the CVar, so changes didn't take effect until the next game boot / new save. New `SOH_MenuApplyCVarChange` / `MM_MenuApplyCVarChange` exports run `ShipInit::Init(cvar)`, wired into the comboui menu model + `ComboWidgetRender` and routed to the owning game (so a toggle on the Ship/2Ship tab re-applies in that game). Closes #27.
- **Save-version overflow.** The build MINOR/PATCH are derived from the upstream-pin SHAs (`0..0xFFFF`); a value over 32767 (e.g. `0xEC2A`=60458) overflowed the signed `s16` save-version fields, so the rando save-gate renamed **every** same-build save to `.bak`. `CMakeLists` now masks them to 15 bits (`& 0x7FFF`), so the version (`1.27690.13637`) fits `s16` — no vendored save-code change. Still changes per upstream merge, preserving the auto-invalidate gate.

Vendored deviations documented in `docs/UPSTREAM_MERGES.md`.

## Testing
Built Debug (soh/2ship/comboui) + regenerated soh.o2r/2ship.o2r for the new version. Verified in-game: enhancements toggle live from the menu, and same-build saves no longer get backed up to `.bak`.

Closes #27


<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/7936081569.zip)
<!--- section:artifacts:end -->