### PR TITLE
Consolidate shared settings + fix MM/OOT dev-tool windows

### DIFF
--- a/combo/CMakeLists.txt
+++ b/combo/CMakeLists.txt
@@ -31,6 +31,7 @@ set(COMBOUI_SOURCES
     gui/ComboWidgetStyle.cpp
     gui/ComboExtractScreen.cpp
     gui/ComboTrackerVisibility.cpp
+    gui/ComboAudioBridge.cpp
 )
 add_library(comboui SHARED ${COMBOUI_SOURCES})
 set_target_properties(comboui PROPERTIES PREFIX "")

--- a/combo/gui/ComboAudioBridge.cpp
+++ b/combo/gui/ComboAudioBridge.cpp
@@ -1,0 +1,80 @@
+// combo/gui/ComboAudioBridge.cpp — see ComboAudioBridge.h for rationale.
+#include "ComboAudioBridge.h"
+#include "ComboForeground.h"           // ComboUI::IsMmActive
+#include <libultraship/libultraship.h> // CVarGetInteger / CVarSetFloat
+#ifdef _WIN32
+#include <windows.h>
+#endif
+#include <cstring>
+
+namespace {
+
+// OOT Volume.* (int 0-100, canonical) -> MM Audio.* (float 0-1, derived). seqPlayer is MM's
+// SEQ_PLAYER index for the per-port apply call; -1 = master (read live by MM each note-init, so
+// setting the CVar is enough — no apply call). Indices match both games' SEQ_PLAYER_* enums.
+struct VolMap {
+    const char* ootCVar;
+    const char* mmCVar;
+    int seqPlayer;
+};
+const VolMap kMap[] = {
+    { "gSettings.Volume.Master", "gSettings.Audio.MasterVolume", -1 },
+    { "gSettings.Volume.MainMusic", "gSettings.Audio.MainMusicVolume", 0 },     // SEQ_PLAYER_BGM_MAIN
+    { "gSettings.Volume.SubMusic", "gSettings.Audio.SubMusicVolume", 3 },       // SEQ_PLAYER_BGM_SUB
+    { "gSettings.Volume.SFX", "gSettings.Audio.SoundEffectsVolume", 2 },        // SEQ_PLAYER_SFX
+    { "gSettings.Volume.Fanfare", "gSettings.Audio.FanfareVolume", 1 },         // SEQ_PLAYER_FANFARE
+};
+
+// Resolved once from 2ship.dll. MM applies per-port volume via AudioSeq_SetPortVolumeScale, exposed
+// as MM_ApplyAudioVolume (BenPort.cpp, COMBO_BUILD). Safe to call even when MM is dormant — gAudioCtx
+// persists across transitions — but we only call it when warranted (see MirrorRow).
+typedef void (*Fn_ApplyAudioVolume)(int seqPlayer, float volume);
+Fn_ApplyAudioVolume ResolveApply() {
+    static Fn_ApplyAudioVolume sFn = nullptr;
+    static bool sTried = false;
+#ifdef _WIN32
+    if (!sTried) {
+        sTried = true;
+        if (HMODULE h = GetModuleHandleA("2ship.dll")) {
+            sFn = (Fn_ApplyAudioVolume)GetProcAddress(h, "MM_ApplyAudioVolume");
+        }
+    }
+#endif
+    return sFn;
+}
+
+// Mirror one row. `forceApply` pushes the per-port scale regardless of the active game (used by the
+// boot/resume sync, where MM's audio is about to play); otherwise the apply only fires when MM is the
+// foreground game (a live slider while playing OOT just updates the CVar — SyncAllToMM re-applies it
+// on the next MM entry).
+void MirrorRow(const VolMap& m, bool forceApply) {
+    int vi = CVarGetInteger(m.ootCVar, 0);
+    float f = vi / 100.0f;
+    f = f < 0.0f ? 0.0f : (f > 1.0f ? 1.0f : f);
+    CVarSetFloat(m.mmCVar, f);
+    if (m.seqPlayer >= 0 && (forceApply || ComboUI::IsMmActive())) {
+        if (auto fn = ResolveApply()) {
+            fn(m.seqPlayer, f);
+        }
+    }
+}
+
+} // namespace
+
+void ComboAudio::MirrorIfVolumeCVar(const char* cvar) {
+    if (!cvar || !cvar[0]) {
+        return;
+    }
+    for (const auto& m : kMap) {
+        if (std::strcmp(cvar, m.ootCVar) == 0) {
+            MirrorRow(m, /*forceApply=*/false);
+            return;
+        }
+    }
+}
+
+void ComboAudio::SyncAllToMM() {
+    for (const auto& m : kMap) {
+        MirrorRow(m, /*forceApply=*/true);
+    }
+}

--- a/combo/gui/ComboAudioBridge.cpp
+++ b/combo/gui/ComboAudioBridge.cpp
@@ -16,13 +16,15 @@ struct VolMap {
     const char* ootCVar;
     const char* mmCVar;
     int seqPlayer;
+    int defaultPct; // OOT slider default — must match SohMenuSettings.cpp so an untouched slider isn't
+                    // read as 0 (which would silence MM). Master 40, the rest 100.
 };
 const VolMap kMap[] = {
-    { "gSettings.Volume.Master", "gSettings.Audio.MasterVolume", -1 },
-    { "gSettings.Volume.MainMusic", "gSettings.Audio.MainMusicVolume", 0 },     // SEQ_PLAYER_BGM_MAIN
-    { "gSettings.Volume.SubMusic", "gSettings.Audio.SubMusicVolume", 3 },       // SEQ_PLAYER_BGM_SUB
-    { "gSettings.Volume.SFX", "gSettings.Audio.SoundEffectsVolume", 2 },        // SEQ_PLAYER_SFX
-    { "gSettings.Volume.Fanfare", "gSettings.Audio.FanfareVolume", 1 },         // SEQ_PLAYER_FANFARE
+    { "gSettings.Volume.Master", "gSettings.Audio.MasterVolume", -1, 40 },
+    { "gSettings.Volume.MainMusic", "gSettings.Audio.MainMusicVolume", 0, 100 }, // SEQ_PLAYER_BGM_MAIN
+    { "gSettings.Volume.SubMusic", "gSettings.Audio.SubMusicVolume", 3, 100 },   // SEQ_PLAYER_BGM_SUB
+    { "gSettings.Volume.SFX", "gSettings.Audio.SoundEffectsVolume", 2, 100 },    // SEQ_PLAYER_SFX
+    { "gSettings.Volume.Fanfare", "gSettings.Audio.FanfareVolume", 1, 100 },     // SEQ_PLAYER_FANFARE
 };
 
 // Resolved once from 2ship.dll. MM applies per-port volume via AudioSeq_SetPortVolumeScale, exposed
@@ -48,7 +50,7 @@ Fn_ApplyAudioVolume ResolveApply() {
 // foreground game (a live slider while playing OOT just updates the CVar — SyncAllToMM re-applies it
 // on the next MM entry).
 void MirrorRow(const VolMap& m, bool forceApply) {
-    int vi = CVarGetInteger(m.ootCVar, 0);
+    int vi = CVarGetInteger(m.ootCVar, m.defaultPct);
     float f = vi / 100.0f;
     f = f < 0.0f ? 0.0f : (f > 1.0f ? 1.0f : f);
     CVarSetFloat(m.mmCVar, f);

--- a/combo/gui/ComboAudioBridge.h
+++ b/combo/gui/ComboAudioBridge.h
@@ -1,0 +1,22 @@
+// combo/gui/ComboAudioBridge.h
+//
+// ComboShip-owned: bridges the Shared tab's audio sliders to MM. The Shared tab's Audio section is
+// OOT's, writing gSettings.Volume.* (int 0-100). MM reads its own gSettings.Audio.* (float 0-1) and
+// applies per-port volume via AudioSeq_SetPortVolumeScale (not ShipInit), so the Shared sliders would
+// otherwise never reach MM. This is a one-way mirror: OOT's Volume.* is canonical, MM's Audio.* is
+// derived. See Part A4 of the shared-settings consolidation.
+#pragma once
+
+namespace ComboAudio {
+
+// If `cvar` is one of OOT's gSettings.Volume.* sliders, mirror it into MM's matching gSettings.Audio.*
+// (int 0-100 -> float 0-1) and, when MM is the active game, apply it live. No-op otherwise. Call from
+// the combo widget render apply-step.
+void MirrorIfVolumeCVar(const char* cvar);
+
+// Push all canonical OOT volumes into MM's CVars and apply the per-port scales. Call when MM becomes
+// the foreground game (boot/resume), so volume changes made while MM was dormant take effect, and
+// MM's audio ports match the canonical Shared values on entry.
+void SyncAllToMM();
+
+} // namespace ComboAudio

--- a/combo/gui/ComboForeground.h
+++ b/combo/gui/ComboForeground.h
@@ -1,0 +1,21 @@
+// combo/gui/ComboForeground.h
+//
+// ComboShip-owned: query which game is currently foreground (0 = OOT, 1 = MM). The launcher
+// (combo/ComboShip.cpp) calls ComboUI_OnForegroundGame at each transition; ComboTrackerVisibility.cpp
+// caches the value here. Used by the audio bridge, the controls reload hook, and dev-tool window
+// gating to avoid driving the dormant game's live runtime state.
+#pragma once
+
+namespace ComboUI {
+
+// 0 = OOT, 1 = MM. Defaults to OOT (the foreground game at startup after the eager MM boot).
+int GetForegroundGame();
+
+inline bool IsGameActive(int game) {
+    return GetForegroundGame() == game;
+}
+inline bool IsMmActive() {
+    return GetForegroundGame() == 1;
+}
+
+} // namespace ComboUI

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -316,13 +316,14 @@ void ComboMenu::DrawGamePanel(const char* gameKey) {
         if (isOot && section && strcmp(section, "Settings") == 0) {
             return sidebar && (strcmp(sidebar, "Mod Menu") == 0 || strcmp(sidebar, "Presets") == 0);
         }
-        // MM's Graphics/Audio/Controls are consolidated into the Shared tab — Graphics applies via the
-        // single shared window, Controls via the shared gSettings.Controllers.* CVars, and Audio via the
-        // combo audio bridge (gSettings.Volume.* -> gSettings.Audio.*). Hide them from MM's per-game
-        // Settings section so they live only in Shared; the rest of MM Settings stays.
+        // MM's Graphics/Audio/Controls/General are consolidated into the Shared tab — Graphics applies via
+        // the single shared window, Controls via the shared gSettings.Controllers.* CVars, Audio via the
+        // combo audio bridge (gSettings.Volume.* -> gSettings.Audio.*), and General is menu/engine settings
+        // on shared gSettings.Menu.*/ImGuiScale CVars. Hide them from MM's per-game Settings section so they
+        // live only in Shared; MM-specific sidebars (Overlay, Presets, ...) stay.
         if (!isOot && section && strcmp(section, "Settings") == 0 && sidebar &&
             (strcmp(sidebar, "Graphics") == 0 || strcmp(sidebar, "Audio") == 0 ||
-             strcmp(sidebar, "Controls") == 0)) {
+             strcmp(sidebar, "Controls") == 0 || strcmp(sidebar, "General") == 0)) {
             return false;
         }
         // The rando section's settings live in the Shared tab; here we surface only its trackers.

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -316,6 +316,15 @@ void ComboMenu::DrawGamePanel(const char* gameKey) {
         if (isOot && section && strcmp(section, "Settings") == 0) {
             return sidebar && (strcmp(sidebar, "Mod Menu") == 0 || strcmp(sidebar, "Presets") == 0);
         }
+        // MM's Graphics/Audio/Controls are consolidated into the Shared tab — Graphics applies via the
+        // single shared window, Controls via the shared gSettings.Controllers.* CVars, and Audio via the
+        // combo audio bridge (gSettings.Volume.* -> gSettings.Audio.*). Hide them from MM's per-game
+        // Settings section so they live only in Shared; the rest of MM Settings stays.
+        if (!isOot && section && strcmp(section, "Settings") == 0 && sidebar &&
+            (strcmp(sidebar, "Graphics") == 0 || strcmp(sidebar, "Audio") == 0 ||
+             strcmp(sidebar, "Controls") == 0)) {
+            return false;
+        }
         // The rando section's settings live in the Shared tab; here we surface only its trackers.
         const char* randoSec = isOot ? "Randomizer" : "Rando";
         if (section && strcmp(section, randoSec) == 0)

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -322,8 +322,8 @@ void ComboMenu::DrawGamePanel(const char* gameKey) {
         // on shared gSettings.Menu.*/ImGuiScale CVars. Hide them from MM's per-game Settings section so they
         // live only in Shared; MM-specific sidebars (Overlay, Presets, ...) stay.
         if (!isOot && section && strcmp(section, "Settings") == 0 && sidebar &&
-            (strcmp(sidebar, "Graphics") == 0 || strcmp(sidebar, "Audio") == 0 ||
-             strcmp(sidebar, "Controls") == 0 || strcmp(sidebar, "General") == 0)) {
+            (strcmp(sidebar, "Graphics") == 0 || strcmp(sidebar, "Audio") == 0 || strcmp(sidebar, "Controls") == 0 ||
+             strcmp(sidebar, "General") == 0)) {
             return false;
         }
         // The rando section's settings live in the Shared tab; here we surface only its trackers.

--- a/combo/gui/ComboTrackerVisibility.cpp
+++ b/combo/gui/ComboTrackerVisibility.cpp
@@ -28,8 +28,17 @@
 
 #include <libultraship/libultraship.h> // Ship::Context / Gui + CVarGet/SetInteger
 #include <memory>                      // std::weak_ptr (notification-window handle)
+#include "ComboForeground.h"           // ComboUI::GetForegroundGame (cached below)
+#include "ComboAudioBridge.h"          // ComboAudio::SyncAllToMM (on MM entry)
+#ifdef _WIN32
+#include <windows.h> // GetModuleHandleA/GetProcAddress for the MM_ReloadControls entry point
+#endif
 
 namespace {
+
+// Cached foreground game (0 = OOT, 1 = MM), updated by ComboUI_OnForegroundGame. Defaults to OOT,
+// the foreground game at startup after the eager MM boot. Read via ComboUI::GetForegroundGame.
+int sForegroundGame = 0;
 
 struct TrackerWin {
     const char* cvar; // visibility CVar (source of truth; MM's CheckTracker reads it directly)
@@ -83,6 +92,25 @@ const char* const kNotificationWin[2] = {
 // member keeps them alive); we only need a handle to re-add the backgrounded one later.
 std::weak_ptr<Ship::GuiWindow> sNotif[2];
 
+// Reload MM's controller bindings from the shared gSettings.Controllers.* CVars. Resolved once from
+// 2ship.dll. Called on MM entry so rebinds made via the Shared (OOT) controls UI while MM was dormant
+// take effect when MM resumes (MM's ControlDeck caches mappings; it only re-reads on Init / this call).
+void ReloadMmControls() {
+#ifdef _WIN32
+    static void (*sFn)() = nullptr;
+    static bool sTried = false;
+    if (!sTried) {
+        sTried = true;
+        if (HMODULE h = GetModuleHandleA("2ship.dll")) {
+            sFn = (void (*)())GetProcAddress(h, "MM_ReloadControls");
+        }
+    }
+    if (sFn) {
+        sFn();
+    }
+#endif
+}
+
 // Keep only the foreground game's notification window in the shared Gui's draw loop.
 void SetForegroundNotification(int fg) {
     auto ctx = Ship::Context::GetInstance();
@@ -108,6 +136,18 @@ void SetForegroundNotification(int fg) {
 
 } // namespace
 
+// Foreground-game query consumed by the audio bridge, controls reload, and dev-tool gating.
+int ComboUI::GetForegroundGame() {
+    return sForegroundGame;
+}
+
+// C-ABI variant so the game DLLs can query the foreground game (0 = OOT, 1 = MM) across the DLL
+// boundary — MM uses it to gate its live-world dev viewers (Actor/Collision/Message) from drawing
+// against dormant/swapped play state when its tab is opened while OOT is foreground.
+extern "C" __declspec(dllexport) int ComboUI_GetForegroundGame(void) {
+    return sForegroundGame;
+}
+
 // Called by the launcher whenever a game becomes the foreground game (0 = OOT, 1 = MM).
 extern "C" __declspec(dllexport) void ComboUI_OnForegroundGame(int game) {
     if (game != 0 && game != 1) {
@@ -115,6 +155,7 @@ extern "C" __declspec(dllexport) void ComboUI_OnForegroundGame(int game) {
     }
     const int fg = game;
     const int bg = game ^ 1;
+    sForegroundGame = fg;
 
     // Background game: remember the user's current intent, then hide its trackers.
     for (int i = 0; i < 4; ++i) {
@@ -133,6 +174,15 @@ extern "C" __declspec(dllexport) void ComboUI_OnForegroundGame(int game) {
     // Notification window follows the active game too (so MM's toasts show only while MM is foreground
     // and OOT's only while OOT is). Independent of the tracker intent above.
     SetForegroundNotification(fg);
+
+    // ComboShip: on MM entry (boot/resume), reconcile the settings MM consumes from its own CVars with
+    // the canonical Shared values changed while MM was dormant — push audio volumes (apply per-port
+    // scales) and reload controller bindings. Graphics needs no equivalent (the shared window applies
+    // OOT's graphics callbacks process-wide), and Controls' data already lives in shared CVars.
+    if (fg == 1) {
+        ComboAudio::SyncAllToMM();
+        ReloadMmControls();
+    }
 }
 
 // Called by the launcher just before shutdown teardown. Restores both games' tracker CVars to the

--- a/combo/gui/ComboWidgetRender.cpp
+++ b/combo/gui/ComboWidgetRender.cpp
@@ -15,6 +15,7 @@
 #include "ComboWidgetRender.h"
 #include "ComboMenuModel.h"   // GameMenu (resolved export fn-ptrs)
 #include "ComboWidgetStyle.h" // combo-owned replication of OOT UIWidgets menu styling
+#include "ComboAudioBridge.h" // Shared-tab audio -> MM mirror
 
 #include <libultraship/libultraship.h> // ImGui-adjacent + CVar bridge (CVarGet/Set*) + color.h
 #include <imgui.h>
@@ -243,6 +244,12 @@ void RenderWidget(const CwWidget& w, const GameMenu& game) {
     // the combo menu only take effect on the next ShipInit::InitAll (game boot / new save).
     if (changed && w.cvar && w.cvar[0] && game.applyCVarChange) {
         game.applyCVarChange(w.cvar);
+    }
+
+    // 6) ComboShip: the Shared tab's audio sliders are OOT's (gSettings.Volume.*); mirror them into
+    // MM's gSettings.Audio.* so a single Shared Audio section drives both games (see ComboAudioBridge).
+    if (changed && w.cvar && w.cvar[0]) {
+        ComboAudio::MirrorIfVolumeCVar(w.cvar);
     }
 
     if (disabled) {

--- a/docs/UPSTREAM_MERGES.md
+++ b/docs/UPSTREAM_MERGES.md
@@ -1148,6 +1148,9 @@ MM's identically-named dev windows were dropped (OOT boots first). (c) Dev-tool 
   window's `DrawElement()` inline (skipped when popped out, so no double-draw); live-world viewers
   (Actor/Collision/Message/DL/Event Log) gate on `Combo_MmIsForeground()` so they don't read MM's
   dormant/swapped play state when the MM tab is opened while OOT is foreground.
+- `soh/soh/SohGui/SohMenuDevTools.cpp` + `OTRGlobals.cpp` — the same inline `WIDGET_CUSTOM` treatment for
+  OOT's dev tools, gating live viewers on `Combo_OotIsForeground()`. Both `Combo_*IsForeground` helpers
+  resolve comboui's `ComboUI_GetForegroundGame` once.
 - `mm/2s2h/BenPort.cpp` — exports `MM_ApplyAudioVolume(seqPlayer, vol)` (→ `AudioSeq_SetPortVolumeScale`,
   the apply path MM uses instead of ShipInit) and `MM_ReloadControls()` (reloads MM's ControlDeck ports
   from the shared `gSettings.Controllers.*` CVars); `Combo_MmIsForeground()` queries comboui's
@@ -1162,6 +1165,8 @@ MM's identically-named dev windows were dropped (OOT boots first). (c) Dev-tool 
   existing `ComboUI_OnForegroundGame` callback; expose `ComboUI::GetForegroundGame()` (C++) and
   `ComboUI_GetForegroundGame()` (C ABI, for MM's gating). On MM entry the callback also runs
   `ComboAudio::SyncAllToMM()` + `MM_ReloadControls` so changes made while MM was dormant take effect.
-- `combo/gui/ComboMenu.cpp` — the per-game tab sidebar filter now also hides MM's Graphics/Audio/Controls
-  (they live only in Shared). **On future merges:** if MM's audio CVar names/scale change, update
-  `kMap` in `ComboAudioBridge.cpp`.
+- `combo/gui/ComboMenu.cpp` — the per-game tab sidebar filter now also hides MM's
+  Graphics/Audio/Controls/General (they live only in Shared, on shared CVars). **On future merges:** if
+  MM's audio CVar names/scale change, update `kMap` in `ComboAudioBridge.cpp` (note: the OOT `Volume.*`
+  defaults — Master 40, rest 100 — are duplicated in `kMap`'s `defaultPct` and must match
+  SohMenuSettings.cpp, else an untouched slider reads as 0 and silences MM).

--- a/docs/UPSTREAM_MERGES.md
+++ b/docs/UPSTREAM_MERGES.md
@@ -1128,3 +1128,40 @@ until the next `ShipInit::InitAll` (game boot / new save). New exports `SOH_Menu
 `MM_MenuApplyCVarChange` (OTRGlobals.cpp / BenPort.cpp) run `ShipInit::Init(cvar)`; the comboui menu
 model + `ComboWidgetRender` call them after each change. Fixes #27. **On future merges:** if the
 native UIWidgets stop using `ShipInit::Init`-on-change, revisit.
+
+## Shared-settings consolidation + dev-tool window fixes (issue #22, 2026-06-28)
+
+**Why:** three related issues in the shared menu/window subsystem. (a) #22 — MM ignored the Shared
+tab's Graphics/Audio/Controls and the per-game tabs redundantly exposed them. (b) Opening MM's "Save
+Editor" showed OOT's: the shared `Gui::AddGuiWindow` keys by display name and rejects duplicates, so
+MM's identically-named dev windows were dropped (OOT boots first). (c) Dev-tool windows only offered a
+"popout" button, never rendering inline.
+
+**Vendored (additive, `COMBO_BUILD`-guarded):**
+- `mm/2s2h/BenGui/BenGui.cpp` — the 9 MM dev/debug windows whose names collide with OOT's (Save Editor,
+  Actor/Collision/Message Viewer, Audio Editor, Mod Menu, Hook Debugger, Input Viewer (+Settings)) now
+  register with `COMBO_MM_TRACKER_SUFFIX` (`"##MM"`), same mechanism as the trackers — map-key/ID only,
+  visible title unchanged, empty in standalone. (Cosmetic Editor / Time Splits Window / DL Viewer differ
+  from OOT's strings already, so they don't collide.)
+- `mm/2s2h/BenGui/BenMenu.cpp` — matching `WindowName(...)` popout refs carry the same suffix
+  (`COMBO_MM_WINDOW_SUFFIX`). New `#ifdef COMBO_BUILD` inline `WIDGET_CUSTOM` entries render each dev
+  window's `DrawElement()` inline (skipped when popped out, so no double-draw); live-world viewers
+  (Actor/Collision/Message/DL/Event Log) gate on `Combo_MmIsForeground()` so they don't read MM's
+  dormant/swapped play state when the MM tab is opened while OOT is foreground.
+- `mm/2s2h/BenPort.cpp` — exports `MM_ApplyAudioVolume(seqPlayer, vol)` (→ `AudioSeq_SetPortVolumeScale`,
+  the apply path MM uses instead of ShipInit) and `MM_ReloadControls()` (reloads MM's ControlDeck ports
+  from the shared `gSettings.Controllers.*` CVars); `Combo_MmIsForeground()` queries comboui's
+  foreground game. All inside the existing `COMBO_BUILD` export block.
+
+**Combo-owned:**
+- `combo/gui/ComboAudioBridge.{h,cpp}` — one-way mirror of OOT's canonical `gSettings.Volume.*` (int
+  0-100) into MM's `gSettings.Audio.*` (float 0-1). `MirrorIfVolumeCVar` fires from the
+  `ComboWidgetRender` apply-step; `SyncAllToMM` runs on MM entry. Graphics needs no bridge (one shared
+  window) and Controls' data is already shared CVars.
+- `combo/gui/ComboForeground.h` + `ComboTrackerVisibility.cpp` — cache the foreground game from the
+  existing `ComboUI_OnForegroundGame` callback; expose `ComboUI::GetForegroundGame()` (C++) and
+  `ComboUI_GetForegroundGame()` (C ABI, for MM's gating). On MM entry the callback also runs
+  `ComboAudio::SyncAllToMM()` + `MM_ReloadControls` so changes made while MM was dormant take effect.
+- `combo/gui/ComboMenu.cpp` — the per-game tab sidebar filter now also hides MM's Graphics/Audio/Controls
+  (they live only in Shared). **On future merges:** if MM's audio CVar names/scale change, update
+  `kMap` in `ComboAudioBridge.cpp`.

--- a/mm/2s2h/BenGui/BenGui.cpp
+++ b/mm/2s2h/BenGui/BenGui.cpp
@@ -38,11 +38,13 @@
 
 // ComboShip: in the combo build, OOT (soh) registers identically-named tracker windows FIRST into
 // the single shared libultraship Gui. Gui::AddGuiWindow keys by display name and rejects duplicates,
-// so MM's "Check Tracker"/"Item Tracker"(+Settings) would be silently dropped and never drawn.
-// Suffix MM's window keys with "##MM": ImGui shows only the text before "##", so the visible title
-// stays "Check Tracker", but the map key (and ImGui window ID) is unique and both games coexist.
-// The popout WindowName() references in 2s2h/Rando/Menu.cpp use the same suffix. The active-game
-// gating in combo/gui/ComboTrackerVisibility.cpp ensures the two games' trackers never draw at once.
+// so any MM window whose name matches an OOT one (trackers, plus dev tools like "Save Editor",
+// "Actor Viewer", "Audio Editor", "Mod Menu", "Input Viewer"...) would be silently dropped and never
+// drawn — that is why MM's "Save Editor" used to show OOT's. Suffix MM's window keys with "##MM":
+// ImGui shows only the text before "##", so the visible title stays "Save Editor", but the map key
+// (and ImGui window ID) is unique and both games coexist. The popout WindowName() references in
+// BenMenu.cpp / 2s2h/Rando/Menu.cpp use the same suffix. The active-game gating in
+// combo/gui/ComboTrackerVisibility.cpp ensures the two games' trackers never draw at once.
 // See docs/UPSTREAM_MERGES.md.
 #ifdef COMBO_BUILD
 #define COMBO_MM_TRACKER_SUFFIX "##MM"
@@ -154,11 +156,12 @@ void SetupGuiElements() {
         SPDLOG_ERROR("Could not find input editor window");
     }
 
-    mHookDebuggerWindow =
-        std::make_shared<HookDebuggerWindow>("gWindows.HookDebugger", "Hook Debugger", ImVec2(480, 600));
+    mHookDebuggerWindow = std::make_shared<HookDebuggerWindow>(
+        "gWindows.HookDebugger", "Hook Debugger" COMBO_MM_TRACKER_SUFFIX, ImVec2(480, 600));
     gui->AddGuiWindow(mHookDebuggerWindow);
 
-    mSaveEditorWindow = std::make_shared<SaveEditorWindow>("gWindows.SaveEditor", "Save Editor", ImVec2(480, 600));
+    mSaveEditorWindow = std::make_shared<SaveEditorWindow>("gWindows.SaveEditor", "Save Editor" COMBO_MM_TRACKER_SUFFIX,
+                                                           ImVec2(480, 600));
     gui->AddGuiWindow(mSaveEditorWindow);
 
     mHudEditorWindow = std::make_shared<HudEditorWindow>("gWindows.HudEditor", "HUD Editor", ImVec2(480, 600));
@@ -168,11 +171,12 @@ void SetupGuiElements() {
         std::make_shared<CosmeticEditorWindow>("gWindows.CosmeticEditor", "Cosmetic Editor", ImVec2(480, 600));
     gui->AddGuiWindow(mCosmeticEditorWindow);
 
-    mActorViewerWindow = std::make_shared<ActorViewerWindow>("gWindows.ActorViewer", "Actor Viewer", ImVec2(520, 600));
+    mActorViewerWindow = std::make_shared<ActorViewerWindow>("gWindows.ActorViewer",
+                                                             "Actor Viewer" COMBO_MM_TRACKER_SUFFIX, ImVec2(520, 600));
     gui->AddGuiWindow(mActorViewerWindow);
 
-    mCollisionViewerWindow =
-        std::make_shared<CollisionViewerWindow>("gWindows.CollisionViewer", "Collision Viewer", ImVec2(390, 475));
+    mCollisionViewerWindow = std::make_shared<CollisionViewerWindow>(
+        "gWindows.CollisionViewer", "Collision Viewer" COMBO_MM_TRACKER_SUFFIX, ImVec2(390, 475));
     gui->AddGuiWindow(mCollisionViewerWindow);
 
     mEventLogWindow = std::make_shared<EventLogWindow>("gWindows.EventLog", "Event Log", ImVec2(520, 600));
@@ -180,14 +184,16 @@ void SetupGuiElements() {
 
     mDLViewerWindow = std::make_shared<DLViewerWindow>("gWindows.DLViewer", "DL Viewer", ImVec2(520, 600));
     gui->AddGuiWindow(mDLViewerWindow);
-    mMessageViewerWindow =
-        std::make_shared<MessageViewerWindow>("gWindows.MessageViewer", "Message Viewer", ImVec2(520, 600));
+    mMessageViewerWindow = std::make_shared<MessageViewerWindow>(
+        "gWindows.MessageViewer", "Message Viewer" COMBO_MM_TRACKER_SUFFIX, ImVec2(520, 600));
     gui->AddGuiWindow(mMessageViewerWindow);
 
-    mAudioEditorWindow = std::make_shared<AudioEditor>("gWindows.AudioEditor", "Audio Editor", ImVec2(520, 600));
+    mAudioEditorWindow =
+        std::make_shared<AudioEditor>("gWindows.AudioEditor", "Audio Editor" COMBO_MM_TRACKER_SUFFIX, ImVec2(520, 600));
     gui->AddGuiWindow(mAudioEditorWindow);
 
-    mModMenuWindow = std::make_shared<ModMenuWindow>("gWindows.ModMenu", "Mod Menu", ImVec2(820, 630));
+    mModMenuWindow =
+        std::make_shared<ModMenuWindow>("gWindows.ModMenu", "Mod Menu" COMBO_MM_TRACKER_SUFFIX, ImVec2(820, 630));
     gui->AddGuiWindow(mModMenuWindow);
 
     mItemTrackerWindow =
@@ -225,10 +231,10 @@ void SetupGuiElements() {
         "gWindows.CheckTrackerSettings", "Check Tracker Settings" COMBO_MM_TRACKER_SUFFIX);
     gui->AddGuiWindow(mRandoCheckTrackerSettingsWindow);
 
-    mInputViewer = std::make_shared<InputViewer>("gWindows.InputViewer", "Input Viewer");
+    mInputViewer = std::make_shared<InputViewer>("gWindows.InputViewer", "Input Viewer" COMBO_MM_TRACKER_SUFFIX);
     gui->AddGuiWindow(mInputViewer);
-    mInputViewerSettings = std::make_shared<InputViewerSettingsWindow>("gWindows.InputViewerSettings",
-                                                                       "Input Viewer Settings", ImVec2(500, 525));
+    mInputViewerSettings = std::make_shared<InputViewerSettingsWindow>(
+        "gWindows.InputViewerSettings", "Input Viewer Settings" COMBO_MM_TRACKER_SUFFIX, ImVec2(500, 525));
     gui->AddGuiWindow(mInputViewerSettings);
 }
 

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -23,6 +23,45 @@
 #include "2s2h/Rando/Rando.h"
 #include "build.h"
 
+// ComboShip: MM dev-tool / viewer windows share names with OOT's in the single shared Gui registry,
+// which keys by display name and rejects duplicates. BenGui.cpp registers the MM windows with this
+// "##MM" suffix so they are not dropped; the popout WindowName() references below must use the same
+// suffix to resolve the MM window (not OOT's). Standalone build => empty suffix (unchanged).
+#ifdef COMBO_BUILD
+#define COMBO_MM_WINDOW_SUFFIX "##MM"
+#else
+#define COMBO_MM_WINDOW_SUFFIX ""
+#endif
+
+#ifdef COMBO_BUILD
+bool Combo_MmIsForeground(void); // defined in BenPort.cpp
+
+// ComboShip: draw a dev/debug tool window inline inside the combo menu panel. Without this the menu only
+// offers a "popout" button, so the user has to detach every window just to see it. Skips drawing when
+// the window is shown as a popout (the shared Gui loop already draws that floating copy) or is not yet
+// registered. Live-world viewers (Actor/Collision/Message/DL/Event Log) pass requiresForeground=true so
+// they do not read MM's dormant/swapped play state when MM's tab is opened while OOT is foreground.
+static void ComboInlineWindow(const char* windowName, bool requiresForeground) {
+    if (requiresForeground && !Combo_MmIsForeground()) {
+        ImGui::TextDisabled("Available while 2 Ship 2 Harkinian is running.");
+        return;
+    }
+    auto ctx = Ship::Context::GetInstance();
+    if (!ctx || !ctx->GetWindow() || !ctx->GetWindow()->GetGui()) {
+        return;
+    }
+    auto win = ctx->GetWindow()->GetGui()->GetGuiWindow(windowName);
+    if (!win || win->IsVisible()) { // not registered, or already shown as a popout — don't double-draw
+        return;
+    }
+    // The Gui loop only runs Update()+Draw() on visible windows; since we draw this one inline while it
+    // is hidden, run Update() ourselves first so DrawElement sees the same per-frame state it normally
+    // would. Runs exactly once per frame (we returned above when the window is visible/popped out).
+    win->Update();
+    win->DrawElement();
+}
+#endif
+
 extern "C" {
 #include "z64.h"
 #include "functions.h"
@@ -706,13 +745,13 @@ void BenMenu::AddSettings() {
     AddWidget(path, "Input Viewer", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Toggle Input Viewer", WIDGET_WINDOW_BUTTON)
         .CVar("gWindows.InputViewer")
-        .WindowName("Input Viewer")
+        .WindowName("Input Viewer" COMBO_MM_WINDOW_SUFFIX)
         .Options(ButtonOptions().Tooltip("Toggles the Input Viewer."));
 
     AddWidget(path, "Input Viewer Settings", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Popout Input Viewer Settings", WIDGET_WINDOW_BUTTON)
         .CVar("gWindows.InputViewerSettings")
-        .WindowName("Input Viewer Settings")
+        .WindowName("Input Viewer Settings" COMBO_MM_WINDOW_SUFFIX)
         .Options(ButtonOptions().Tooltip("Enables the separate Input Viewer Settings Window."));
 
     // Mod Menu
@@ -722,9 +761,14 @@ void BenMenu::AddSettings() {
     AddWidget(path, "Mod Menu", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Popout Mod Menu Window", WIDGET_WINDOW_BUTTON)
         .CVar("gWindows.ModMenu")
-        .WindowName("Mod Menu")
+        .WindowName("Mod Menu" COMBO_MM_WINDOW_SUFFIX)
         .HideInSearch(true)
         .Options(ButtonOptions().Tooltip("Enables the separate Mod Menu Window."));
+#ifdef COMBO_BUILD
+    AddWidget(path, "Mod Menu Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Mod Menu" COMBO_MM_WINDOW_SUFFIX, /*requiresForeground=*/false);
+    });
+#endif
 }
 int32_t motionBlurStrength;
 
@@ -1928,6 +1972,11 @@ void BenMenu::AddEnhancements() {
         .Options(ButtonOptions()
                      .Tooltip("Enables the HUD Editor window, allowing you to modify your HUD.")
                      .Size(Sizes::Inline));
+#ifdef COMBO_BUILD
+    AddWidget(path, "HUD Editor Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("HUD Editor", /*requiresForeground=*/false);
+    });
+#endif
 
     // Cosmetics Editor
     path = { "Enhancements", "Cosmetic Editor", SECTION_COLUMN_1 };
@@ -1938,6 +1987,11 @@ void BenMenu::AddEnhancements() {
         .Options(ButtonOptions()
                      .Tooltip("Enables the Cosmetic Editor window, allowing you to modify various colors in the game.")
                      .Size(Sizes::Inline));
+#ifdef COMBO_BUILD
+    AddWidget(path, "Cosmetic Editor Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Cosmetic Editor", /*requiresForeground=*/false);
+    });
+#endif
 
     // Timesplit Settings
     path = { "Enhancements", "Time Splits", SECTION_COLUMN_1 };
@@ -1951,7 +2005,12 @@ void BenMenu::AddEnhancements() {
     AddSidebarEntry("Enhancements", "Audio Editor", 1);
     AddWidget(path, "Popout Audio Editor", WIDGET_WINDOW_BUTTON)
         .CVar("gWindows.AudioEditor")
-        .WindowName("Audio Editor");
+        .WindowName("Audio Editor" COMBO_MM_WINDOW_SUFFIX);
+#ifdef COMBO_BUILD
+    AddWidget(path, "Audio Editor Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Audio Editor" COMBO_MM_WINDOW_SUFFIX, /*requiresForeground=*/false);
+    });
+#endif
 }
 
 void BenMenu::AddDevTools() {
@@ -2060,7 +2119,12 @@ void BenMenu::AddDevTools() {
     AddWidget(path, "Popout Collision Viewer", WIDGET_WINDOW_BUTTON)
         .CVar("gWindows.CollisionViewer")
         .Options(ButtonOptions().Tooltip("Makes collision visible on screen.").Size(Sizes::Inline))
-        .WindowName("Collision Viewer");
+        .WindowName("Collision Viewer" COMBO_MM_WINDOW_SUFFIX);
+#ifdef COMBO_BUILD
+    AddWidget(path, "Collision Viewer Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Collision Viewer" COMBO_MM_WINDOW_SUFFIX, /*requiresForeground=*/true);
+    });
+#endif
 
     path = { "Dev Tools", "Stats", SECTION_COLUMN_1 };
     AddSidebarEntry("Dev Tools", "Stats", 1);
@@ -2091,21 +2155,36 @@ void BenMenu::AddDevTools() {
     AddWidget(path, "Popout Hook Debugger", WIDGET_WINDOW_BUTTON)
         .CVar("gWindows.HookDebugger")
         .Options(ButtonOptions().Tooltip("Enables the Hook Debugger window, for viewing info about registered hooks."))
-        .WindowName("Hook Debugger");
+        .WindowName("Hook Debugger" COMBO_MM_WINDOW_SUFFIX);
+#ifdef COMBO_BUILD
+    AddWidget(path, "Hook Debugger Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Hook Debugger" COMBO_MM_WINDOW_SUFFIX, /*requiresForeground=*/false);
+    });
+#endif
 
     path = { "Dev Tools", "Save Editor", SECTION_COLUMN_1 };
     AddSidebarEntry("Dev Tools", "Save Editor", 1);
     AddWidget(path, "Popout Save Editor", WIDGET_WINDOW_BUTTON)
         .CVar("gWindows.SaveEditor")
         .Options(ButtonOptions().Tooltip("Enables the Save Editor window, allowing you to edit your save file."))
-        .WindowName("Save Editor");
+        .WindowName("Save Editor" COMBO_MM_WINDOW_SUFFIX);
+#ifdef COMBO_BUILD
+    AddWidget(path, "Save Editor Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Save Editor" COMBO_MM_WINDOW_SUFFIX, /*requiresForeground=*/false);
+    });
+#endif
 
     path = { "Dev Tools", "Actor Viewer", SECTION_COLUMN_1 };
     AddSidebarEntry("Dev Tools", "Actor Viewer", 1);
     AddWidget(path, "Popout Actor Viewer", WIDGET_WINDOW_BUTTON)
         .CVar("gWindows.ActorViewer")
         .Options(ButtonOptions().Tooltip("Enables the Actor Viewer window, allowing you to view actors in the world."))
-        .WindowName("Actor Viewer");
+        .WindowName("Actor Viewer" COMBO_MM_WINDOW_SUFFIX);
+#ifdef COMBO_BUILD
+    AddWidget(path, "Actor Viewer Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Actor Viewer" COMBO_MM_WINDOW_SUFFIX, /*requiresForeground=*/true);
+    });
+#endif
 
     path = { "Dev Tools", "Event Log", SECTION_COLUMN_1 };
     AddSidebarEntry("Dev Tools", "Event Log", 1);
@@ -2113,6 +2192,11 @@ void BenMenu::AddDevTools() {
         .CVar("gWindows.EventLog")
         .Options(ButtonOptions().Tooltip("Enables the Event Log window."))
         .WindowName("Event Log");
+#ifdef COMBO_BUILD
+    AddWidget(path, "Event Log Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Event Log", /*requiresForeground=*/true);
+    });
+#endif
 
     path = { "Dev Tools", "DL Viewer", SECTION_COLUMN_1 };
     AddSidebarEntry("Dev Tools", "DL Viewer", 1);
@@ -2120,12 +2204,22 @@ void BenMenu::AddDevTools() {
         .CVar("gWindows.DLViewer")
         .Options(ButtonOptions().Tooltip("Enables the DL Viewer window for inspecting and editing display lists."))
         .WindowName("DL Viewer");
+#ifdef COMBO_BUILD
+    AddWidget(path, "DL Viewer Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("DL Viewer", /*requiresForeground=*/true);
+    });
+#endif
     path = { "Dev Tools", "Message Viewer", SECTION_COLUMN_1 };
     AddSidebarEntry("Dev Tools", "Message Viewer", 1);
     AddWidget(path, "Popout Message Viewer", WIDGET_WINDOW_BUTTON)
         .CVar("gWindows.MessageViewer")
         .Options(ButtonOptions().Tooltip("Enables the Message Viewer window for testing in-game messages."))
-        .WindowName("Message Viewer");
+        .WindowName("Message Viewer" COMBO_MM_WINDOW_SUFFIX);
+#ifdef COMBO_BUILD
+    AddWidget(path, "Message Viewer Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Message Viewer" COMBO_MM_WINDOW_SUFFIX, /*requiresForeground=*/true);
+    });
+#endif
 }
 
 BenMenu::BenMenu(const std::string& consoleVariable, const std::string& name)

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -3608,6 +3608,44 @@ extern "C" __declspec(dllexport) void MM_MenuApplyCVarChange(const char* cvar) {
         ShipInit::Init(cvar);
 }
 
+// ComboShip: combo-owned audio bridge entry point (combo/gui/ComboAudioBridge.cpp). The Shared tab's
+// audio sliders are OOT's (gSettings.Volume.* int 0-100); the combo layer mirrors them into MM's float
+// CVars and calls this to apply per-port volume live. MM applies volume via AudioSeq_SetPortVolumeScale
+// (not ShipInit), so MM_MenuApplyCVarChange would not pick it up. gAudioCtx persists across transitions,
+// so this is safe even when MM is not the foreground game.
+extern "C" __declspec(dllexport) void MM_ApplyAudioVolume(int32_t seqPlayerIndex, float volume) {
+    AudioSeq_SetPortVolumeScale((u8)seqPlayerIndex, volume);
+}
+
+// ComboShip: controller bindings live in the shared gSettings.Controllers.* CVars, so the Shared tab's
+// (OOT) controls UI edits the same data MM reads. But each game's ControlDeck caches its mappings (it
+// only re-reads on Init / this call), so a rebind made while MM was dormant is not picked up until MM
+// reloads. The combo layer calls this when MM becomes the foreground game. Reloads all populated ports.
+extern "C" __declspec(dllexport) void MM_ReloadControls(void) {
+    auto controlDeck = Ship::Context::GetInstance()->GetControlDeck();
+    if (!controlDeck)
+        return;
+    for (uint8_t port = 0; port < 4; ++port) {
+        if (auto controller = controlDeck->GetControllerByPort(port))
+            controller->ReloadAllMappingsFromConfig();
+    }
+}
+
+// ComboShip: true when MM is the foreground game (queries comboui's ComboUI_GetForegroundGame, resolved
+// once). BenMenu uses it to gate MM's live-world dev viewers — opening MM's tab while OOT is foreground
+// must not draw against MM's dormant/swapped play state. comboui is always loaded under ComboShip; if it
+// somehow isn't, default to true (draw) rather than hiding the tools.
+bool Combo_MmIsForeground(void) {
+    static int (*sFn)(void) = nullptr;
+    static bool sTried = false;
+    if (!sTried) {
+        sTried = true;
+        if (HMODULE h = GetModuleHandleA("comboui.dll"))
+            sFn = (int (*)(void))GetProcAddress(h, "ComboUI_GetForegroundGame");
+    }
+    return sFn ? (sFn() == 1) : true;
+}
+
 extern "C" __declspec(dllexport) int32_t MM_MenuEvalDisabled(int32_t i, const char** outReason) {
     ComboMenuContext::UseSharedImGuiContext();
     auto menu = Combo_EnsureBenMenu();

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -2817,6 +2817,23 @@ extern "C" __declspec(dllexport) void SOH_MenuApplyCVarChange(const char* cvar) 
         ShipInit::Init(cvar);
 }
 
+#ifdef COMBO_BUILD
+// ComboShip: true when OOT is the foreground game (queries comboui's ComboUI_GetForegroundGame, resolved
+// once). SohMenuDevTools uses it to gate OOT's live-world dev viewers — opening OOT's tab while MM is
+// foreground must not draw against OOT's dormant/swapped play state. comboui is always loaded under
+// ComboShip; if it somehow isn't, default to true (draw) rather than hiding the tools.
+bool Combo_OotIsForeground(void) {
+    static int (*sFn)(void) = nullptr;
+    static bool sTried = false;
+    if (!sTried) {
+        sTried = true;
+        if (HMODULE h = GetModuleHandleA("comboui.dll"))
+            sFn = (int (*)(void))GetProcAddress(h, "ComboUI_GetForegroundGame");
+    }
+    return sFn ? (sFn() == 0) : true;
+}
+#endif
+
 extern "C" __declspec(dllexport) int32_t SOH_MenuEvalDisabled(int32_t i, const char** outReason) {
     ComboMenuContext::UseSharedImGuiContext();
     auto menu = SohGui::GetSohMenu();

--- a/soh/soh/SohGui/SohMenuDevTools.cpp
+++ b/soh/soh/SohGui/SohMenuDevTools.cpp
@@ -7,10 +7,42 @@ extern PlayState* gPlayState;
 
 void WarpPointsWidget(WidgetInfo& info);
 
+#ifdef COMBO_BUILD
+bool Combo_OotIsForeground(void); // defined in OTRGlobals.cpp
+#endif
+
 namespace SohGui {
 
 extern std::shared_ptr<SohMenu> mSohMenu;
 using namespace UIWidgets;
+
+#ifdef COMBO_BUILD
+// ComboShip: draw a dev/debug tool window inline inside the combo menu panel. Without this the menu only
+// offers a "popout" button, so the user has to detach every window just to see it (mirrors the MM side
+// in BenMenu.cpp). Skips drawing when the window is shown as a popout (the shared Gui loop already draws
+// that floating copy) or is not yet registered. Live-world viewers (Actor/Collision/DList/Value/Message)
+// pass requiresForeground=true so they do not read OOT's dormant/swapped play state when OOT's tab is
+// opened while MM is foreground.
+static void ComboInlineWindow(const char* windowName, bool requiresForeground) {
+    if (requiresForeground && !Combo_OotIsForeground()) {
+        ImGui::TextDisabled("Available while Ship of Harkinian is running.");
+        return;
+    }
+    auto ctx = Ship::Context::GetInstance();
+    if (!ctx || !ctx->GetWindow() || !ctx->GetWindow()->GetGui()) {
+        return;
+    }
+    auto win = ctx->GetWindow()->GetGui()->GetGuiWindow(windowName);
+    if (!win || win->IsVisible()) { // not registered, or already shown as a popout — don't double-draw
+        return;
+    }
+    // The Gui loop only runs Update()+Draw() on visible windows; since we draw this one inline while it is
+    // hidden, run Update() ourselves first so DrawElement sees its normal per-frame state. Runs once per
+    // frame (we returned above when the window is visible/popped out).
+    win->Update();
+    win->DrawElement();
+}
+#endif
 
 static const std::map<int32_t, const char*> logLevels = {
     { DEBUG_LOG_TRACE, "Trace" }, { DEBUG_LOG_DEBUG, "Debug" }, { DEBUG_LOG_INFO, "Info" },
@@ -165,6 +197,11 @@ void SohMenu::AddMenuDevTools() {
         .WindowName("Save Editor")
         .HideInSearch(true)
         .Options(WindowButtonOptions().Tooltip("Enables the separate Save Editor Window."));
+#ifdef COMBO_BUILD
+    AddWidget(path, "Save Editor Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Save Editor", /*requiresForeground=*/false);
+    });
+#endif
 
     // Hook Debugger
     path.sidebarName = "Hook Debugger";
@@ -174,6 +211,11 @@ void SohMenu::AddMenuDevTools() {
         .WindowName("Hook Debugger")
         .HideInSearch(true)
         .Options(WindowButtonOptions().Tooltip("Enables the separate Hook Debugger Window."));
+#ifdef COMBO_BUILD
+    AddWidget(path, "Hook Debugger Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Hook Debugger", /*requiresForeground=*/false);
+    });
+#endif
 
     // Collision Viewer
     path.sidebarName = "Collision Viewer";
@@ -183,6 +225,11 @@ void SohMenu::AddMenuDevTools() {
         .WindowName("Collision Viewer")
         .HideInSearch(true)
         .Options(WindowButtonOptions().Tooltip("Enables the separate Collision Viewer Window."));
+#ifdef COMBO_BUILD
+    AddWidget(path, "Collision Viewer Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Collision Viewer", /*requiresForeground=*/true);
+    });
+#endif
 
     // Actor Viewer
     path.sidebarName = "Actor Viewer";
@@ -192,6 +239,11 @@ void SohMenu::AddMenuDevTools() {
         .WindowName("Actor Viewer")
         .HideInSearch(true)
         .Options(WindowButtonOptions().Tooltip("Enables the separate Actor Viewer Window."));
+#ifdef COMBO_BUILD
+    AddWidget(path, "Actor Viewer Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Actor Viewer", /*requiresForeground=*/true);
+    });
+#endif
 
     // Display List Viewer
     path.sidebarName = "DList Viewer";
@@ -201,6 +253,11 @@ void SohMenu::AddMenuDevTools() {
         .WindowName("Display List Viewer")
         .HideInSearch(true)
         .Options(WindowButtonOptions().Tooltip("Enables the separate Display List Viewer Window."));
+#ifdef COMBO_BUILD
+    AddWidget(path, "Display List Viewer Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Display List Viewer", /*requiresForeground=*/true);
+    });
+#endif
 
     // Value Viewer
     path.sidebarName = "Value Viewer";
@@ -210,6 +267,11 @@ void SohMenu::AddMenuDevTools() {
         .WindowName("Value Viewer")
         .HideInSearch(true)
         .Options(WindowButtonOptions().Tooltip("Enables the separate Value Viewer Window."));
+#ifdef COMBO_BUILD
+    AddWidget(path, "Value Viewer Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Value Viewer", /*requiresForeground=*/true);
+    });
+#endif
 
     // Message Viewer
     path.sidebarName = "Message Viewer";
@@ -219,6 +281,11 @@ void SohMenu::AddMenuDevTools() {
         .WindowName("Message Viewer")
         .HideInSearch(true)
         .Options(WindowButtonOptions().Tooltip("Enables the separate Message Viewer Window."));
+#ifdef COMBO_BUILD
+    AddWidget(path, "Message Viewer Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Message Viewer", /*requiresForeground=*/true);
+    });
+#endif
 
     // Gfx Debugger
     path.sidebarName = "Gfx Debugger";


### PR DESCRIPTION
Resolves #22 and two related menu/window bugs.

## Settings consolidation (#22)
- **Audio**: new combo-owned `ComboAudioBridge` mirrors the Shared tab's `gSettings.Volume.*` (OOT, int 0-100) into MM's `gSettings.Audio.*` (float 0-1), applied live when MM is active and re-synced on MM entry (new `MM_ApplyAudioVolume` export). Uses OOT's real defaults so untouched sliders don't silence MM.
- **Controls**: `MM_ReloadControls` reloads MM's ControlDeck from the already-shared `gSettings.Controllers.*` on MM entry.
- **Graphics**: already cross-applies via the single shared window — no bridge.
- MM's per-game tab no longer exposes Graphics/Audio/Controls/General (they live only in Shared).

## Dev-tool window fixes
- **Name collisions**: MM's 9 dev/debug windows that share a name with OOT's now register with a `##MM` suffix in the shared Gui (which rejects duplicate names) — fixes MM's "Save Editor" showing OOT's.
- **Inline rendering**: dev-tool windows now render inline in the menu (popout still works) for both MM and OOT; live-world viewers are gated to the foreground game to avoid reading dormant play state.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/7937021758.zip)
<!--- section:artifacts:end -->