### PR TITLE
Fix OOT extraction + add settings import (#24)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ logs
 *.nix
 2ship2harkinian.json
 shipofharkinian.json
+comboship.json
 *.sav
 .envrc
 imgui.ini

--- a/combo/CMakeLists.txt
+++ b/combo/CMakeLists.txt
@@ -31,6 +31,7 @@ set(COMBOUI_SOURCES
     gui/ComboWidgetStyle.cpp
     gui/ComboExtractScreen.cpp
     gui/ComboTrackerVisibility.cpp
+    gui/ComboAudioBridge.cpp
 )
 add_library(comboui SHARED ${COMBOUI_SOURCES})
 set_target_properties(comboui PROPERTIES PREFIX "")

--- a/combo/CMakeLists.txt
+++ b/combo/CMakeLists.txt
@@ -30,6 +30,7 @@ set(COMBOUI_SOURCES
     gui/ComboWidgetRender.cpp
     gui/ComboWidgetStyle.cpp
     gui/ComboExtractScreen.cpp
+    gui/ComboSettingsImportScreen.cpp
     gui/ComboTrackerVisibility.cpp
     gui/ComboAudioBridge.cpp
 )

--- a/combo/CMakeLists.txt
+++ b/combo/CMakeLists.txt
@@ -102,6 +102,14 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_SOURCE_DIR}/x64/Release"
     )
 
+    # Release: no console window (kept in Debug for logs). Same /SUBSYSTEM:WINDOWS soh uses; soh relies
+    # on SDL2main for WinMain, but ComboShip has its own main() (see above), so /ENTRY:mainCRTStartup
+    # keeps it. Errors still persist to *_extract_error.log.
+    if(MSVC)
+        target_link_options(ComboShip PRIVATE
+            $<$<CONFIG:Release>:/SUBSYSTEM:WINDOWS;/ENTRY:mainCRTStartup>)
+    endif()
+
     # The exe and all game DLLs already land in x64/<config> (their own output dirs), so only the asset
     # tree and the PORT/custom .o2r archives need deploying. $<TARGET_FILE_DIR:ComboShip> == x64/<config>,
     # so this is config-correct for Debug AND Release.

--- a/combo/ComboSettingsImport.h
+++ b/combo/ComboSettingsImport.h
@@ -1,0 +1,33 @@
+// combo/ComboSettingsImport.h
+// ComboShip: ABI for the first-launch settings-import screen (issue 24; mirrors ComboExtract.h).
+// comboui renders the screen + returns chosen paths; the launcher merges (SoH wins) and applies via
+// soh's SOH_ApplyImportedConfig. Pure C ABI — no STL across the boundary; fixed-size path buffers.
+#pragma once
+
+extern "C" {
+
+// Optional soft validator: returns nonzero if the file looks like the expected game's config. Used
+// only to show a hint in the screen, never to block import. May be null.
+typedef int (*ComboFnValidateConfig)(const char* path);
+
+typedef struct ComboSettingsImportCallbacks {
+    ComboFnValidateConfig sohValidate;
+    ComboFnValidateConfig mmValidate;
+} ComboSettingsImportCallbacks;
+
+// Filled by the screen. Paths are "" when that slot was left empty.
+typedef struct ComboSettingsImportResult {
+    int action;        // 0 = Skip, 1 = Import
+    char sohPath[1024];
+    char mmPath[1024];
+} ComboSettingsImportResult;
+
+// Implemented in comboui.dll. Renders the screen and blocks until Import or Skip. Returns 1 if the
+// user made a decision (action valid), 0 if the window was closed (launcher treats as Skip).
+typedef int (*ComboFnRunSettingsImport)(const ComboSettingsImportCallbacks* cb, ComboSettingsImportResult* out);
+
+// Implemented in soh.dll. Applies a merged config (JSON object, UTF-8) to the live Ship::Config and
+// reloads CVars + controller mappings. Caller excludes the Window block. Returns nonzero on success.
+typedef int (*ComboFnApplyImportedConfig)(const char* mergedJsonUtf8);
+
+} // extern "C"

--- a/combo/ComboSettingsImport.h
+++ b/combo/ComboSettingsImport.h
@@ -17,7 +17,7 @@ typedef struct ComboSettingsImportCallbacks {
 
 // Filled by the screen. Paths are "" when that slot was left empty.
 typedef struct ComboSettingsImportResult {
-    int action;        // 0 = Skip, 1 = Import
+    int action; // 0 = Skip, 1 = Import
     char sohPath[1024];
     char mmPath[1024];
 } ComboSettingsImportResult;

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -35,6 +35,7 @@
 #include "rando/CrossWorldRando.h"
 #include "gui/ComboGenProgress.h"
 #include "ComboExtract.h"
+#include "ComboSettingsImport.h"
 
 // Surfaces the real exception behind a silent terminate()/exit(3). With the shared dynamic
 // CRT, exceptions thrown in soh.dll/2ship.dll propagate across the DLL boundary to here.
@@ -234,6 +235,11 @@ static ComboFnValidateRom MM_ValidateRom = nullptr;
 static ComboFnStartExtraction MM_StartExtraction = nullptr;
 static ComboFnGetProgress MM_GetExtractionProgress = nullptr;
 static ComboFnRunExtraction ComboUI_RunExtraction = nullptr;
+
+// ComboShip-owned first-launch settings import (see ComboSettingsImport.h). comboui renders the
+// screen; soh applies the launcher-merged config to the live Config.
+static ComboFnRunSettingsImport ComboUI_RunSettingsImport = nullptr;
+static ComboFnApplyImportedConfig SOH_ApplyImportedConfig = nullptr;
 
 // ComboShip: per-game reachability oracle exports
 typedef void (*FnOracleVoid)(void);
@@ -1275,6 +1281,55 @@ static bool MMArchivesExist() {
     return MMRomArchiveExists() || std::filesystem::exists("2ship.o2r");
 }
 
+// ComboShip (issue 24): the combined config. Absent => fresh install => offer settings import.
+static bool ComboConfigExists() {
+    return std::filesystem::exists("comboship.json");
+}
+
+// Parse a JSON object from disk. False on missing/parse-failure/non-object (slot then skipped).
+static bool LoadJsonObject(const std::string& path, nlohmann::json& out) {
+    if (path.empty()) {
+        return false;
+    }
+    try {
+        std::ifstream f(path);
+        if (!f) {
+            return false;
+        }
+        nlohmann::json j = nlohmann::json::parse(f);
+        if (!j.is_object()) {
+            return false;
+        }
+        out = std::move(j);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+// Per-leaf merge: objects recurse; on a leaf collision (scalar/array) the overlay wins. Keys unique
+// to either side are kept. Used with 2Ship as base + SoH as overlay so SoH wins.
+static void DeepMerge(nlohmann::json& base, const nlohmann::json& overlay) {
+    if (!base.is_object() || !overlay.is_object()) {
+        base = overlay;
+        return;
+    }
+    for (auto it = overlay.begin(); it != overlay.end(); ++it) {
+        auto found = base.find(it.key());
+        if (found != base.end() && found->is_object() && it->is_object()) {
+            DeepMerge(*found, *it);
+        } else {
+            base[it.key()] = it.value();
+        }
+    }
+}
+
+// Soft validator (non-blocking hint): a Ship config is a JSON object with a CVars block.
+static int LauncherValidateShipConfig(const char* path) {
+    nlohmann::json j;
+    return (path && LoadJsonObject(path, j) && j.contains("CVars")) ? 1 : 0;
+}
+
 // ---------- Entry point ----------
 
 int main(int argc, char** argv) {
@@ -1368,6 +1423,7 @@ int main(int argc, char** argv) {
     MM_ValidateRom = (ComboFnValidateRom)GetSym(mmModule, "MM_ValidateRom");
     MM_StartExtraction = (ComboFnStartExtraction)GetSym(mmModule, "MM_StartExtraction");
     MM_GetExtractionProgress = (ComboFnGetProgress)GetSym(mmModule, "MM_GetExtractionProgress");
+    SOH_ApplyImportedConfig = (ComboFnApplyImportedConfig)GetSym(sohModule, "SOH_ApplyImportedConfig");
 
     // Anchor transport seam exports (Phase 1)
     SOH_SetAnchorSend = (FnSetAnchorSend)GetSym(sohModule, "SOH_SetAnchorSend");
@@ -1423,6 +1479,9 @@ int main(int argc, char** argv) {
     // It returns false if the player quits or extraction fails -> we exit. When the archives are
     // present we skip this entirely and use the monolithic SOH_Init() fast path below.
     bool windowInitialized = false;
+    // Capture BEFORE any window/config init: a fresh install (no comboship.json) gets the settings
+    // import offer. (The Config ctor doesn't create the file, but capturing early stays robust.)
+    const bool freshInstall = !ComboConfigExists();
     const bool needOot = !OOTArchivesExist();
     const bool needMm = !MMRomArchiveExists();
     if (needOot || needMm) {
@@ -1481,6 +1540,51 @@ int main(int argc, char** argv) {
             return 1;
         }
         std::cout << "[ComboShip] Extraction complete." << std::endl;
+    }
+
+    // --- 3b. First-launch settings import (ComboShip-owned, issue 24) ---
+    // Fresh install: offer to import an existing SoH/2Ship config (after extraction, ROMs first). The
+    // window/config exist only post-SOH_InitWindowOnly, so we merge here (SoH wins) and apply to the
+    // LIVE config before SOH_FinishInit's version updates. Optional — any missing piece skips it.
+    if (freshInstall) {
+        if (!windowInitialized && SOH_InitWindowOnly) {
+            SOH_InitWindowOnly();
+            windowInitialized = true;
+        }
+        if (!comboUIModule) {
+            comboUIModule = LoadDll("comboui.dll");
+        }
+        if (comboUIModule && !ComboUI_RunSettingsImport) {
+            ComboUI_RunSettingsImport = (ComboFnRunSettingsImport)GetSym(comboUIModule, "ComboUI_RunSettingsImport");
+        }
+        if (windowInitialized && ComboUI_RunSettingsImport && SOH_ApplyImportedConfig) {
+            ComboSettingsImportCallbacks cb = {};
+            cb.sohValidate = LauncherValidateShipConfig;
+            cb.mmValidate = LauncherValidateShipConfig;
+            ComboSettingsImportResult res = {};
+            if (ComboUI_RunSettingsImport(&cb, &res) && res.action == 1) {
+                nlohmann::json merged = nlohmann::json::object(), sohJson, mmJson;
+                const bool haveMm = LoadJsonObject(res.mmPath, mmJson);
+                const bool haveSoh = LoadJsonObject(res.sohPath, sohJson);
+                if (haveMm) {
+                    merged = mmJson; // 2Ship is the base (lower priority)
+                }
+                if (haveSoh) {
+                    DeepMerge(merged, sohJson); // SoH overlays and wins on collisions
+                }
+                if (haveSoh || haveMm) {
+                    merged.erase("Window"); // machine-specific
+                    // ConfigVersion drives OOT's updaters; keep it only when it actually came from the
+                    // SoH source (a 2Ship version, or none, would misdirect them).
+                    if (!haveSoh || !sohJson.contains("ConfigVersion")) {
+                        merged.erase("ConfigVersion");
+                    }
+                    SOH_ApplyImportedConfig(merged.dump().c_str());
+                    std::cout << "[ComboShip] Settings imported (SoH=" << haveSoh << " MM=" << haveMm << ")."
+                              << std::endl;
+                }
+            }
+        }
     }
 
     // Wire the Anchor transport to the launcher-owned connection BEFORE SOH_Init(): OOT auto-enables

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -1302,9 +1302,7 @@ static bool LoadJsonObject(const std::string& path, nlohmann::json& out) {
         }
         out = std::move(j);
         return true;
-    } catch (...) {
-        return false;
-    }
+    } catch (...) { return false; }
 }
 
 // Per-leaf merge: objects recurse; on a leaf collision (scalar/array) the overlay wins. Keys unique

--- a/combo/gui/ComboAudioBridge.cpp
+++ b/combo/gui/ComboAudioBridge.cpp
@@ -1,0 +1,80 @@
+// combo/gui/ComboAudioBridge.cpp — see ComboAudioBridge.h for rationale.
+#include "ComboAudioBridge.h"
+#include "ComboForeground.h"           // ComboUI::IsMmActive
+#include <libultraship/libultraship.h> // CVarGetInteger / CVarSetFloat
+#ifdef _WIN32
+#include <windows.h>
+#endif
+#include <cstring>
+
+namespace {
+
+// OOT Volume.* (int 0-100, canonical) -> MM Audio.* (float 0-1, derived). seqPlayer is MM's
+// SEQ_PLAYER index for the per-port apply call; -1 = master (read live by MM each note-init, so
+// setting the CVar is enough — no apply call). Indices match both games' SEQ_PLAYER_* enums.
+struct VolMap {
+    const char* ootCVar;
+    const char* mmCVar;
+    int seqPlayer;
+};
+const VolMap kMap[] = {
+    { "gSettings.Volume.Master", "gSettings.Audio.MasterVolume", -1 },
+    { "gSettings.Volume.MainMusic", "gSettings.Audio.MainMusicVolume", 0 },     // SEQ_PLAYER_BGM_MAIN
+    { "gSettings.Volume.SubMusic", "gSettings.Audio.SubMusicVolume", 3 },       // SEQ_PLAYER_BGM_SUB
+    { "gSettings.Volume.SFX", "gSettings.Audio.SoundEffectsVolume", 2 },        // SEQ_PLAYER_SFX
+    { "gSettings.Volume.Fanfare", "gSettings.Audio.FanfareVolume", 1 },         // SEQ_PLAYER_FANFARE
+};
+
+// Resolved once from 2ship.dll. MM applies per-port volume via AudioSeq_SetPortVolumeScale, exposed
+// as MM_ApplyAudioVolume (BenPort.cpp, COMBO_BUILD). Safe to call even when MM is dormant — gAudioCtx
+// persists across transitions — but we only call it when warranted (see MirrorRow).
+typedef void (*Fn_ApplyAudioVolume)(int seqPlayer, float volume);
+Fn_ApplyAudioVolume ResolveApply() {
+    static Fn_ApplyAudioVolume sFn = nullptr;
+    static bool sTried = false;
+#ifdef _WIN32
+    if (!sTried) {
+        sTried = true;
+        if (HMODULE h = GetModuleHandleA("2ship.dll")) {
+            sFn = (Fn_ApplyAudioVolume)GetProcAddress(h, "MM_ApplyAudioVolume");
+        }
+    }
+#endif
+    return sFn;
+}
+
+// Mirror one row. `forceApply` pushes the per-port scale regardless of the active game (used by the
+// boot/resume sync, where MM's audio is about to play); otherwise the apply only fires when MM is the
+// foreground game (a live slider while playing OOT just updates the CVar — SyncAllToMM re-applies it
+// on the next MM entry).
+void MirrorRow(const VolMap& m, bool forceApply) {
+    int vi = CVarGetInteger(m.ootCVar, 0);
+    float f = vi / 100.0f;
+    f = f < 0.0f ? 0.0f : (f > 1.0f ? 1.0f : f);
+    CVarSetFloat(m.mmCVar, f);
+    if (m.seqPlayer >= 0 && (forceApply || ComboUI::IsMmActive())) {
+        if (auto fn = ResolveApply()) {
+            fn(m.seqPlayer, f);
+        }
+    }
+}
+
+} // namespace
+
+void ComboAudio::MirrorIfVolumeCVar(const char* cvar) {
+    if (!cvar || !cvar[0]) {
+        return;
+    }
+    for (const auto& m : kMap) {
+        if (std::strcmp(cvar, m.ootCVar) == 0) {
+            MirrorRow(m, /*forceApply=*/false);
+            return;
+        }
+    }
+}
+
+void ComboAudio::SyncAllToMM() {
+    for (const auto& m : kMap) {
+        MirrorRow(m, /*forceApply=*/true);
+    }
+}

--- a/combo/gui/ComboAudioBridge.cpp
+++ b/combo/gui/ComboAudioBridge.cpp
@@ -16,13 +16,15 @@ struct VolMap {
     const char* ootCVar;
     const char* mmCVar;
     int seqPlayer;
+    int defaultPct; // OOT slider default — must match SohMenuSettings.cpp so an untouched slider isn't
+                    // read as 0 (which would silence MM). Master 40, the rest 100.
 };
 const VolMap kMap[] = {
-    { "gSettings.Volume.Master", "gSettings.Audio.MasterVolume", -1 },
-    { "gSettings.Volume.MainMusic", "gSettings.Audio.MainMusicVolume", 0 },     // SEQ_PLAYER_BGM_MAIN
-    { "gSettings.Volume.SubMusic", "gSettings.Audio.SubMusicVolume", 3 },       // SEQ_PLAYER_BGM_SUB
-    { "gSettings.Volume.SFX", "gSettings.Audio.SoundEffectsVolume", 2 },        // SEQ_PLAYER_SFX
-    { "gSettings.Volume.Fanfare", "gSettings.Audio.FanfareVolume", 1 },         // SEQ_PLAYER_FANFARE
+    { "gSettings.Volume.Master", "gSettings.Audio.MasterVolume", -1, 40 },
+    { "gSettings.Volume.MainMusic", "gSettings.Audio.MainMusicVolume", 0, 100 }, // SEQ_PLAYER_BGM_MAIN
+    { "gSettings.Volume.SubMusic", "gSettings.Audio.SubMusicVolume", 3, 100 },   // SEQ_PLAYER_BGM_SUB
+    { "gSettings.Volume.SFX", "gSettings.Audio.SoundEffectsVolume", 2, 100 },    // SEQ_PLAYER_SFX
+    { "gSettings.Volume.Fanfare", "gSettings.Audio.FanfareVolume", 1, 100 },     // SEQ_PLAYER_FANFARE
 };
 
 // Resolved once from 2ship.dll. MM applies per-port volume via AudioSeq_SetPortVolumeScale, exposed
@@ -48,7 +50,7 @@ Fn_ApplyAudioVolume ResolveApply() {
 // foreground game (a live slider while playing OOT just updates the CVar — SyncAllToMM re-applies it
 // on the next MM entry).
 void MirrorRow(const VolMap& m, bool forceApply) {
-    int vi = CVarGetInteger(m.ootCVar, 0);
+    int vi = CVarGetInteger(m.ootCVar, m.defaultPct);
     float f = vi / 100.0f;
     f = f < 0.0f ? 0.0f : (f > 1.0f ? 1.0f : f);
     CVarSetFloat(m.mmCVar, f);

--- a/combo/gui/ComboAudioBridge.h
+++ b/combo/gui/ComboAudioBridge.h
@@ -1,0 +1,22 @@
+// combo/gui/ComboAudioBridge.h
+//
+// ComboShip-owned: bridges the Shared tab's audio sliders to MM. The Shared tab's Audio section is
+// OOT's, writing gSettings.Volume.* (int 0-100). MM reads its own gSettings.Audio.* (float 0-1) and
+// applies per-port volume via AudioSeq_SetPortVolumeScale (not ShipInit), so the Shared sliders would
+// otherwise never reach MM. This is a one-way mirror: OOT's Volume.* is canonical, MM's Audio.* is
+// derived. See Part A4 of the shared-settings consolidation.
+#pragma once
+
+namespace ComboAudio {
+
+// If `cvar` is one of OOT's gSettings.Volume.* sliders, mirror it into MM's matching gSettings.Audio.*
+// (int 0-100 -> float 0-1) and, when MM is the active game, apply it live. No-op otherwise. Call from
+// the combo widget render apply-step.
+void MirrorIfVolumeCVar(const char* cvar);
+
+// Push all canonical OOT volumes into MM's CVars and apply the per-port scales. Call when MM becomes
+// the foreground game (boot/resume), so volume changes made while MM was dormant take effect, and
+// MM's audio ports match the canonical Shared values on entry.
+void SyncAllToMM();
+
+} // namespace ComboAudio

--- a/combo/gui/ComboForeground.h
+++ b/combo/gui/ComboForeground.h
@@ -1,0 +1,21 @@
+// combo/gui/ComboForeground.h
+//
+// ComboShip-owned: query which game is currently foreground (0 = OOT, 1 = MM). The launcher
+// (combo/ComboShip.cpp) calls ComboUI_OnForegroundGame at each transition; ComboTrackerVisibility.cpp
+// caches the value here. Used by the audio bridge, the controls reload hook, and dev-tool window
+// gating to avoid driving the dormant game's live runtime state.
+#pragma once
+
+namespace ComboUI {
+
+// 0 = OOT, 1 = MM. Defaults to OOT (the foreground game at startup after the eager MM boot).
+int GetForegroundGame();
+
+inline bool IsGameActive(int game) {
+    return GetForegroundGame() == game;
+}
+inline bool IsMmActive() {
+    return GetForegroundGame() == 1;
+}
+
+} // namespace ComboUI

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -316,13 +316,14 @@ void ComboMenu::DrawGamePanel(const char* gameKey) {
         if (isOot && section && strcmp(section, "Settings") == 0) {
             return sidebar && (strcmp(sidebar, "Mod Menu") == 0 || strcmp(sidebar, "Presets") == 0);
         }
-        // MM's Graphics/Audio/Controls are consolidated into the Shared tab — Graphics applies via the
-        // single shared window, Controls via the shared gSettings.Controllers.* CVars, and Audio via the
-        // combo audio bridge (gSettings.Volume.* -> gSettings.Audio.*). Hide them from MM's per-game
-        // Settings section so they live only in Shared; the rest of MM Settings stays.
+        // MM's Graphics/Audio/Controls/General are consolidated into the Shared tab — Graphics applies via
+        // the single shared window, Controls via the shared gSettings.Controllers.* CVars, Audio via the
+        // combo audio bridge (gSettings.Volume.* -> gSettings.Audio.*), and General is menu/engine settings
+        // on shared gSettings.Menu.*/ImGuiScale CVars. Hide them from MM's per-game Settings section so they
+        // live only in Shared; MM-specific sidebars (Overlay, Presets, ...) stay.
         if (!isOot && section && strcmp(section, "Settings") == 0 && sidebar &&
             (strcmp(sidebar, "Graphics") == 0 || strcmp(sidebar, "Audio") == 0 ||
-             strcmp(sidebar, "Controls") == 0)) {
+             strcmp(sidebar, "Controls") == 0 || strcmp(sidebar, "General") == 0)) {
             return false;
         }
         // The rando section's settings live in the Shared tab; here we surface only its trackers.

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -316,6 +316,15 @@ void ComboMenu::DrawGamePanel(const char* gameKey) {
         if (isOot && section && strcmp(section, "Settings") == 0) {
             return sidebar && (strcmp(sidebar, "Mod Menu") == 0 || strcmp(sidebar, "Presets") == 0);
         }
+        // MM's Graphics/Audio/Controls are consolidated into the Shared tab — Graphics applies via the
+        // single shared window, Controls via the shared gSettings.Controllers.* CVars, and Audio via the
+        // combo audio bridge (gSettings.Volume.* -> gSettings.Audio.*). Hide them from MM's per-game
+        // Settings section so they live only in Shared; the rest of MM Settings stays.
+        if (!isOot && section && strcmp(section, "Settings") == 0 && sidebar &&
+            (strcmp(sidebar, "Graphics") == 0 || strcmp(sidebar, "Audio") == 0 ||
+             strcmp(sidebar, "Controls") == 0)) {
+            return false;
+        }
         // The rando section's settings live in the Shared tab; here we surface only its trackers.
         const char* randoSec = isOot ? "Randomizer" : "Rando";
         if (section && strcmp(section, randoSec) == 0)

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -322,8 +322,8 @@ void ComboMenu::DrawGamePanel(const char* gameKey) {
         // on shared gSettings.Menu.*/ImGuiScale CVars. Hide them from MM's per-game Settings section so they
         // live only in Shared; MM-specific sidebars (Overlay, Presets, ...) stay.
         if (!isOot && section && strcmp(section, "Settings") == 0 && sidebar &&
-            (strcmp(sidebar, "Graphics") == 0 || strcmp(sidebar, "Audio") == 0 ||
-             strcmp(sidebar, "Controls") == 0 || strcmp(sidebar, "General") == 0)) {
+            (strcmp(sidebar, "Graphics") == 0 || strcmp(sidebar, "Audio") == 0 || strcmp(sidebar, "Controls") == 0 ||
+             strcmp(sidebar, "General") == 0)) {
             return false;
         }
         // The rando section's settings live in the Shared tab; here we surface only its trackers.

--- a/combo/gui/ComboSettingsImportScreen.cpp
+++ b/combo/gui/ComboSettingsImportScreen.cpp
@@ -1,0 +1,208 @@
+// combo/gui/ComboSettingsImportScreen.cpp
+// ComboShip-owned first-launch settings-import screen (see ComboSettingsImportScreen.h). Structurally
+// a trimmed ComboExtractScreen: one PICK phase, two optional slots (SoH / 2Ship), Browse + auto-detect,
+// Import / Skip. The launcher does the JSON parse + merge + apply; this file only renders and reports
+// the chosen paths.
+#include "ComboSettingsImportScreen.h"
+#include "ComboWidgetStyle.h" // ComboMenu_ThemeColor / PushButton / PopButton
+
+#include <libultraship/libultraship.h>
+#include <fast/Fast3dWindow.h>
+#include <imgui.h>
+
+#include <string>
+#include <filesystem>
+#include <cstring>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <commdlg.h>
+#pragma comment(lib, "comdlg32")
+#endif
+
+using ComboRando::ComboMenu_PopButton;
+using ComboRando::ComboMenu_PushButton;
+using ComboRando::ComboMenu_ThemeColor;
+
+namespace {
+
+struct ConfigSlot {
+    const char* label = "";
+    const char* fileName = ""; // expected filename for auto-detect
+    ComboFnValidateConfig validate = nullptr;
+    std::string path;
+    bool valid = false;
+};
+
+// Native open-file dialog filtered to .json. Returns "" if cancelled.
+std::string PickConfigFile() {
+#ifdef _WIN32
+    char file[MAX_PATH] = { 0 };
+    OPENFILENAMEA ofn = { 0 };
+    ofn.lStructSize = sizeof(ofn);
+    ofn.lpstrFilter = "Settings (*.json)\0*.json\0All Files (*.*)\0*.*\0";
+    ofn.lpstrFile = file;
+    ofn.nMaxFile = MAX_PATH;
+    ofn.lpstrTitle = "Select settings file";
+    ofn.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_NOCHANGEDIR;
+    if (GetOpenFileNameA(&ofn)) {
+        return std::string(file);
+    }
+#endif
+    return std::string();
+}
+
+void CopyPath(char* dst, size_t cap, const std::string& src) {
+    std::strncpy(dst, src.c_str(), cap - 1);
+    dst[cap - 1] = '\0';
+}
+
+void UseSharedImGuiContext() {
+    auto ctx = Ship::Context::GetInstance();
+    if (ctx && ctx->GetWindow() && ctx->GetWindow()->GetGui()) {
+        ImGui::SetCurrentContext(ctx->GetWindow()->GetGui()->GetImGuiContext());
+    }
+}
+
+} // namespace
+
+extern "C" __declspec(dllexport) int ComboUI_RunSettingsImport(const ComboSettingsImportCallbacks* cb,
+                                                               ComboSettingsImportResult* out) {
+    if (!out) {
+        return 0;
+    }
+    out->action = 0;
+    out->sohPath[0] = '\0';
+    out->mmPath[0] = '\0';
+
+    auto ctx = Ship::Context::GetInstance();
+    if (!ctx || !ctx->GetWindow() || !ctx->GetWindow()->GetGui()) {
+        return 0;
+    }
+    auto wnd = std::dynamic_pointer_cast<Fast::Fast3dWindow>(ctx->GetWindow());
+    if (!wnd) {
+        return 0;
+    }
+    auto gui = wnd->GetGui();
+    UseSharedImGuiContext();
+
+    ConfigSlot slots[2];
+    slots[0].label = "Ship of Harkinian (OoT)";
+    slots[0].fileName = "shipofharkinian.json";
+    slots[0].validate = cb ? cb->sohValidate : nullptr;
+    slots[1].label = "2 Ship 2 Harkinian (MM)";
+    slots[1].fileName = "2ship2harkinian.json";
+    slots[1].validate = cb ? cb->mmValidate : nullptr;
+
+    // Auto-detect each game's config in the working dir (same convenience as the ROM auto-scan).
+    for (auto& s : slots) {
+        std::error_code ec;
+        if (std::filesystem::exists(s.fileName, ec)) {
+            s.path = std::filesystem::absolute(s.fileName, ec).string();
+            s.valid = !s.validate || s.validate(s.path.c_str()) != 0;
+        }
+    }
+
+    bool finished = false;
+    while (!finished) {
+        if (!ctx->GetWindow()->IsRunning()) {
+            return 0; // window closed -> launcher treats as Skip
+        }
+        wnd->HandleEvents();
+        if (!wnd->IsFrameReady()) {
+            continue;
+        }
+
+        UseSharedImGuiContext();
+        gui->StartDraw();
+        wnd->StartFrame();
+        wnd->RunGuiOnly();
+
+        const ImVec4 theme = ComboMenu_ThemeColor();
+        const ImVec4 kGreen(0.5f, 1.0f, 0.5f, 1.0f);
+        const ImVec4 kRed(1.0f, 0.4f, 0.4f, 1.0f);
+
+        ImGuiViewport* vp = ImGui::GetMainViewport();
+        ImGui::GetBackgroundDrawList()->AddRectFilled(vp->Pos, ImVec2(vp->Pos.x + vp->Size.x, vp->Pos.y + vp->Size.y),
+                                                      IM_COL32(0, 0, 0, 210));
+
+        const float kMargin = 20.0f;
+        float panelW = vp->WorkSize.x - kMargin * 2.0f;
+        if (panelW > 680.0f) {
+            panelW = 680.0f;
+        }
+        float panelMaxH = vp->WorkSize.y - kMargin * 2.0f;
+        ImGui::SetNextWindowPos(vp->GetCenter(), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+        ImGui::SetNextWindowSizeConstraints(ImVec2(panelW, 0.0f), ImVec2(panelW, panelMaxH));
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(24.0f, 20.0f));
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 6.0f);
+        ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.09f, 0.09f, 0.11f, 0.98f));
+        bool open = ImGui::Begin("ComboShip - Import Settings", nullptr,
+                                 ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
+                                     ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings |
+                                     ImGuiWindowFlags_AlwaysAutoResize);
+        ImGui::PopStyleColor();
+        ImGui::PopStyleVar(2);
+        if (open) {
+            ImGui::SetWindowFontScale(1.4f);
+            ImGui::TextColored(theme, "ComboShip Settings Import");
+            ImGui::SetWindowFontScale(1.0f);
+            ImGui::Separator();
+
+            ImGui::TextWrapped("Optional: bring over your settings from an existing Ship of Harkinian and/or "
+                               "2 Ship 2 Harkinian install. Pick one or both files, or Skip to start fresh. "
+                               "Where both set the same option (e.g. graphics or controls), OoT wins.");
+            ImGui::Spacing();
+
+            for (int i = 0; i < 2; i++) {
+                ConfigSlot& s = slots[i];
+                ImGui::PushID(i);
+                ImGui::TextColored(theme, "%s", s.label);
+                ImGui::TextWrapped("%s", s.path.empty() ? "(none selected)" : s.path.c_str());
+                ComboMenu_PushButton(theme);
+                if (ImGui::Button(s.path.empty() ? "Browse..." : "Change")) {
+                    std::string picked = PickConfigFile();
+                    if (!picked.empty()) {
+                        s.path = picked;
+                        s.valid = !s.validate || s.validate(picked.c_str()) != 0;
+                    }
+                }
+                ComboMenu_PopButton();
+                if (!s.path.empty()) {
+                    ImGui::SameLine();
+                    if (s.valid) {
+                        ImGui::TextColored(kGreen, "Looks like a %s config", s.label);
+                    } else {
+                        ImGui::TextColored(kRed, "May not be a %s config", s.label);
+                    }
+                }
+                ImGui::Spacing();
+                ImGui::Separator();
+                ImGui::Spacing();
+                ImGui::PopID();
+            }
+
+            ComboMenu_PushButton(theme);
+            if (ImGui::Button("Import", ImVec2(150.0f, 0.0f))) {
+                out->action = 1;
+                CopyPath(out->sohPath, sizeof(out->sohPath), slots[0].path);
+                CopyPath(out->mmPath, sizeof(out->mmPath), slots[1].path);
+                finished = true;
+            }
+            ComboMenu_PopButton();
+            ImGui::SameLine();
+            ComboMenu_PushButton(theme);
+            if (ImGui::Button("Skip", ImVec2(150.0f, 0.0f))) {
+                out->action = 0;
+                finished = true;
+            }
+            ComboMenu_PopButton();
+        }
+        ImGui::End();
+
+        gui->EndDraw();
+        wnd->EndFrame();
+    }
+
+    return 1;
+}

--- a/combo/gui/ComboSettingsImportScreen.h
+++ b/combo/gui/ComboSettingsImportScreen.h
@@ -1,0 +1,14 @@
+// combo/gui/ComboSettingsImportScreen.h
+// ComboShip: the combo-owned first-launch settings-import screen, hosted in comboui.dll. Runs the
+// libultraship frame loop and lets the player pick an existing SoH and/or 2Ship config to import.
+// See ComboSettingsImport.h for the ABI.
+#pragma once
+
+#include "../ComboSettingsImport.h"
+
+#ifdef _WIN32
+extern "C" __declspec(dllexport) int ComboUI_RunSettingsImport(const ComboSettingsImportCallbacks* cb,
+                                                               ComboSettingsImportResult* out);
+#else
+extern "C" int ComboUI_RunSettingsImport(const ComboSettingsImportCallbacks* cb, ComboSettingsImportResult* out);
+#endif

--- a/combo/gui/ComboTrackerVisibility.cpp
+++ b/combo/gui/ComboTrackerVisibility.cpp
@@ -28,8 +28,17 @@
 
 #include <libultraship/libultraship.h> // Ship::Context / Gui + CVarGet/SetInteger
 #include <memory>                      // std::weak_ptr (notification-window handle)
+#include "ComboForeground.h"           // ComboUI::GetForegroundGame (cached below)
+#include "ComboAudioBridge.h"          // ComboAudio::SyncAllToMM (on MM entry)
+#ifdef _WIN32
+#include <windows.h> // GetModuleHandleA/GetProcAddress for the MM_ReloadControls entry point
+#endif
 
 namespace {
+
+// Cached foreground game (0 = OOT, 1 = MM), updated by ComboUI_OnForegroundGame. Defaults to OOT,
+// the foreground game at startup after the eager MM boot. Read via ComboUI::GetForegroundGame.
+int sForegroundGame = 0;
 
 struct TrackerWin {
     const char* cvar; // visibility CVar (source of truth; MM's CheckTracker reads it directly)
@@ -83,6 +92,25 @@ const char* const kNotificationWin[2] = {
 // member keeps them alive); we only need a handle to re-add the backgrounded one later.
 std::weak_ptr<Ship::GuiWindow> sNotif[2];
 
+// Reload MM's controller bindings from the shared gSettings.Controllers.* CVars. Resolved once from
+// 2ship.dll. Called on MM entry so rebinds made via the Shared (OOT) controls UI while MM was dormant
+// take effect when MM resumes (MM's ControlDeck caches mappings; it only re-reads on Init / this call).
+void ReloadMmControls() {
+#ifdef _WIN32
+    static void (*sFn)() = nullptr;
+    static bool sTried = false;
+    if (!sTried) {
+        sTried = true;
+        if (HMODULE h = GetModuleHandleA("2ship.dll")) {
+            sFn = (void (*)())GetProcAddress(h, "MM_ReloadControls");
+        }
+    }
+    if (sFn) {
+        sFn();
+    }
+#endif
+}
+
 // Keep only the foreground game's notification window in the shared Gui's draw loop.
 void SetForegroundNotification(int fg) {
     auto ctx = Ship::Context::GetInstance();
@@ -108,6 +136,18 @@ void SetForegroundNotification(int fg) {
 
 } // namespace
 
+// Foreground-game query consumed by the audio bridge, controls reload, and dev-tool gating.
+int ComboUI::GetForegroundGame() {
+    return sForegroundGame;
+}
+
+// C-ABI variant so the game DLLs can query the foreground game (0 = OOT, 1 = MM) across the DLL
+// boundary — MM uses it to gate its live-world dev viewers (Actor/Collision/Message) from drawing
+// against dormant/swapped play state when its tab is opened while OOT is foreground.
+extern "C" __declspec(dllexport) int ComboUI_GetForegroundGame(void) {
+    return sForegroundGame;
+}
+
 // Called by the launcher whenever a game becomes the foreground game (0 = OOT, 1 = MM).
 extern "C" __declspec(dllexport) void ComboUI_OnForegroundGame(int game) {
     if (game != 0 && game != 1) {
@@ -115,6 +155,7 @@ extern "C" __declspec(dllexport) void ComboUI_OnForegroundGame(int game) {
     }
     const int fg = game;
     const int bg = game ^ 1;
+    sForegroundGame = fg;
 
     // Background game: remember the user's current intent, then hide its trackers.
     for (int i = 0; i < 4; ++i) {
@@ -133,6 +174,15 @@ extern "C" __declspec(dllexport) void ComboUI_OnForegroundGame(int game) {
     // Notification window follows the active game too (so MM's toasts show only while MM is foreground
     // and OOT's only while OOT is). Independent of the tracker intent above.
     SetForegroundNotification(fg);
+
+    // ComboShip: on MM entry (boot/resume), reconcile the settings MM consumes from its own CVars with
+    // the canonical Shared values changed while MM was dormant — push audio volumes (apply per-port
+    // scales) and reload controller bindings. Graphics needs no equivalent (the shared window applies
+    // OOT's graphics callbacks process-wide), and Controls' data already lives in shared CVars.
+    if (fg == 1) {
+        ComboAudio::SyncAllToMM();
+        ReloadMmControls();
+    }
 }
 
 // Called by the launcher just before shutdown teardown. Restores both games' tracker CVars to the

--- a/combo/gui/ComboWidgetRender.cpp
+++ b/combo/gui/ComboWidgetRender.cpp
@@ -15,6 +15,7 @@
 #include "ComboWidgetRender.h"
 #include "ComboMenuModel.h"   // GameMenu (resolved export fn-ptrs)
 #include "ComboWidgetStyle.h" // combo-owned replication of OOT UIWidgets menu styling
+#include "ComboAudioBridge.h" // Shared-tab audio -> MM mirror
 
 #include <libultraship/libultraship.h> // ImGui-adjacent + CVar bridge (CVarGet/Set*) + color.h
 #include <imgui.h>
@@ -243,6 +244,12 @@ void RenderWidget(const CwWidget& w, const GameMenu& game) {
     // the combo menu only take effect on the next ShipInit::InitAll (game boot / new save).
     if (changed && w.cvar && w.cvar[0] && game.applyCVarChange) {
         game.applyCVarChange(w.cvar);
+    }
+
+    // 6) ComboShip: the Shared tab's audio sliders are OOT's (gSettings.Volume.*); mirror them into
+    // MM's gSettings.Audio.* so a single Shared Audio section drives both games (see ComboAudioBridge).
+    if (changed && w.cvar && w.cvar[0]) {
+        ComboAudio::MirrorIfVolumeCVar(w.cvar);
     }
 
     if (disabled) {

--- a/docs/UPSTREAM_MERGES.md
+++ b/docs/UPSTREAM_MERGES.md
@@ -1148,6 +1148,9 @@ MM's identically-named dev windows were dropped (OOT boots first). (c) Dev-tool 
   window's `DrawElement()` inline (skipped when popped out, so no double-draw); live-world viewers
   (Actor/Collision/Message/DL/Event Log) gate on `Combo_MmIsForeground()` so they don't read MM's
   dormant/swapped play state when the MM tab is opened while OOT is foreground.
+- `soh/soh/SohGui/SohMenuDevTools.cpp` + `OTRGlobals.cpp` — the same inline `WIDGET_CUSTOM` treatment for
+  OOT's dev tools, gating live viewers on `Combo_OotIsForeground()`. Both `Combo_*IsForeground` helpers
+  resolve comboui's `ComboUI_GetForegroundGame` once.
 - `mm/2s2h/BenPort.cpp` — exports `MM_ApplyAudioVolume(seqPlayer, vol)` (→ `AudioSeq_SetPortVolumeScale`,
   the apply path MM uses instead of ShipInit) and `MM_ReloadControls()` (reloads MM's ControlDeck ports
   from the shared `gSettings.Controllers.*` CVars); `Combo_MmIsForeground()` queries comboui's
@@ -1162,6 +1165,8 @@ MM's identically-named dev windows were dropped (OOT boots first). (c) Dev-tool 
   existing `ComboUI_OnForegroundGame` callback; expose `ComboUI::GetForegroundGame()` (C++) and
   `ComboUI_GetForegroundGame()` (C ABI, for MM's gating). On MM entry the callback also runs
   `ComboAudio::SyncAllToMM()` + `MM_ReloadControls` so changes made while MM was dormant take effect.
-- `combo/gui/ComboMenu.cpp` — the per-game tab sidebar filter now also hides MM's Graphics/Audio/Controls
-  (they live only in Shared). **On future merges:** if MM's audio CVar names/scale change, update
-  `kMap` in `ComboAudioBridge.cpp`.
+- `combo/gui/ComboMenu.cpp` — the per-game tab sidebar filter now also hides MM's
+  Graphics/Audio/Controls/General (they live only in Shared, on shared CVars). **On future merges:** if
+  MM's audio CVar names/scale change, update `kMap` in `ComboAudioBridge.cpp` (note: the OOT `Volume.*`
+  defaults — Master 40, rest 100 — are duplicated in `kMap`'s `defaultPct` and must match
+  SohMenuSettings.cpp, else an untouched slider reads as 0 and silences MM).

--- a/docs/UPSTREAM_MERGES.md
+++ b/docs/UPSTREAM_MERGES.md
@@ -848,6 +848,13 @@ broke; restored in `soh/soh/Extractor/Extract.cpp` to mirror the MM sibling (cat
 archive exists → `return true`). Also Release links `/SUBSYSTEM:WINDOWS` (no console window; Debug
 keeps it), `+/ENTRY:mainCRTStartup` since ComboShip has its own `main()` and doesn't link SDL2main.
 
+**Combined config renamed to `comboship.json` (issue 24).** OOT + MM share one libultraship Context, so
+there is a single config file. `OTRGlobals.cpp` now names it `comboship.json` (COMBO_BUILD-guarded; `#else`
+keeps `shipofharkinian.json` for standalone soh) to make the combined nature explicit and to gate the
+first-launch settings import (absent file = fresh install). New combo-owned export `SOH_ApplyImportedConfig`
+installs a launcher-merged config into the live `Config` (`SetBlock` + `Save` + `CVarLoad` + controller
+reload). MM's `2ship2harkinian.json` literals are untouched (standalone-only, off the combo path).
+
 ## Cross-game Check/Item tracker windows (collision fix + active-game gating) (2026-06-21)
 
 **Why:** Both soh and mm register tracker windows named identically — `"Check Tracker"`,

--- a/docs/UPSTREAM_MERGES.md
+++ b/docs/UPSTREAM_MERGES.md
@@ -840,6 +840,14 @@ Verified: fast path (archives present) boots straight to title unchanged; first-
 extraction screen (`OoT=1 MM=1`). The old `SOH_Extract`/`MM_Extract` exports remain for non-combo use
 but the launcher no longer calls them.
 
+**`CallZapd` must return `true` on success (re-survive on every re-vendor).** Upstream `CallZapd`
+returns `false` unconditionally (native flow gates on exceptions, not the return value), but
+`SOH_/MM_StartExtraction` use it as the combo screen's success flag — so a `false` return makes a
+*successful* extract read as "failed". The soh re-vendor `19427b200` reverted this and OOT extraction
+broke; restored in `soh/soh/Extractor/Extract.cpp` to mirror the MM sibling (catch throw → verify
+archive exists → `return true`). Also Release links `/SUBSYSTEM:WINDOWS` (no console window; Debug
+keeps it), `+/ENTRY:mainCRTStartup` since ComboShip has its own `main()` and doesn't link SDL2main.
+
 ## Cross-game Check/Item tracker windows (collision fix + active-game gating) (2026-06-21)
 
 **Why:** Both soh and mm register tracker windows named identically — `"Check Tracker"`,

--- a/docs/UPSTREAM_MERGES.md
+++ b/docs/UPSTREAM_MERGES.md
@@ -1128,3 +1128,40 @@ until the next `ShipInit::InitAll` (game boot / new save). New exports `SOH_Menu
 `MM_MenuApplyCVarChange` (OTRGlobals.cpp / BenPort.cpp) run `ShipInit::Init(cvar)`; the comboui menu
 model + `ComboWidgetRender` call them after each change. Fixes #27. **On future merges:** if the
 native UIWidgets stop using `ShipInit::Init`-on-change, revisit.
+
+## Shared-settings consolidation + dev-tool window fixes (issue #22, 2026-06-28)
+
+**Why:** three related issues in the shared menu/window subsystem. (a) #22 — MM ignored the Shared
+tab's Graphics/Audio/Controls and the per-game tabs redundantly exposed them. (b) Opening MM's "Save
+Editor" showed OOT's: the shared `Gui::AddGuiWindow` keys by display name and rejects duplicates, so
+MM's identically-named dev windows were dropped (OOT boots first). (c) Dev-tool windows only offered a
+"popout" button, never rendering inline.
+
+**Vendored (additive, `COMBO_BUILD`-guarded):**
+- `mm/2s2h/BenGui/BenGui.cpp` — the 9 MM dev/debug windows whose names collide with OOT's (Save Editor,
+  Actor/Collision/Message Viewer, Audio Editor, Mod Menu, Hook Debugger, Input Viewer (+Settings)) now
+  register with `COMBO_MM_TRACKER_SUFFIX` (`"##MM"`), same mechanism as the trackers — map-key/ID only,
+  visible title unchanged, empty in standalone. (Cosmetic Editor / Time Splits Window / DL Viewer differ
+  from OOT's strings already, so they don't collide.)
+- `mm/2s2h/BenGui/BenMenu.cpp` — matching `WindowName(...)` popout refs carry the same suffix
+  (`COMBO_MM_WINDOW_SUFFIX`). New `#ifdef COMBO_BUILD` inline `WIDGET_CUSTOM` entries render each dev
+  window's `DrawElement()` inline (skipped when popped out, so no double-draw); live-world viewers
+  (Actor/Collision/Message/DL/Event Log) gate on `Combo_MmIsForeground()` so they don't read MM's
+  dormant/swapped play state when the MM tab is opened while OOT is foreground.
+- `mm/2s2h/BenPort.cpp` — exports `MM_ApplyAudioVolume(seqPlayer, vol)` (→ `AudioSeq_SetPortVolumeScale`,
+  the apply path MM uses instead of ShipInit) and `MM_ReloadControls()` (reloads MM's ControlDeck ports
+  from the shared `gSettings.Controllers.*` CVars); `Combo_MmIsForeground()` queries comboui's
+  foreground game. All inside the existing `COMBO_BUILD` export block.
+
+**Combo-owned:**
+- `combo/gui/ComboAudioBridge.{h,cpp}` — one-way mirror of OOT's canonical `gSettings.Volume.*` (int
+  0-100) into MM's `gSettings.Audio.*` (float 0-1). `MirrorIfVolumeCVar` fires from the
+  `ComboWidgetRender` apply-step; `SyncAllToMM` runs on MM entry. Graphics needs no bridge (one shared
+  window) and Controls' data is already shared CVars.
+- `combo/gui/ComboForeground.h` + `ComboTrackerVisibility.cpp` — cache the foreground game from the
+  existing `ComboUI_OnForegroundGame` callback; expose `ComboUI::GetForegroundGame()` (C++) and
+  `ComboUI_GetForegroundGame()` (C ABI, for MM's gating). On MM entry the callback also runs
+  `ComboAudio::SyncAllToMM()` + `MM_ReloadControls` so changes made while MM was dormant take effect.
+- `combo/gui/ComboMenu.cpp` — the per-game tab sidebar filter now also hides MM's Graphics/Audio/Controls
+  (they live only in Shared). **On future merges:** if MM's audio CVar names/scale change, update
+  `kMap` in `ComboAudioBridge.cpp`.

--- a/mm/2s2h/BenGui/BenGui.cpp
+++ b/mm/2s2h/BenGui/BenGui.cpp
@@ -38,11 +38,13 @@
 
 // ComboShip: in the combo build, OOT (soh) registers identically-named tracker windows FIRST into
 // the single shared libultraship Gui. Gui::AddGuiWindow keys by display name and rejects duplicates,
-// so MM's "Check Tracker"/"Item Tracker"(+Settings) would be silently dropped and never drawn.
-// Suffix MM's window keys with "##MM": ImGui shows only the text before "##", so the visible title
-// stays "Check Tracker", but the map key (and ImGui window ID) is unique and both games coexist.
-// The popout WindowName() references in 2s2h/Rando/Menu.cpp use the same suffix. The active-game
-// gating in combo/gui/ComboTrackerVisibility.cpp ensures the two games' trackers never draw at once.
+// so any MM window whose name matches an OOT one (trackers, plus dev tools like "Save Editor",
+// "Actor Viewer", "Audio Editor", "Mod Menu", "Input Viewer"...) would be silently dropped and never
+// drawn — that is why MM's "Save Editor" used to show OOT's. Suffix MM's window keys with "##MM":
+// ImGui shows only the text before "##", so the visible title stays "Save Editor", but the map key
+// (and ImGui window ID) is unique and both games coexist. The popout WindowName() references in
+// BenMenu.cpp / 2s2h/Rando/Menu.cpp use the same suffix. The active-game gating in
+// combo/gui/ComboTrackerVisibility.cpp ensures the two games' trackers never draw at once.
 // See docs/UPSTREAM_MERGES.md.
 #ifdef COMBO_BUILD
 #define COMBO_MM_TRACKER_SUFFIX "##MM"
@@ -154,11 +156,12 @@ void SetupGuiElements() {
         SPDLOG_ERROR("Could not find input editor window");
     }
 
-    mHookDebuggerWindow =
-        std::make_shared<HookDebuggerWindow>("gWindows.HookDebugger", "Hook Debugger", ImVec2(480, 600));
+    mHookDebuggerWindow = std::make_shared<HookDebuggerWindow>(
+        "gWindows.HookDebugger", "Hook Debugger" COMBO_MM_TRACKER_SUFFIX, ImVec2(480, 600));
     gui->AddGuiWindow(mHookDebuggerWindow);
 
-    mSaveEditorWindow = std::make_shared<SaveEditorWindow>("gWindows.SaveEditor", "Save Editor", ImVec2(480, 600));
+    mSaveEditorWindow = std::make_shared<SaveEditorWindow>("gWindows.SaveEditor", "Save Editor" COMBO_MM_TRACKER_SUFFIX,
+                                                           ImVec2(480, 600));
     gui->AddGuiWindow(mSaveEditorWindow);
 
     mHudEditorWindow = std::make_shared<HudEditorWindow>("gWindows.HudEditor", "HUD Editor", ImVec2(480, 600));
@@ -168,11 +171,12 @@ void SetupGuiElements() {
         std::make_shared<CosmeticEditorWindow>("gWindows.CosmeticEditor", "Cosmetic Editor", ImVec2(480, 600));
     gui->AddGuiWindow(mCosmeticEditorWindow);
 
-    mActorViewerWindow = std::make_shared<ActorViewerWindow>("gWindows.ActorViewer", "Actor Viewer", ImVec2(520, 600));
+    mActorViewerWindow = std::make_shared<ActorViewerWindow>("gWindows.ActorViewer",
+                                                             "Actor Viewer" COMBO_MM_TRACKER_SUFFIX, ImVec2(520, 600));
     gui->AddGuiWindow(mActorViewerWindow);
 
-    mCollisionViewerWindow =
-        std::make_shared<CollisionViewerWindow>("gWindows.CollisionViewer", "Collision Viewer", ImVec2(390, 475));
+    mCollisionViewerWindow = std::make_shared<CollisionViewerWindow>(
+        "gWindows.CollisionViewer", "Collision Viewer" COMBO_MM_TRACKER_SUFFIX, ImVec2(390, 475));
     gui->AddGuiWindow(mCollisionViewerWindow);
 
     mEventLogWindow = std::make_shared<EventLogWindow>("gWindows.EventLog", "Event Log", ImVec2(520, 600));
@@ -180,14 +184,16 @@ void SetupGuiElements() {
 
     mDLViewerWindow = std::make_shared<DLViewerWindow>("gWindows.DLViewer", "DL Viewer", ImVec2(520, 600));
     gui->AddGuiWindow(mDLViewerWindow);
-    mMessageViewerWindow =
-        std::make_shared<MessageViewerWindow>("gWindows.MessageViewer", "Message Viewer", ImVec2(520, 600));
+    mMessageViewerWindow = std::make_shared<MessageViewerWindow>(
+        "gWindows.MessageViewer", "Message Viewer" COMBO_MM_TRACKER_SUFFIX, ImVec2(520, 600));
     gui->AddGuiWindow(mMessageViewerWindow);
 
-    mAudioEditorWindow = std::make_shared<AudioEditor>("gWindows.AudioEditor", "Audio Editor", ImVec2(520, 600));
+    mAudioEditorWindow =
+        std::make_shared<AudioEditor>("gWindows.AudioEditor", "Audio Editor" COMBO_MM_TRACKER_SUFFIX, ImVec2(520, 600));
     gui->AddGuiWindow(mAudioEditorWindow);
 
-    mModMenuWindow = std::make_shared<ModMenuWindow>("gWindows.ModMenu", "Mod Menu", ImVec2(820, 630));
+    mModMenuWindow =
+        std::make_shared<ModMenuWindow>("gWindows.ModMenu", "Mod Menu" COMBO_MM_TRACKER_SUFFIX, ImVec2(820, 630));
     gui->AddGuiWindow(mModMenuWindow);
 
     mItemTrackerWindow =
@@ -225,10 +231,10 @@ void SetupGuiElements() {
         "gWindows.CheckTrackerSettings", "Check Tracker Settings" COMBO_MM_TRACKER_SUFFIX);
     gui->AddGuiWindow(mRandoCheckTrackerSettingsWindow);
 
-    mInputViewer = std::make_shared<InputViewer>("gWindows.InputViewer", "Input Viewer");
+    mInputViewer = std::make_shared<InputViewer>("gWindows.InputViewer", "Input Viewer" COMBO_MM_TRACKER_SUFFIX);
     gui->AddGuiWindow(mInputViewer);
-    mInputViewerSettings = std::make_shared<InputViewerSettingsWindow>("gWindows.InputViewerSettings",
-                                                                       "Input Viewer Settings", ImVec2(500, 525));
+    mInputViewerSettings = std::make_shared<InputViewerSettingsWindow>(
+        "gWindows.InputViewerSettings", "Input Viewer Settings" COMBO_MM_TRACKER_SUFFIX, ImVec2(500, 525));
     gui->AddGuiWindow(mInputViewerSettings);
 }
 

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -23,6 +23,45 @@
 #include "2s2h/Rando/Rando.h"
 #include "build.h"
 
+// ComboShip: MM dev-tool / viewer windows share names with OOT's in the single shared Gui registry,
+// which keys by display name and rejects duplicates. BenGui.cpp registers the MM windows with this
+// "##MM" suffix so they are not dropped; the popout WindowName() references below must use the same
+// suffix to resolve the MM window (not OOT's). Standalone build => empty suffix (unchanged).
+#ifdef COMBO_BUILD
+#define COMBO_MM_WINDOW_SUFFIX "##MM"
+#else
+#define COMBO_MM_WINDOW_SUFFIX ""
+#endif
+
+#ifdef COMBO_BUILD
+bool Combo_MmIsForeground(void); // defined in BenPort.cpp
+
+// ComboShip: draw a dev/debug tool window inline inside the combo menu panel. Without this the menu only
+// offers a "popout" button, so the user has to detach every window just to see it. Skips drawing when
+// the window is shown as a popout (the shared Gui loop already draws that floating copy) or is not yet
+// registered. Live-world viewers (Actor/Collision/Message/DL/Event Log) pass requiresForeground=true so
+// they do not read MM's dormant/swapped play state when MM's tab is opened while OOT is foreground.
+static void ComboInlineWindow(const char* windowName, bool requiresForeground) {
+    if (requiresForeground && !Combo_MmIsForeground()) {
+        ImGui::TextDisabled("Available while 2 Ship 2 Harkinian is running.");
+        return;
+    }
+    auto ctx = Ship::Context::GetInstance();
+    if (!ctx || !ctx->GetWindow() || !ctx->GetWindow()->GetGui()) {
+        return;
+    }
+    auto win = ctx->GetWindow()->GetGui()->GetGuiWindow(windowName);
+    if (!win || win->IsVisible()) { // not registered, or already shown as a popout — don't double-draw
+        return;
+    }
+    // The Gui loop only runs Update()+Draw() on visible windows; since we draw this one inline while it
+    // is hidden, run Update() ourselves first so DrawElement sees the same per-frame state it normally
+    // would. Runs exactly once per frame (we returned above when the window is visible/popped out).
+    win->Update();
+    win->DrawElement();
+}
+#endif
+
 extern "C" {
 #include "z64.h"
 #include "functions.h"
@@ -706,13 +745,13 @@ void BenMenu::AddSettings() {
     AddWidget(path, "Input Viewer", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Toggle Input Viewer", WIDGET_WINDOW_BUTTON)
         .CVar("gWindows.InputViewer")
-        .WindowName("Input Viewer")
+        .WindowName("Input Viewer" COMBO_MM_WINDOW_SUFFIX)
         .Options(ButtonOptions().Tooltip("Toggles the Input Viewer."));
 
     AddWidget(path, "Input Viewer Settings", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Popout Input Viewer Settings", WIDGET_WINDOW_BUTTON)
         .CVar("gWindows.InputViewerSettings")
-        .WindowName("Input Viewer Settings")
+        .WindowName("Input Viewer Settings" COMBO_MM_WINDOW_SUFFIX)
         .Options(ButtonOptions().Tooltip("Enables the separate Input Viewer Settings Window."));
 
     // Mod Menu
@@ -722,9 +761,14 @@ void BenMenu::AddSettings() {
     AddWidget(path, "Mod Menu", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Popout Mod Menu Window", WIDGET_WINDOW_BUTTON)
         .CVar("gWindows.ModMenu")
-        .WindowName("Mod Menu")
+        .WindowName("Mod Menu" COMBO_MM_WINDOW_SUFFIX)
         .HideInSearch(true)
         .Options(ButtonOptions().Tooltip("Enables the separate Mod Menu Window."));
+#ifdef COMBO_BUILD
+    AddWidget(path, "Mod Menu Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Mod Menu" COMBO_MM_WINDOW_SUFFIX, /*requiresForeground=*/false);
+    });
+#endif
 }
 int32_t motionBlurStrength;
 
@@ -1928,6 +1972,11 @@ void BenMenu::AddEnhancements() {
         .Options(ButtonOptions()
                      .Tooltip("Enables the HUD Editor window, allowing you to modify your HUD.")
                      .Size(Sizes::Inline));
+#ifdef COMBO_BUILD
+    AddWidget(path, "HUD Editor Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("HUD Editor", /*requiresForeground=*/false);
+    });
+#endif
 
     // Cosmetics Editor
     path = { "Enhancements", "Cosmetic Editor", SECTION_COLUMN_1 };
@@ -1938,6 +1987,11 @@ void BenMenu::AddEnhancements() {
         .Options(ButtonOptions()
                      .Tooltip("Enables the Cosmetic Editor window, allowing you to modify various colors in the game.")
                      .Size(Sizes::Inline));
+#ifdef COMBO_BUILD
+    AddWidget(path, "Cosmetic Editor Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Cosmetic Editor", /*requiresForeground=*/false);
+    });
+#endif
 
     // Timesplit Settings
     path = { "Enhancements", "Time Splits", SECTION_COLUMN_1 };
@@ -1951,7 +2005,12 @@ void BenMenu::AddEnhancements() {
     AddSidebarEntry("Enhancements", "Audio Editor", 1);
     AddWidget(path, "Popout Audio Editor", WIDGET_WINDOW_BUTTON)
         .CVar("gWindows.AudioEditor")
-        .WindowName("Audio Editor");
+        .WindowName("Audio Editor" COMBO_MM_WINDOW_SUFFIX);
+#ifdef COMBO_BUILD
+    AddWidget(path, "Audio Editor Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Audio Editor" COMBO_MM_WINDOW_SUFFIX, /*requiresForeground=*/false);
+    });
+#endif
 }
 
 void BenMenu::AddDevTools() {
@@ -2060,7 +2119,12 @@ void BenMenu::AddDevTools() {
     AddWidget(path, "Popout Collision Viewer", WIDGET_WINDOW_BUTTON)
         .CVar("gWindows.CollisionViewer")
         .Options(ButtonOptions().Tooltip("Makes collision visible on screen.").Size(Sizes::Inline))
-        .WindowName("Collision Viewer");
+        .WindowName("Collision Viewer" COMBO_MM_WINDOW_SUFFIX);
+#ifdef COMBO_BUILD
+    AddWidget(path, "Collision Viewer Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Collision Viewer" COMBO_MM_WINDOW_SUFFIX, /*requiresForeground=*/true);
+    });
+#endif
 
     path = { "Dev Tools", "Stats", SECTION_COLUMN_1 };
     AddSidebarEntry("Dev Tools", "Stats", 1);
@@ -2091,21 +2155,36 @@ void BenMenu::AddDevTools() {
     AddWidget(path, "Popout Hook Debugger", WIDGET_WINDOW_BUTTON)
         .CVar("gWindows.HookDebugger")
         .Options(ButtonOptions().Tooltip("Enables the Hook Debugger window, for viewing info about registered hooks."))
-        .WindowName("Hook Debugger");
+        .WindowName("Hook Debugger" COMBO_MM_WINDOW_SUFFIX);
+#ifdef COMBO_BUILD
+    AddWidget(path, "Hook Debugger Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Hook Debugger" COMBO_MM_WINDOW_SUFFIX, /*requiresForeground=*/false);
+    });
+#endif
 
     path = { "Dev Tools", "Save Editor", SECTION_COLUMN_1 };
     AddSidebarEntry("Dev Tools", "Save Editor", 1);
     AddWidget(path, "Popout Save Editor", WIDGET_WINDOW_BUTTON)
         .CVar("gWindows.SaveEditor")
         .Options(ButtonOptions().Tooltip("Enables the Save Editor window, allowing you to edit your save file."))
-        .WindowName("Save Editor");
+        .WindowName("Save Editor" COMBO_MM_WINDOW_SUFFIX);
+#ifdef COMBO_BUILD
+    AddWidget(path, "Save Editor Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Save Editor" COMBO_MM_WINDOW_SUFFIX, /*requiresForeground=*/false);
+    });
+#endif
 
     path = { "Dev Tools", "Actor Viewer", SECTION_COLUMN_1 };
     AddSidebarEntry("Dev Tools", "Actor Viewer", 1);
     AddWidget(path, "Popout Actor Viewer", WIDGET_WINDOW_BUTTON)
         .CVar("gWindows.ActorViewer")
         .Options(ButtonOptions().Tooltip("Enables the Actor Viewer window, allowing you to view actors in the world."))
-        .WindowName("Actor Viewer");
+        .WindowName("Actor Viewer" COMBO_MM_WINDOW_SUFFIX);
+#ifdef COMBO_BUILD
+    AddWidget(path, "Actor Viewer Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Actor Viewer" COMBO_MM_WINDOW_SUFFIX, /*requiresForeground=*/true);
+    });
+#endif
 
     path = { "Dev Tools", "Event Log", SECTION_COLUMN_1 };
     AddSidebarEntry("Dev Tools", "Event Log", 1);
@@ -2113,6 +2192,11 @@ void BenMenu::AddDevTools() {
         .CVar("gWindows.EventLog")
         .Options(ButtonOptions().Tooltip("Enables the Event Log window."))
         .WindowName("Event Log");
+#ifdef COMBO_BUILD
+    AddWidget(path, "Event Log Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Event Log", /*requiresForeground=*/true);
+    });
+#endif
 
     path = { "Dev Tools", "DL Viewer", SECTION_COLUMN_1 };
     AddSidebarEntry("Dev Tools", "DL Viewer", 1);
@@ -2120,12 +2204,22 @@ void BenMenu::AddDevTools() {
         .CVar("gWindows.DLViewer")
         .Options(ButtonOptions().Tooltip("Enables the DL Viewer window for inspecting and editing display lists."))
         .WindowName("DL Viewer");
+#ifdef COMBO_BUILD
+    AddWidget(path, "DL Viewer Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("DL Viewer", /*requiresForeground=*/true);
+    });
+#endif
     path = { "Dev Tools", "Message Viewer", SECTION_COLUMN_1 };
     AddSidebarEntry("Dev Tools", "Message Viewer", 1);
     AddWidget(path, "Popout Message Viewer", WIDGET_WINDOW_BUTTON)
         .CVar("gWindows.MessageViewer")
         .Options(ButtonOptions().Tooltip("Enables the Message Viewer window for testing in-game messages."))
-        .WindowName("Message Viewer");
+        .WindowName("Message Viewer" COMBO_MM_WINDOW_SUFFIX);
+#ifdef COMBO_BUILD
+    AddWidget(path, "Message Viewer Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Message Viewer" COMBO_MM_WINDOW_SUFFIX, /*requiresForeground=*/true);
+    });
+#endif
 }
 
 BenMenu::BenMenu(const std::string& consoleVariable, const std::string& name)

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -3608,6 +3608,44 @@ extern "C" __declspec(dllexport) void MM_MenuApplyCVarChange(const char* cvar) {
         ShipInit::Init(cvar);
 }
 
+// ComboShip: combo-owned audio bridge entry point (combo/gui/ComboAudioBridge.cpp). The Shared tab's
+// audio sliders are OOT's (gSettings.Volume.* int 0-100); the combo layer mirrors them into MM's float
+// CVars and calls this to apply per-port volume live. MM applies volume via AudioSeq_SetPortVolumeScale
+// (not ShipInit), so MM_MenuApplyCVarChange would not pick it up. gAudioCtx persists across transitions,
+// so this is safe even when MM is not the foreground game.
+extern "C" __declspec(dllexport) void MM_ApplyAudioVolume(int32_t seqPlayerIndex, float volume) {
+    AudioSeq_SetPortVolumeScale((u8)seqPlayerIndex, volume);
+}
+
+// ComboShip: controller bindings live in the shared gSettings.Controllers.* CVars, so the Shared tab's
+// (OOT) controls UI edits the same data MM reads. But each game's ControlDeck caches its mappings (it
+// only re-reads on Init / this call), so a rebind made while MM was dormant is not picked up until MM
+// reloads. The combo layer calls this when MM becomes the foreground game. Reloads all populated ports.
+extern "C" __declspec(dllexport) void MM_ReloadControls(void) {
+    auto controlDeck = Ship::Context::GetInstance()->GetControlDeck();
+    if (!controlDeck)
+        return;
+    for (uint8_t port = 0; port < 4; ++port) {
+        if (auto controller = controlDeck->GetControllerByPort(port))
+            controller->ReloadAllMappingsFromConfig();
+    }
+}
+
+// ComboShip: true when MM is the foreground game (queries comboui's ComboUI_GetForegroundGame, resolved
+// once). BenMenu uses it to gate MM's live-world dev viewers — opening MM's tab while OOT is foreground
+// must not draw against MM's dormant/swapped play state. comboui is always loaded under ComboShip; if it
+// somehow isn't, default to true (draw) rather than hiding the tools.
+bool Combo_MmIsForeground(void) {
+    static int (*sFn)(void) = nullptr;
+    static bool sTried = false;
+    if (!sTried) {
+        sTried = true;
+        if (HMODULE h = GetModuleHandleA("comboui.dll"))
+            sFn = (int (*)(void))GetProcAddress(h, "ComboUI_GetForegroundGame");
+    }
+    return sFn ? (sFn() == 1) : true;
+}
+
 extern "C" __declspec(dllexport) int32_t MM_MenuEvalDisabled(int32_t i, const char** outReason) {
     ComboMenuContext::UseSharedImGuiContext();
     auto menu = Combo_EnsureBenMenu();

--- a/soh/soh/Extractor/Extract.cpp
+++ b/soh/soh/Extractor/Extract.cpp
@@ -690,7 +690,33 @@ bool Extractor::CallZapd(std::string installPath, std::string exportdir, std::at
     argv[20] = "-osf";
     argv[21] = "placeholder";
 
-    zapd_report(argc, (char**)argv.data(), extractCount, totalExtract);
+    // ComboShip: upstream returns false unconditionally (native flow gates on exceptions). But
+    // SOH_StartExtraction uses the return value as the combo screen's success flag, so OOT success
+    // read as "failed". Mirror mm/Extract.cpp; reverted once by re-vendor 19427b200 — keep on merges.
+    try {
+        zapd_report(argc, (char**)argv.data(), extractCount, totalExtract);
+    } catch (const std::exception& e) {
+        fprintf(stderr, "OoT Extractor: ZAPD failed: %s\n", e.what());
+        if (FILE* ef = fopen((curdir + "/soh_extract_error.log").c_str(), "w")) {
+            fprintf(ef, "OoT Extractor: ZAPD threw:\n%s\n", e.what());
+            fclose(ef);
+        }
+        std::filesystem::current_path(curdir);
+        std::filesystem::remove_all(tempdir);
+        return false;
+    }
+
+    // Copying a non-existent file throws and crashes the process; bail if ZAPD produced nothing.
+    if (!std::filesystem::exists(otrFile)) {
+        fprintf(stderr, "OoT Extractor: ZAPD did not produce %s\n", otrFile);
+        if (FILE* ef = fopen((curdir + "/soh_extract_error.log").c_str(), "w")) {
+            fprintf(ef, "OoT Extractor: ZAPD produced no %s.\n", otrFile);
+            fclose(ef);
+        }
+        std::filesystem::current_path(curdir);
+        std::filesystem::remove_all(tempdir);
+        return false;
+    }
 
     std::filesystem::copy(otrFile, exportdir + "/" + otrFile, std::filesystem::copy_options::overwrite_existing);
 
@@ -698,7 +724,7 @@ bool Extractor::CallZapd(std::string installPath, std::string exportdir, std::at
     std::filesystem::current_path(curdir);
     std::filesystem::remove_all(tempdir);
 
-    return false;
+    return true;
 }
 
 static void MessageboxWorker() {

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1633,7 +1633,7 @@ extern "C" __declspec(dllexport) int SOH_ApplyImportedConfig(const char* mergedJ
                 conf->SetBlock(key, value);
             }
         }
-        conf->Save();  // persist first: CVarLoad() reloads CVars from disk
+        conf->Save(); // persist first: CVarLoad() reloads CVars from disk
         CVarLoad();
         if (auto deck = OTRGlobals::Instance->context->GetControlDeck()) {
             for (uint8_t p = 0; p < 4; p++) {
@@ -1643,9 +1643,7 @@ extern "C" __declspec(dllexport) int SOH_ApplyImportedConfig(const char* mergedJ
             }
         }
         return 1;
-    } catch (...) {
-        return 0;
-    }
+    } catch (...) { return 0; }
 }
 #endif
 

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -316,7 +316,14 @@ static std::shared_ptr<Ship::ResourceManager> sOOTResourceManager;
 #endif
 
 OTRGlobals::OTRGlobals() {
+#ifdef COMBO_BUILD
+    // ComboShip (issue 24): OOT + MM share this one Context, so this is the single combined config.
+    // Named comboship.json to make that explicit and to gate the first-launch settings import. See
+    // docs/UPSTREAM_MERGES.md.
+    context = Ship::Context::CreateUninitializedInstance("Ship of Harkinian", appShortName, "comboship.json");
+#else
     context = Ship::Context::CreateUninitializedInstance("Ship of Harkinian", appShortName, "shipofharkinian.json");
+#endif
 
     portArchivePath = Ship::Context::LocateFileAcrossAppDirs("soh.o2r");
     OTRVersion portArchiveVersion = DetectOTRVersion("soh.o2r", false);
@@ -1599,6 +1606,46 @@ extern "C" __declspec(dllexport) void SOH_InitWindowOnly() {
 }
 extern "C" __declspec(dllexport) void SOH_FinishInit() {
     Combo_FinishInit();
+}
+
+// ComboShip (issue 24): apply a launcher-merged config (JSON object) to the live Config and reload the
+// dependent subsystems. The launcher does the per-leaf merge (SoH wins) and excludes the Window block;
+// here we install each block, persist, and reload CVars + controller mappings. Runs before
+// Combo_FinishInit so RunVersionUpdates() then sees the imported state.
+extern "C" __declspec(dllexport) int SOH_ApplyImportedConfig(const char* mergedJsonUtf8) {
+    if (!mergedJsonUtf8 || !OTRGlobals::Instance) {
+        return 0;
+    }
+    try {
+        nlohmann::json merged = nlohmann::json::parse(mergedJsonUtf8);
+        auto conf = OTRGlobals::Instance->context->GetConfig();
+        for (auto& [key, value] : merged.items()) {
+            if (key == "Window") {
+                continue; // machine-specific; excluded per design
+            }
+            if (key == "ConfigVersion") {
+                if (value.is_number_unsigned()) {
+                    conf->SetUInt("ConfigVersion", value.get<uint32_t>());
+                }
+                continue;
+            }
+            if (value.is_object()) {
+                conf->SetBlock(key, value);
+            }
+        }
+        conf->Save();  // persist first: CVarLoad() reloads CVars from disk
+        CVarLoad();
+        if (auto deck = OTRGlobals::Instance->context->GetControlDeck()) {
+            for (uint8_t p = 0; p < 4; p++) {
+                if (auto c = deck->GetControllerByPort(p); c && c->HasConfig()) {
+                    c->ReloadAllMappingsFromConfig();
+                }
+            }
+        }
+        return 1;
+    } catch (...) {
+        return 0;
+    }
 }
 #endif
 

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -2817,6 +2817,23 @@ extern "C" __declspec(dllexport) void SOH_MenuApplyCVarChange(const char* cvar) 
         ShipInit::Init(cvar);
 }
 
+#ifdef COMBO_BUILD
+// ComboShip: true when OOT is the foreground game (queries comboui's ComboUI_GetForegroundGame, resolved
+// once). SohMenuDevTools uses it to gate OOT's live-world dev viewers — opening OOT's tab while MM is
+// foreground must not draw against OOT's dormant/swapped play state. comboui is always loaded under
+// ComboShip; if it somehow isn't, default to true (draw) rather than hiding the tools.
+bool Combo_OotIsForeground(void) {
+    static int (*sFn)(void) = nullptr;
+    static bool sTried = false;
+    if (!sTried) {
+        sTried = true;
+        if (HMODULE h = GetModuleHandleA("comboui.dll"))
+            sFn = (int (*)(void))GetProcAddress(h, "ComboUI_GetForegroundGame");
+    }
+    return sFn ? (sFn() == 0) : true;
+}
+#endif
+
 extern "C" __declspec(dllexport) int32_t SOH_MenuEvalDisabled(int32_t i, const char** outReason) {
     ComboMenuContext::UseSharedImGuiContext();
     auto menu = SohGui::GetSohMenu();

--- a/soh/soh/SohGui/SohMenuDevTools.cpp
+++ b/soh/soh/SohGui/SohMenuDevTools.cpp
@@ -7,10 +7,42 @@ extern PlayState* gPlayState;
 
 void WarpPointsWidget(WidgetInfo& info);
 
+#ifdef COMBO_BUILD
+bool Combo_OotIsForeground(void); // defined in OTRGlobals.cpp
+#endif
+
 namespace SohGui {
 
 extern std::shared_ptr<SohMenu> mSohMenu;
 using namespace UIWidgets;
+
+#ifdef COMBO_BUILD
+// ComboShip: draw a dev/debug tool window inline inside the combo menu panel. Without this the menu only
+// offers a "popout" button, so the user has to detach every window just to see it (mirrors the MM side
+// in BenMenu.cpp). Skips drawing when the window is shown as a popout (the shared Gui loop already draws
+// that floating copy) or is not yet registered. Live-world viewers (Actor/Collision/DList/Value/Message)
+// pass requiresForeground=true so they do not read OOT's dormant/swapped play state when OOT's tab is
+// opened while MM is foreground.
+static void ComboInlineWindow(const char* windowName, bool requiresForeground) {
+    if (requiresForeground && !Combo_OotIsForeground()) {
+        ImGui::TextDisabled("Available while Ship of Harkinian is running.");
+        return;
+    }
+    auto ctx = Ship::Context::GetInstance();
+    if (!ctx || !ctx->GetWindow() || !ctx->GetWindow()->GetGui()) {
+        return;
+    }
+    auto win = ctx->GetWindow()->GetGui()->GetGuiWindow(windowName);
+    if (!win || win->IsVisible()) { // not registered, or already shown as a popout — don't double-draw
+        return;
+    }
+    // The Gui loop only runs Update()+Draw() on visible windows; since we draw this one inline while it is
+    // hidden, run Update() ourselves first so DrawElement sees its normal per-frame state. Runs once per
+    // frame (we returned above when the window is visible/popped out).
+    win->Update();
+    win->DrawElement();
+}
+#endif
 
 static const std::map<int32_t, const char*> logLevels = {
     { DEBUG_LOG_TRACE, "Trace" }, { DEBUG_LOG_DEBUG, "Debug" }, { DEBUG_LOG_INFO, "Info" },
@@ -165,6 +197,11 @@ void SohMenu::AddMenuDevTools() {
         .WindowName("Save Editor")
         .HideInSearch(true)
         .Options(WindowButtonOptions().Tooltip("Enables the separate Save Editor Window."));
+#ifdef COMBO_BUILD
+    AddWidget(path, "Save Editor Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Save Editor", /*requiresForeground=*/false);
+    });
+#endif
 
     // Hook Debugger
     path.sidebarName = "Hook Debugger";
@@ -174,6 +211,11 @@ void SohMenu::AddMenuDevTools() {
         .WindowName("Hook Debugger")
         .HideInSearch(true)
         .Options(WindowButtonOptions().Tooltip("Enables the separate Hook Debugger Window."));
+#ifdef COMBO_BUILD
+    AddWidget(path, "Hook Debugger Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Hook Debugger", /*requiresForeground=*/false);
+    });
+#endif
 
     // Collision Viewer
     path.sidebarName = "Collision Viewer";
@@ -183,6 +225,11 @@ void SohMenu::AddMenuDevTools() {
         .WindowName("Collision Viewer")
         .HideInSearch(true)
         .Options(WindowButtonOptions().Tooltip("Enables the separate Collision Viewer Window."));
+#ifdef COMBO_BUILD
+    AddWidget(path, "Collision Viewer Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Collision Viewer", /*requiresForeground=*/true);
+    });
+#endif
 
     // Actor Viewer
     path.sidebarName = "Actor Viewer";
@@ -192,6 +239,11 @@ void SohMenu::AddMenuDevTools() {
         .WindowName("Actor Viewer")
         .HideInSearch(true)
         .Options(WindowButtonOptions().Tooltip("Enables the separate Actor Viewer Window."));
+#ifdef COMBO_BUILD
+    AddWidget(path, "Actor Viewer Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Actor Viewer", /*requiresForeground=*/true);
+    });
+#endif
 
     // Display List Viewer
     path.sidebarName = "DList Viewer";
@@ -201,6 +253,11 @@ void SohMenu::AddMenuDevTools() {
         .WindowName("Display List Viewer")
         .HideInSearch(true)
         .Options(WindowButtonOptions().Tooltip("Enables the separate Display List Viewer Window."));
+#ifdef COMBO_BUILD
+    AddWidget(path, "Display List Viewer Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Display List Viewer", /*requiresForeground=*/true);
+    });
+#endif
 
     // Value Viewer
     path.sidebarName = "Value Viewer";
@@ -210,6 +267,11 @@ void SohMenu::AddMenuDevTools() {
         .WindowName("Value Viewer")
         .HideInSearch(true)
         .Options(WindowButtonOptions().Tooltip("Enables the separate Value Viewer Window."));
+#ifdef COMBO_BUILD
+    AddWidget(path, "Value Viewer Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Value Viewer", /*requiresForeground=*/true);
+    });
+#endif
 
     // Message Viewer
     path.sidebarName = "Message Viewer";
@@ -219,6 +281,11 @@ void SohMenu::AddMenuDevTools() {
         .WindowName("Message Viewer")
         .HideInSearch(true)
         .Options(WindowButtonOptions().Tooltip("Enables the separate Message Viewer Window."));
+#ifdef COMBO_BUILD
+    AddWidget(path, "Message Viewer Inline", WIDGET_CUSTOM).CustomFunction([](WidgetInfo&) {
+        ComboInlineWindow("Message Viewer", /*requiresForeground=*/true);
+    });
+#endif
 
     // Gfx Debugger
     path.sidebarName = "Gfx Debugger";


### PR DESCRIPTION
Three changes, all combo-side.

### OOT extraction success
`CallZapd` returned `false` on success (upstream gates on exceptions, not the return value), so the combo extraction screen read a good OOT extract as "failed". Restored to mirror the MM sibling (catch throw → verify archive → `return true`). Reverted once by re-vendor `19427b200`; documented to survive future merges.

### Hide Release console
Release links `/SUBSYSTEM:WINDOWS` (+`/ENTRY:mainCRTStartup`, since ComboShip has its own `main()`); Debug keeps the console for logs.

### Combined config rename + settings import (#24)
- Shared OOT+MM config renamed to `comboship.json` (COMBO_BUILD-guarded; standalone soh unchanged).
- Fresh install (no `comboship.json`): after ROM extraction, a screen offers to import an existing SoH and/or 2Ship config — auto-detect in the folder + Browse. Per-leaf merge, **SoH wins** on collisions, all blocks except `Window`. Applied to the live config via new export `SOH_ApplyImportedConfig`.

Verified in-app: extraction succeeds, Release has no console, import screen imports/merges as expected.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/7939365633.zip)
<!--- section:artifacts:end -->