### PR TITLE
Combo menu: search bar + Shared-tab fixes

### DIFF
--- a/combo/CMakeLists.txt
+++ b/combo/CMakeLists.txt
@@ -28,6 +28,7 @@ set(COMBOUI_SOURCES
     gui/ComboMenu.cpp
     gui/ComboMenuModel.cpp
     gui/ComboWidgetRender.cpp
+    gui/ComboResolutionEditor.cpp
     gui/ComboWidgetStyle.cpp
     gui/ComboExtractScreen.cpp
     gui/ComboSettingsImportScreen.cpp

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -164,7 +164,7 @@ void ComboMenu::DrawSearchResults(const std::string& query) {
         const GameMenu* game;
     };
     const Source sources[] = {
-        { "Ship of Harkinian", &model.Oot() },   // OOT first: its copy wins the dedupe
+        { "Ship of Harkinian", &model.Oot() }, // OOT first: its copy wins the dedupe
         { "2 Ship 2 Harkinian", &model.Mm() },
     };
 

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -59,6 +59,14 @@ namespace ComboRando {
 
 static std::shared_ptr<ComboMenu> sComboMenu;
 
+// Search normalization shared by the query and every widget haystack: lowercase + strip spaces.
+static std::string NormalizeSearch(std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+    s.erase(std::remove(s.begin(), s.end(), ' '), s.end());
+    return s;
+}
+static const ImVec4 kBreadcrumbColor(0.6f, 0.6f, 0.6f, 1.0f); // muted gray for the result origin line
+
 void ComboMenu::Draw() {
     // Mirror Ship::Menu::Draw — skip GuiWindow::Draw's normal Begin/End wrapper so DrawElement
     // can open its own fullscreen overlay window instead of a floating one.
@@ -117,8 +125,22 @@ void ComboMenu::DrawElement() {
                 mScope = sc.id;
             }
         }
+        // Global search row beneath the scope strip: a themed Clear button + a full-width input.
+        // A non-empty query takes over the content area (results span both games); the scope tabs
+        // stay visible but inert until the box is cleared.
+        ComboMenu_PushButton(ComboMenu_ThemeColor());
+        if (ImGui::Button("Clear")) {
+            mSearchBuf[0] = '\0';
+        }
+        ComboMenu_PopButton();
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth(-FLT_MIN);
+        ImGui::InputTextWithHint("##ComboSearch", "Search settings...", mSearchBuf, sizeof(mSearchBuf));
         ImGui::Separator();
 
+        // Normalize once per frame; the scope panels render search results in their content area
+        // (keeping the left nav visible) when this is non-empty.
+        mSearchQuery = NormalizeSearch(mSearchBuf);
         if (mScope == "oot") {
             DrawGamePanel("oot");
         } else if (mScope == "mm") {
@@ -128,6 +150,82 @@ void ComboMenu::DrawElement() {
         }
     }
     ImGui::End();
+}
+
+// Global search (issue #26): scans BOTH games' CwMenu models for a name+tooltip match against the
+// pre-normalized query, rendering each hit inline via RenderWidget with an origin breadcrumb.
+// Shared settings live in both models; dedupe by cvar|name (OOT wins) so they surface once.
+void ComboMenu::DrawSearchResults(const std::string& query) {
+    auto& model = ComboMenuModel::Get();
+    model.EnsureLoaded();
+
+    struct Source {
+        const char* label;
+        const GameMenu* game;
+    };
+    const Source sources[] = {
+        { "Ship of Harkinian", &model.Oot() },   // OOT first: its copy wins the dedupe
+        { "2 Ship 2 Harkinian", &model.Mm() },
+    };
+
+    // 2-3 equal-width columns (by available width) so results read as a grid, not one tall list —
+    // same stretch-table pattern as RenderSidebarWidgets. Each match fills the next cell, wrapping
+    // rows; the narrower cell width is what keeps the controls from spanning the whole panel.
+    float avail = ImGui::GetContentRegionAvail().x;
+    int cols = avail > 1100.0f ? 3 : (avail > 720.0f ? 2 : 1);
+
+    std::unordered_set<std::string> seen; // dedupe key: normalized cvar (or per-game name for no-cvar)
+    int matches = 0;
+    const ImGuiTableFlags flags = ImGuiTableFlags_SizingStretchSame | ImGuiTableFlags_NoSavedSettings;
+    if (ImGui::BeginTable("##searchresults", cols, flags)) {
+        for (const auto& src : sources) {
+            const GameMenu& game = *src.game;
+            if (!game.loaded || !game.menu)
+                continue;
+            const CwMenu* m = game.menu;
+            for (int s = 0; s < m->sectionCount; ++s) {
+                const CwSection& sec = m->sections[s];
+                for (int sb = 0; sb < sec.sidebarCount; ++sb) {
+                    const CwSidebar& side = sec.sidebars[sb];
+                    for (int w = 0; w < side.widgetCount; ++w) {
+                        const CwWidget& wd = side.widgets[w];
+                        // Non-interactive / opted-out kinds never appear in search.
+                        if (wd.kind == CW_SEPARATOR || wd.kind == CW_SEPARATOR_TEXT || wd.kind == CW_TEXT ||
+                            wd.kind == CW_CUSTOM || wd.hideInSearch)
+                            continue;
+                        std::string hay =
+                            NormalizeSearch(std::string(wd.name ? wd.name : "") + (wd.tooltip ? wd.tooltip : ""));
+                        if (hay.find(query) == std::string::npos)
+                            continue;
+                        // Dedupe shared settings (same backing CVar) across both games. Widgets with no
+                        // CVar (buttons/window toggles) drive distinct callbacks, so scope their key per
+                        // game — otherwise two same-named buttons would collapse and one would vanish.
+                        std::string cvar = wd.cvar ? wd.cvar : "";
+                        std::string key = cvar.empty() ? (std::string(src.label) + "|" + (wd.name ? wd.name : ""))
+                                                       : NormalizeSearch(cvar);
+                        if (!seen.insert(NormalizeSearch(key)).second)
+                            continue; // a shared setting already shown from OOT
+
+                        ImGui::TableNextColumn();
+                        // Extra per-game ID scope: RenderWidget PushID(w.index) internally, and the two
+                        // games can emit the same index — without this, their interaction state collides.
+                        ImGui::PushID(src.label);
+                        RenderWidget(wd, game);
+                        ImGui::TextColored(kBreadcrumbColor, "[%s] %s -> %s", src.label,
+                                           (sec.sectionLabel && sec.sectionLabel[0]) ? sec.sectionLabel : "Section",
+                                           (side.sidebarName && side.sidebarName[0]) ? side.sidebarName : "Section");
+                        ImGui::PopID();
+                        ImGui::Spacing();
+                        ++matches;
+                    }
+                }
+            }
+        }
+        ImGui::EndTable();
+    }
+
+    if (matches == 0)
+        ImGui::TextDisabled("No matching settings.");
 }
 
 // Shared tab: a left-panel navigation hub (mirrors the native menu's left sidebar). Groups of
@@ -279,7 +377,9 @@ void ComboMenu::DrawSharedPanel() {
 
     // Right content panel for the active entry.
     ImGui::BeginChild("##HubContent", ImVec2(0, 0));
-    if (!active) {
+    if (!mSearchQuery.empty()) {
+        DrawSearchResults(mSearchQuery);
+    } else if (!active) {
         ImGui::TextUnformatted("Select an option.");
     } else if (active->kind == HubEntry::COMBO_GEN) {
         DrawComboPanel();
@@ -409,7 +509,9 @@ void ComboMenu::DrawGamePanel(const char* gameKey) {
     ImGui::SameLine();
 
     ImGui::BeginChild("##GameContent", ImVec2(0, 0));
-    if (!activeSide) {
+    if (!mSearchQuery.empty()) {
+        DrawSearchResults(mSearchQuery);
+    } else if (!activeSide) {
         ImGui::TextUnformatted("Select an option.");
     } else {
         RenderSidebarWidgets(*activeSide, game);

--- a/combo/gui/ComboMenu.h
+++ b/combo/gui/ComboMenu.h
@@ -33,7 +33,13 @@ class ComboMenu final : public Ship::GuiWindow {
     void DrawGamePanel(const char* gameKey); // renders from the C-ABI model (ComboMenuModel + RenderWidget)
     void DrawComboPanel();                   // cross-world Generate (seed + button + progress)
     void DrawHintSection();                  // sphere "Get a hint" helper, when a seed save is active
+    // Global menu search: scans BOTH games' CwMenu models for widgets whose name+tooltip match the
+    // (normalized) query, rendering each match inline + editable (2-3 column grid) with a breadcrumb.
+    // Drawn in the active scope's content area, so the left navigation panel stays visible.
+    void DrawSearchResults(const std::string& query);
 
+    char mSearchBuf[256] = { 0 }; // raw global-search input; normalized into mSearchQuery each frame
+    std::string mSearchQuery;     // normalized search text this frame ("" = not searching)
     char mSeedBuf[128] = { 0 };
     // Sphere-hint state: the active seed's playthrough (game, checkName) in sphere order, cached by
     // save slot; mHintsRevealed = how many of the not-yet-collected steps the player has revealed.

--- a/combo/gui/ComboResolutionEditor.cpp
+++ b/combo/gui/ComboResolutionEditor.cpp
@@ -20,14 +20,15 @@ namespace {
 #define CV_LOWRES "gSettings.LowResMode"
 
 // Preset tables transcribed from ResolutionEditor.cpp (kept in sync per UPSTREAM_MERGES).
-const char* kAspectLabels[] = { "Off",          "Custom",      "Original (4:3)",   "Widescreen (16:9)",
-                                "Nintendo 3DS (5:3)", "16:10 (8:5)", "Ultrawide (21:9)" };
+const char* kAspectLabels[] = {
+    "Off", "Custom", "Original (4:3)", "Widescreen (16:9)", "Nintendo 3DS (5:3)", "16:10 (8:5)", "Ultrawide (21:9)"
+};
 const float kAspectX[] = { 0.0f, 16.0f, 4.0f, 16.0f, 5.0f, 16.0f, 21.0f };
 const float kAspectY[] = { 0.0f, 9.0f, 3.0f, 9.0f, 3.0f, 10.0f, 9.0f };
 const int kAspectCustom = 1; // "Custom" — the index that shows the manual X/Y sliders
 
-const char* kPixelLabels[] = { "Custom",      "Native N64 (240p)", "2x (480p)",       "3x (720p)", "4x (960p)",
-                               "5x (1200p)",  "6x (1440p)",        "Full HD (1080p)", "4K (2160p)" };
+const char* kPixelLabels[] = { "Custom",     "Native N64 (240p)", "2x (480p)",       "3x (720p)", "4x (960p)",
+                               "5x (1200p)", "6x (1440p)",        "Full HD (1080p)", "4K (2160p)" };
 const int kPixelValues[] = { 480, 240, 480, 720, 960, 1200, 1440, 1080, 2160 };
 const int kPixelCustom = 0;
 

--- a/combo/gui/ComboResolutionEditor.cpp
+++ b/combo/gui/ComboResolutionEditor.cpp
@@ -1,0 +1,303 @@
+// combo/gui/ComboResolutionEditor.cpp — see ComboResolutionEditor.h for the why.
+#include "ComboResolutionEditor.h"
+#include "ComboWidgetStyle.h" // themed Push/Pop helpers + ComboMenu_ThemeColor
+
+#include <libultraship/libultraship.h> // Ship::Context, CVar bridge, Gui::SaveConsoleVariablesNextFrame
+#include <fast/Fast3dWindow.h>         // Fast::Fast3dWindow::GetInterpreterWeak
+#include <fast/interpreter.h>          // Fast::Interpreter dims
+#include <imgui.h>
+#include <cstring>
+#include <memory>
+
+namespace ComboRando {
+
+namespace {
+
+// Effective CVar prefix — top-level CMake/lus-cvars.cmake sets this for both soh and libultraship,
+// overriding libultraship's "gAdvancedResolution" default. String-literal concatenation builds the
+// full names (e.g. CV_ADVRES ".Enabled").
+#define CV_ADVRES "gSettings.AdvancedResolution"
+#define CV_LOWRES "gSettings.LowResMode"
+
+// Preset tables transcribed from ResolutionEditor.cpp (kept in sync per UPSTREAM_MERGES).
+const char* kAspectLabels[] = { "Off",          "Custom",      "Original (4:3)",   "Widescreen (16:9)",
+                                "Nintendo 3DS (5:3)", "16:10 (8:5)", "Ultrawide (21:9)" };
+const float kAspectX[] = { 0.0f, 16.0f, 4.0f, 16.0f, 5.0f, 16.0f, 21.0f };
+const float kAspectY[] = { 0.0f, 9.0f, 3.0f, 9.0f, 3.0f, 10.0f, 9.0f };
+const int kAspectCustom = 1; // "Custom" — the index that shows the manual X/Y sliders
+
+const char* kPixelLabels[] = { "Custom",      "Native N64 (240p)", "2x (480p)",       "3x (720p)", "4x (960p)",
+                               "5x (1200p)",  "6x (1440p)",        "Full HD (1080p)", "4K (2160p)" };
+const int kPixelValues[] = { 480, 240, 480, 720, 960, 1200, 1440, 1080, 2160 };
+const int kPixelCustom = 0;
+
+const int kMinVert = 240;  // SCREEN_HEIGHT
+const int kMaxVert = 4320; // 8K
+const int kDefaultMaxScale = 6;
+
+void Save() {
+    auto ctx = Ship::Context::GetInstance();
+    if (ctx && ctx->GetWindow() && ctx->GetWindow()->GetGui()) {
+        ctx->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+    }
+}
+
+// Live render dimensions from the Fast3d interpreter (same source SoH's readouts use). Read on the
+// overlay's render thread, which is the thread that runs the interpreter (as SoH's MenuUpdate does);
+// a torn read would be a one-frame cosmetic readout, so no synchronization is needed.
+bool GetDims(uint32_t& vpW, uint32_t& vpH, uint32_t& intW, uint32_t& intH) {
+    auto ctx = Ship::Context::GetInstance();
+    if (!ctx || !ctx->GetWindow()) {
+        return false;
+    }
+    auto fast = std::dynamic_pointer_cast<Fast::Fast3dWindow>(ctx->GetWindow());
+    if (!fast) {
+        return false;
+    }
+    auto interp = fast->GetInterpreterWeak().lock();
+    if (!interp) {
+        return false;
+    }
+    vpW = interp->mGameWindowViewport.width;
+    vpH = interp->mGameWindowViewport.height;
+    intW = interp->mCurDimensions.width;
+    intH = interp->mCurDimensions.height;
+    return true;
+}
+
+// Max integer scale factor for the current viewport/internal ratio (mirrors UpdateResolutionVars).
+int ComputeMaxIntegerScale() {
+    uint32_t vpW, vpH, inW, inH;
+    if (!GetDims(vpW, vpH, inW, inH) || inW == 0 || inH == 0 || vpH == 0) {
+        return kDefaultMaxScale;
+    }
+    int bounds = ((float)vpW / vpH > (float)inW / inH) ? (int)(vpH / inH) : (int)(vpW / inW);
+    if (bounds < 1) {
+        bounds = 1;
+    }
+    return kDefaultMaxScale < bounds ? bounds : kDefaultMaxScale;
+}
+
+bool AdvancedEnabled() {
+    return CVarGetInteger(CV_ADVRES ".Enabled", 0) != 0;
+}
+
+void RenderReadout(const char* name) {
+    uint32_t vpW, vpH, inW, inH;
+    const bool ok = GetDims(vpW, vpH, inW, inH);
+    const bool viewport = (std::strncmp(name, "Viewport", 8) == 0);
+    if (!ok) {
+        ImGui::TextUnformatted(viewport ? "Viewport dimensions: (unavailable)" : "Internal resolution: (unavailable)");
+    } else if (viewport) {
+        ImGui::Text("Viewport dimensions: %u x %u", vpW, vpH);
+    } else {
+        ImGui::Text("Internal resolution: %u x %u", inW, inH);
+    }
+}
+
+void RenderEnable(const char* name) {
+    bool en = AdvancedEnabled();
+    ComboMenu_PushCheckbox(ComboMenu_ThemeColor());
+    if (ImGui::Checkbox((name && name[0]) ? name : "Enable advanced settings.", &en)) {
+        CVarSetInteger(CV_ADVRES ".Enabled", en ? 1 : 0);
+        Save();
+    }
+    ComboMenu_PopCheckbox();
+}
+
+void RenderAspect() {
+    const ImVec4 theme = ComboMenu_ThemeColor();
+    ImGui::BeginDisabled(!AdvancedEnabled());
+
+    int item = CVarGetInteger(CV_ADVRES ".UIComboItem.AspectRatio", 3); // SoH default: Widescreen
+    if (item < 0 || item >= IM_ARRAYSIZE(kAspectLabels)) {
+        item = kAspectCustom;
+    }
+    ComboMenu_PushCombobox(theme);
+    if (ImGui::BeginCombo("Aspect Ratio", kAspectLabels[item])) {
+        for (int i = 0; i < IM_ARRAYSIZE(kAspectLabels); ++i) {
+            const bool sel = (i == item);
+            if (ImGui::Selectable(kAspectLabels[i], sel)) {
+                CVarSetInteger(CV_ADVRES ".UIComboItem.AspectRatio", i);
+                if (i != kAspectCustom) { // presets write X/Y directly (Off => 0,0); Custom uses sliders
+                    CVarSetFloat(CV_ADVRES ".AspectRatioX", kAspectX[i]);
+                    CVarSetFloat(CV_ADVRES ".AspectRatioY", kAspectY[i]);
+                }
+                Save();
+            }
+            if (sel) {
+                ImGui::SetItemDefaultFocus();
+            }
+        }
+        ImGui::EndCombo();
+    }
+    ComboMenu_PopCombobox();
+
+    if (item == kAspectCustom) { // manual aspect: X/Y sliders (folds in the AspectRatioCustom widget)
+        float x = CVarGetFloat(CV_ADVRES ".AspectRatioX", 16.0f);
+        float y = CVarGetFloat(CV_ADVRES ".AspectRatioY", 9.0f);
+        ComboMenu_PushSlider(theme);
+        if (ImGui::SliderFloat("X", &x, 0.1f, 32.0f, "%.3f")) {
+            CVarSetFloat(CV_ADVRES ".AspectRatioX", x);
+            Save();
+        }
+        if (ImGui::SliderFloat("Y", &y, 0.1f, 24.0f, "%.3f")) {
+            CVarSetFloat(CV_ADVRES ".AspectRatioY", y);
+            Save();
+        }
+        ComboMenu_PopSlider();
+    }
+    ImGui::EndDisabled();
+}
+
+void RenderMore() {
+    const ImVec4 theme = ComboMenu_ThemeColor();
+    ImGui::BeginDisabled(!AdvancedEnabled());
+
+    bool vToggle = CVarGetInteger(CV_ADVRES ".VerticalResolutionToggle", 0) != 0;
+    ComboMenu_PushCheckbox(theme);
+    if (ImGui::Checkbox("Set fixed vertical resolution (disables resolution slider)", &vToggle)) {
+        CVarSetInteger(CV_ADVRES ".VerticalResolutionToggle", vToggle ? 1 : 0);
+        Save();
+    }
+    ComboMenu_PopCheckbox();
+
+    const bool pixelDisabled = !vToggle;
+    ImGui::BeginDisabled(pixelDisabled);
+
+    int pItem = CVarGetInteger(CV_ADVRES ".UIComboItem.PixelCount", kPixelCustom);
+    if (pItem < 0 || pItem >= IM_ARRAYSIZE(kPixelLabels)) {
+        pItem = kPixelCustom;
+    }
+    ComboMenu_PushCombobox(theme);
+    if (ImGui::BeginCombo("Pixel Count Presets", kPixelLabels[pItem])) {
+        for (int i = 0; i < IM_ARRAYSIZE(kPixelLabels); ++i) {
+            const bool sel = (i == pItem);
+            if (ImGui::Selectable(kPixelLabels[i], sel)) {
+                CVarSetInteger(CV_ADVRES ".UIComboItem.PixelCount", i);
+                if (i != kPixelCustom) {
+                    CVarSetInteger(CV_ADVRES ".VerticalPixelCount", kPixelValues[i]);
+                }
+                Save();
+            }
+            if (sel) {
+                ImGui::SetItemDefaultFocus();
+            }
+        }
+        ImGui::EndCombo();
+    }
+    ComboMenu_PopCombobox();
+
+    int vpc = CVarGetInteger(CV_ADVRES ".VerticalPixelCount", 480);
+    ComboMenu_PushInput(theme);
+    if (ImGui::InputInt("Vertical Pixel Count", &vpc, 8, 240)) {
+        if (vpc < kMinVert) {
+            vpc = kMinVert;
+        } else if (vpc > kMaxVert) {
+            vpc = kMaxVert;
+        }
+        CVarSetInteger(CV_ADVRES ".VerticalPixelCount", vpc);
+        CVarSetInteger(CV_ADVRES ".UIComboItem.PixelCount", kPixelCustom);
+        Save();
+    }
+    ComboMenu_PopInput();
+    ImGui::EndDisabled(); // pixelDisabled
+
+    if (ImGui::CollapsingHeader("Integer Scaling Settings")) {
+        const bool ppm = CVarGetInteger(CV_ADVRES ".PixelPerfectMode", 0) != 0;
+        const bool fitAuto = CVarGetInteger(CV_ADVRES ".IntegerScale.FitAutomatically", 0) != 0;
+
+        bool ppmV = ppm;
+        ComboMenu_PushCheckbox(theme);
+        ImGui::BeginDisabled(pixelDisabled); // Pixel Perfect needs the fixed-vertical-resolution toggle
+        if (ImGui::Checkbox("Pixel Perfect Mode", &ppmV)) {
+            CVarSetInteger(CV_ADVRES ".PixelPerfectMode", ppmV ? 1 : 0);
+            Save();
+        }
+        ImGui::EndDisabled();
+        ComboMenu_PopCheckbox();
+
+        int factor = CVarGetInteger(CV_ADVRES ".IntegerScale.Factor", 1);
+        const int maxFactor = ComputeMaxIntegerScale();
+        if (factor > maxFactor) {
+            factor = maxFactor;
+        }
+        ComboMenu_PushSlider(theme);
+        ImGui::BeginDisabled(!ppm || fitAuto);
+        if (ImGui::SliderInt("Integer scale factor", &factor, 1, maxFactor)) {
+            CVarSetInteger(CV_ADVRES ".IntegerScale.Factor", factor);
+            Save();
+        }
+        ImGui::EndDisabled();
+        ComboMenu_PopSlider();
+
+        bool fitAutoV = fitAuto;
+        ComboMenu_PushCheckbox(theme);
+        ImGui::BeginDisabled(!ppm);
+        if (ImGui::Checkbox("Automatically scale image to fit viewport", &fitAutoV)) {
+            CVarSetInteger(CV_ADVRES ".IntegerScale.FitAutomatically", fitAutoV ? 1 : 0);
+            Save();
+        }
+        ImGui::EndDisabled();
+        ComboMenu_PopCheckbox();
+    }
+    ImGui::EndDisabled(); // !enabled
+}
+
+} // namespace
+
+bool TryRenderResolutionWidget(const CwWidget& w) {
+    const char* name = w.name ? w.name : "";
+    const char* cvar = w.cvar ? w.cvar : "";
+
+    // Enable checkbox — owned so its write persists (SaveConsoleVariablesNextFrame).
+    if (w.kind == CW_CHECKBOX && std::strcmp(cvar, CV_ADVRES ".Enabled") == 0) {
+        RenderEnable(name);
+        return true;
+    }
+    // Live dimension readouts (SoH sets these names per-frame via PreFunc; the snapshot is a template).
+    // Kind-guarded so an unrelated control whose label merely contains these words isn't swallowed.
+    if (w.kind == CW_TEXT && (std::strstr(name, "Viewport dimensions") || std::strstr(name, "Internal resolution"))) {
+        RenderReadout(name);
+        return true;
+    }
+    // Aspect ratio combobox — the broken ValuePointer combo (CW_COMBOBOX with no backing CVar).
+    if (w.kind == CW_COMBOBOX && cvar[0] == '\0' && std::strcmp(name, "Aspect Ratio") == 0) {
+        RenderAspect();
+        return true;
+    }
+    // Custom X/Y are folded into RenderAspect; suppress the standalone custom widget.
+    if (std::strcmp(name, "AspectRatioCustom") == 0) {
+        return true;
+    }
+    // The vertical-resolution + integer-scaling block.
+    if (std::strcmp(name, "MoreResolutionSettings") == 0) {
+        RenderMore();
+        return true;
+    }
+    // Advisory widgets whose PreFunc-driven visibility never runs in the overlay:
+    //  - FPS-drop notice: hidden (combo can't cheaply compute the interpolation target FPS).
+    //  - N64-mode notice + disable button: shown only while N64 (low-res) mode is active.
+    if (w.kind == CW_TEXT && std::strstr(name, "frame rate (FPS) drops")) {
+        return true; // hide
+    }
+    if ((w.kind == CW_TEXT && std::strstr(name, "is overriding these settings")) ||
+        (w.kind == CW_BUTTON && std::strcmp(name, "Click to disable N64 mode") == 0)) {
+        if (CVarGetInteger(CV_LOWRES, 0)) {
+            if (w.kind == CW_BUTTON) {
+                ComboMenu_PushButton(ComboMenu_ThemeColor());
+                if (ImGui::Button(name)) {
+                    CVarSetInteger(CV_LOWRES, 0);
+                    Save();
+                }
+                ComboMenu_PopButton();
+            } else {
+                ImGui::TextUnformatted(name);
+            }
+        }
+        return true;
+    }
+    return false;
+}
+
+} // namespace ComboRando

--- a/combo/gui/ComboResolutionEditor.h
+++ b/combo/gui/ComboResolutionEditor.h
@@ -1,0 +1,26 @@
+// combo/gui/ComboResolutionEditor.h
+//
+// ComboShip: combo-owned reimplementation of SoH's Advanced Resolution editor
+// (soh/soh/SohGui/ResolutionEditor.cpp). That editor is built from machinery the flat C-ABI
+// menu snapshot can't carry — dynamic PreFunc-updated names, a combobox bound to a C++ static
+// via ValuePointer (no CVar), WIDGET_CUSTOM draw lambdas, and a per-page MenuUpdate func that
+// syncs statics to CVars. So those widgets render broken in the overlay (empty "{}" readouts,
+// an empty-CVar combobox, placeholder customs, dead controls).
+//
+// We intercept those specific widgets by name/cvar and render combo-owned controls that
+// read/write the EFFECTIVE gSettings.AdvancedResolution.* CVars directly. libultraship's shared
+// Fast3dGui reads those CVars every frame (Fast3dGui.cpp:367) and applies them live, so no
+// game-side callback is needed and this works regardless of which game is foregrounded.
+//
+// UPSTREAM COUPLING (see docs/UPSTREAM_MERGES.md): this shadows specific vendored SoH widget
+// names and transcribes SoH's preset tables; a SoH menu rename must be re-synced here.
+#pragma once
+#include "ComboMenuABI.h"
+
+namespace ComboRando {
+
+// Returns true if `w` is an advanced-resolution widget handled here — in which case this has
+// already rendered the combo-owned replacement and the caller must skip its generic render.
+bool TryRenderResolutionWidget(const CwWidget& w);
+
+} // namespace ComboRando

--- a/combo/gui/ComboWidgetRender.cpp
+++ b/combo/gui/ComboWidgetRender.cpp
@@ -202,8 +202,8 @@ void RenderWidget(const CwWidget& w, const GameMenu& game) {
             float v = CVarGetFloat(w.cvar, w.fDefault);
             ComboMenu_PushSlider(themeColor);
             // As CW_SLIDER_INT: a float specifier in the name is the value overlay format.
-            if (w.name && (std::strstr(w.name, "%f") || std::strstr(w.name, "%.") ||
-                           std::strstr(w.name, "%g") || std::strstr(w.name, "%e"))) {
+            if (w.name && (std::strstr(w.name, "%f") || std::strstr(w.name, "%.") || std::strstr(w.name, "%g") ||
+                           std::strstr(w.name, "%e"))) {
                 ImGui::SetNextItemWidth(-FLT_MIN);
                 if (ImGui::SliderFloat("##v", &v, w.fMin, w.fMax, w.name)) {
                     CVarSetFloat(w.cvar, v);

--- a/combo/gui/ComboWidgetRender.cpp
+++ b/combo/gui/ComboWidgetRender.cpp
@@ -13,9 +13,10 @@
 // effective CVars by UpdateResolutionVars) do NOT apply through this generic CVar-write path.
 // Toggling them here writes the UI CVars but not the effective ones, so the viewport never changes.
 #include "ComboWidgetRender.h"
-#include "ComboMenuModel.h"   // GameMenu (resolved export fn-ptrs)
-#include "ComboWidgetStyle.h" // combo-owned replication of OOT UIWidgets menu styling
-#include "ComboAudioBridge.h" // Shared-tab audio -> MM mirror
+#include "ComboMenuModel.h"        // GameMenu (resolved export fn-ptrs)
+#include "ComboWidgetStyle.h"      // combo-owned replication of OOT UIWidgets menu styling
+#include "ComboAudioBridge.h"      // Shared-tab audio -> MM mirror
+#include "ComboResolutionEditor.h" // combo-owned Advanced Resolution editor (intercepts broken widgets)
 
 #include <libultraship/libultraship.h> // ImGui-adjacent + CVar bridge (CVarGet/Set*) + color.h
 #include <imgui.h>
@@ -129,6 +130,14 @@ void RenderAudioBackend(const CwWidget& w, const ImVec4& themeColor) {
 void RenderWidget(const CwWidget& w, const GameMenu& game) {
     // Unique id namespace per widget so two widgets sharing a display label don't collide.
     ImGui::PushID(w.index);
+
+    // ComboShip: SoH's Advanced Resolution editor doesn't survive the flat C-ABI (dynamic names,
+    // ValuePointer combo, custom-draw, per-page MenuUpdate). Intercept those widgets and render a
+    // combo-owned replacement over the effective gSettings.AdvancedResolution.* CVars instead.
+    if (TryRenderResolutionWidget(w)) {
+        ImGui::PopID();
+        return;
+    }
 
     // 1) preFunc disable eval (per frame): the game owns the predicate; we call it by index.
     bool disabled = false;

--- a/combo/gui/ComboWidgetRender.cpp
+++ b/combo/gui/ComboWidgetRender.cpp
@@ -23,6 +23,109 @@
 
 namespace ComboRando {
 
+namespace {
+// Human-readable backend names — mirror soh/.../MenuTypes.h windowBackendsMap / audioBackendsMap
+// (those live per-DLL and aren't linkable from comboui). Window ids are Fast::WindowBackend values.
+const char* WindowBackendName(int32_t id) {
+    switch (id) {
+        case 1:
+            return "DirectX"; // FAST3D_DXGI_DX11
+        case 2:
+            return "OpenGL"; // FAST3D_SDL_OPENGL
+        case 3:
+            return "Metal"; // FAST3D_SDL_METAL
+        default:
+            return "Unknown";
+    }
+}
+const char* AudioBackendName(Ship::AudioBackend b) {
+    switch (b) {
+        case Ship::AudioBackend::WASAPI:
+            return "Windows Audio Session API";
+        case Ship::AudioBackend::SDL:
+            return "SDL";
+        case Ship::AudioBackend::COREAUDIO:
+            return "Core Audio";
+        case Ship::AudioBackend::NUL:
+            return "Null";
+        default:
+            return "Unknown";
+    }
+}
+
+// CW_VIDEO_BACKEND: render-API selector. Mirrors SoH's WIDGET_VIDEO_BACKEND — writes the config
+// and saves; the change takes effect on relaunch (hence the native "Needs reload" label).
+void RenderVideoBackend(const CwWidget& w, const ImVec4& themeColor) {
+    auto ctx = Ship::Context::GetInstance();
+    if (!ctx || !ctx->GetWindow() || !ctx->GetConfig()) {
+        ImGui::TextDisabled("%s", (w.name && w.name[0]) ? w.name : "Renderer API");
+        return;
+    }
+    auto window = ctx->GetWindow();
+    auto avail = window->GetAvailableWindowBackends();
+    int32_t curId = ctx->GetConfig()->GetInt("Window.Backend.Id", -1);
+    if (!window->IsAvailableWindowBackend(curId)) {
+        curId = window->GetWindowBackend();
+    }
+    const char* label = (w.name && w.name[0]) ? w.name : "Renderer API";
+    const bool only = !avail || avail->size() <= 1;
+    if (only)
+        ImGui::BeginDisabled(true);
+    ComboMenu_PushCombobox(themeColor);
+    if (ImGui::BeginCombo(label, WindowBackendName(curId))) {
+        if (avail) {
+            for (int32_t id : *avail) {
+                const bool sel = (id == curId);
+                if (ImGui::Selectable(WindowBackendName(id), sel)) {
+                    ctx->GetConfig()->SetInt("Window.Backend.Id", id);
+                    ctx->GetConfig()->SetString("Window.Backend.Name", WindowBackendName(id));
+                    ctx->GetConfig()->Save();
+                }
+                if (sel)
+                    ImGui::SetItemDefaultFocus();
+            }
+        }
+        ImGui::EndCombo();
+    }
+    ComboMenu_PopCombobox();
+    if (only)
+        ImGui::EndDisabled();
+}
+
+// CW_AUDIO_BACKEND: audio-API selector. Mirrors SoH's WIDGET_AUDIO_BACKEND — applies live.
+void RenderAudioBackend(const CwWidget& w, const ImVec4& themeColor) {
+    auto ctx = Ship::Context::GetInstance();
+    if (!ctx || !ctx->GetAudio()) {
+        ImGui::TextDisabled("%s", (w.name && w.name[0]) ? w.name : "Audio API");
+        return;
+    }
+    auto audio = ctx->GetAudio();
+    auto avail = audio->GetAvailableAudioBackends();
+    const Ship::AudioBackend cur = audio->GetCurrentAudioBackend();
+    const char* label = (w.name && w.name[0]) ? w.name : "Audio API";
+    const bool only = !avail || avail->size() <= 1;
+    if (only)
+        ImGui::BeginDisabled(true);
+    ComboMenu_PushCombobox(themeColor);
+    if (ImGui::BeginCombo(label, AudioBackendName(cur))) {
+        if (avail) {
+            for (Ship::AudioBackend b : *avail) {
+                const bool sel = (b == cur);
+                if (ImGui::Selectable(AudioBackendName(b), sel)) {
+                    audio->SetCurrentAudioBackend(b);
+                }
+                if (sel)
+                    ImGui::SetItemDefaultFocus();
+            }
+        }
+        ImGui::EndCombo();
+    }
+    ComboMenu_PopCombobox();
+    if (only)
+        ImGui::EndDisabled();
+}
+} // namespace
+
 void RenderWidget(const CwWidget& w, const GameMenu& game) {
     // Unique id namespace per widget so two widgets sharing a display label don't collide.
     ImGui::PushID(w.index);
@@ -68,7 +171,18 @@ void RenderWidget(const CwWidget& w, const GameMenu& game) {
         case CW_SLIDER_INT: {
             int v = CVarGetInteger(w.cvar, w.iDefault);
             ComboMenu_PushSlider(themeColor);
-            if (ImGui::SliderInt(label, &v, w.iMin, w.iMax)) {
+            // Some sliders embed a printf format in the NAME (e.g. "Master Volume: %d %%"), meant
+            // to be the value overlay. Pass it as ImGui's format with a hidden label so the value
+            // renders on the slider (full width) instead of a literal "%d" label overflowing. Match
+            // an actual integer specifier (not just any '%') so a literal-percent label isn't fed to
+            // vsnprintf as a bogus format.
+            if (w.name && (std::strstr(w.name, "%d") || std::strstr(w.name, "%i"))) {
+                ImGui::SetNextItemWidth(-FLT_MIN);
+                if (ImGui::SliderInt("##v", &v, w.iMin, w.iMax, w.name)) {
+                    CVarSetInteger(w.cvar, v);
+                    changed = true;
+                }
+            } else if (ImGui::SliderInt(label, &v, w.iMin, w.iMax)) {
                 CVarSetInteger(w.cvar, v);
                 changed = true;
             }
@@ -78,7 +192,15 @@ void RenderWidget(const CwWidget& w, const GameMenu& game) {
         case CW_SLIDER_FLOAT: {
             float v = CVarGetFloat(w.cvar, w.fDefault);
             ComboMenu_PushSlider(themeColor);
-            if (ImGui::SliderFloat(label, &v, w.fMin, w.fMax)) {
+            // As CW_SLIDER_INT: a float specifier in the name is the value overlay format.
+            if (w.name && (std::strstr(w.name, "%f") || std::strstr(w.name, "%.") ||
+                           std::strstr(w.name, "%g") || std::strstr(w.name, "%e"))) {
+                ImGui::SetNextItemWidth(-FLT_MIN);
+                if (ImGui::SliderFloat("##v", &v, w.fMin, w.fMax, w.name)) {
+                    CVarSetFloat(w.cvar, v);
+                    changed = true;
+                }
+            } else if (ImGui::SliderFloat(label, &v, w.fMin, w.fMax)) {
                 CVarSetFloat(w.cvar, v);
                 changed = true;
             }
@@ -210,13 +332,10 @@ void RenderWidget(const CwWidget& w, const GameMenu& game) {
             break;
         }
         case CW_AUDIO_BACKEND:
-            // TODO: needs engine audio-backend enumeration (WindowBackend list). Few of these
-            // exist and they don't block the render milestone; wire later.
-            ImGui::TextDisabled("%s (audio backend selector — TODO)", w.name ? w.name : "");
+            RenderAudioBackend(w, themeColor);
             break;
         case CW_VIDEO_BACKEND:
-            // TODO: needs engine video-backend enumeration. See CW_AUDIO_BACKEND note.
-            ImGui::TextDisabled("%s (video backend selector — TODO)", w.name ? w.name : "");
+            RenderVideoBackend(w, themeColor);
             break;
         case CW_CUSTOM:
             // The game draws this entirely under its own context/RM, addressed by index.

--- a/docs/UPSTREAM_MERGES.md
+++ b/docs/UPSTREAM_MERGES.md
@@ -1185,3 +1185,31 @@ MM's identically-named dev windows were dropped (OOT boots first). (c) Dev-tool 
   MM's audio CVar names/scale change, update `kMap` in `ComboAudioBridge.cpp` (note: the OOT `Volume.*`
   defaults — Master 40, rest 100 — are duplicated in `kMap`'s `defaultPct` and must match
   SohMenuSettings.cpp, else an untouched slider reads as 0 and silences MM).
+
+## Combo-side Advanced Resolution editor (issue #26 #3, 2026-06-29)
+
+**Why:** SoH's Advanced Resolution editor (`soh/soh/SohGui/ResolutionEditor.cpp`) is built from
+machinery the flat C-ABI menu snapshot can't carry — dynamic `WIDGET_TEXT` names set per-frame by a
+`PreFunc`, an aspect-ratio combobox bound to a C++ static via `ValuePointer` (no CVar), two
+`WIDGET_CUSTOM` draw lambdas, and a per-page `UpdateResolutionVars` MenuUpdate func. In the overlay
+those widgets render broken (empty `{} x {}` readouts, an empty-CVar combobox, placeholder customs,
+dead aspect/enable controls). User chose a combo-side reimplementation (works regardless of which
+game is foreground) over a game-side custom-draw dependency.
+
+**Combo-owned (no vendored edits):**
+- `combo/gui/ComboResolutionEditor.{h,cpp}` — `TryRenderResolutionWidget(w)`, called at the top of
+  `ComboWidgetRender::RenderWidget`. Intercepts the resolution widgets **by name/cvar** and renders
+  combo controls over the effective `gSettings.AdvancedResolution.*` CVars (libultraship's shared
+  `Fast3dGui::ApplyResolutionChanges` reads them live each frame). Stateless per-frame: the CVars are
+  the source of truth. Live dims read from `Fast::Interpreter` via `Fast3dWindow::GetInterpreterWeak`.
+  Owns the Enable checkbox + calls `SaveConsoleVariablesNextFrame` after writes so changes persist.
+  Scope = core controls; niche extras (horizontal-res-field alt, NeverExceedBounds/ExceedBoundsBy,
+  IgnoreAspectCorrection) intentionally omitted.
+
+**On future merges (coupling — re-verify):** this **shadows specific SoH widget names** —
+`"Aspect Ratio"` (empty-cvar combo), `"AspectRatioCustom"`, `"MoreResolutionSettings"`, the
+`"Viewport dimensions"`/`"Internal resolution"` readout prefixes, the `"...is overriding these
+settings"` / `"Click to disable N64 mode"` advisories — and **transcribes SoH's preset tables**
+(aspect labels + X/Y, pixel-count labels + values, clamps). If SoH renames those widgets or changes
+the tables, re-sync `ComboResolutionEditor.cpp` (else the widgets silently fall back to the broken
+generic render). CVar prefix `gSettings.AdvancedResolution` comes from `CMake/lus-cvars.cmake`.

--- a/docs/UPSTREAM_MERGES.md
+++ b/docs/UPSTREAM_MERGES.md
@@ -1213,3 +1213,20 @@ settings"` / `"Click to disable N64 mode"` advisories — and **transcribes SoH'
 (aspect labels + X/Y, pixel-count labels + values, clamps). If SoH renames those widgets or changes
 the tables, re-sync `ComboResolutionEditor.cpp` (else the widgets silently fall back to the broken
 generic render). CVar prefix `gSettings.AdvancedResolution` comes from `CMake/lus-cvars.cmake`.
+
+## Inline controller bindings on Shared → Controls (issue #26 #1, 2026-06-29)
+
+**Why:** SoH's Controls page is popout-only (no inline bindings widget), so the combo overlay showed
+just a "Popout Bindings Window" button — the user had to detach a floating window to rebind.
+
+**Vendored (additive, `COMBO_BUILD`-guarded):**
+- `soh/soh/SohGui/SohMenuSettings.cpp` — a new "Controller Bindings Inline" `WIDGET_CUSTOM` in the
+  Controls section draws the "Configure Controller" (`SohInputEditorWindow`) inline, reusing the
+  issue #22 inline-window mechanism (get the registered `GuiWindow`; skip when `IsVisible()`/popped
+  out to avoid double-draw; `Update()` then `DrawElement()`). No foreground gate — the input editor
+  only touches the shared `ControlDeck`, not OOT play state.
+
+One inline editor (OOT's) covers both games: controls are shared `gSettings.Controllers.*` CVars and
+`MM_ReloadControls` reloads MM from them, and MM's Controls sidebar is hidden in the overlay (above),
+so no MM-side change is needed. **On future merges:** if SoH renames the "Configure Controller"
+window, update the name string here.

--- a/soh/soh/SohGui/SohMenuSettings.cpp
+++ b/soh/soh/SohGui/SohMenuSettings.cpp
@@ -456,6 +456,28 @@ void SohMenu::AddMenuSettings() {
         .WindowName("Configure Controller")
         .HideInSearch(true)
         .Options(WindowButtonOptions().Tooltip("Enables the separate Bindings Window."));
+#ifdef COMBO_BUILD
+    // ComboShip: draw the bindings inline in the combo menu (native SoH is popout-only, so the combo
+    // overlay otherwise showed only the button). Mirrors the dev-tool inline pattern
+    // (SohMenuDevTools.cpp ComboInlineWindow): skipped while popped out so the shared Gui loop's
+    // floating copy isn't double-drawn. No foreground gate — the editor only touches the shared
+    // ControlDeck, never OOT play state, so it's safe regardless of which game is foreground.
+    AddWidget(path, "Controller Bindings Inline", WIDGET_CUSTOM)
+        .RaceDisable(false)
+        .HideInSearch(true)
+        .CustomFunction([](WidgetInfo&) {
+            auto ctx = Ship::Context::GetInstance();
+            if (!ctx || !ctx->GetWindow() || !ctx->GetWindow()->GetGui()) {
+                return;
+            }
+            auto win = ctx->GetWindow()->GetGui()->GetGuiWindow("Configure Controller");
+            if (!win || win->IsVisible()) { // not registered, or popped out — don't double-draw
+                return;
+            }
+            win->Update(); // Gui loop only Updates visible windows; we draw it hidden, so Update first
+            win->DrawElement();
+        });
+#endif
 
     // Input Viewer
     path.sidebarName = "Input Viewer";


### PR DESCRIPTION
Adds the menu search bar and fixes the broken Shared-tab controls in the combo overlay.

- **Search bar** — global search across both games' settings, results in a multi-column grid in the active scope's content area.
- **Render API / Audio API selectors** — were TODO stubs; now functional backend comboboxes.
- **Volume sliders** — showed a literal `%d` and overflowed; now render the value on the slider.
- **Advanced Resolution** — reimplemented combo-side (live readouts, aspect ratio, vertical resolution, integer scaling) so the controls actually apply.
- **Controller bindings** — render inline in Shared → Controls instead of popout-only.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/7941016193.zip)
<!--- section:artifacts:end -->