### PR TITLE
Fix MM starting items (#39) and OOT items bought in MM shops (#40)

### DIFF
--- a/docs/UPSTREAM_MERGES.md
+++ b/docs/UPSTREAM_MERGES.md
@@ -1230,3 +1230,21 @@ One inline editor (OOT's) covers both games: controls are shared `gSettings.Cont
 `MM_ReloadControls` reloads MM from them, and MM's Controls sidebar is hidden in the overlay (above),
 so no MM-side change is needed. **On future merges:** if SoH renames the "Configure Controller"
 window, update the name string here.
+
+## MM starting items + OOT items in MM shops (issues #39 #40, 2026-07-01)
+
+**Why:** The combo MM save is created headless by `MM_InitRandoSaveFile`, which stored starting
+items but never granted them (#39). And `EnGirlA_RandoBuyFunc` granted shop items directly, bypassing
+the `RI_COMBO_FOREIGN` cross-delivery that `CheckQueue` uses, so OOT items bought in MM shops were
+never delivered or saved (#40).
+
+**Vendored (`COMBO_BUILD`-guarded):**
+- `mm/2s2h/BenPort.cpp` — `MM_InitRandoSaveFile` now calls `Rando::GrantStartingItems()` with
+  `gPlayState` forced `NULL`, baking items into the save like native `OnFileCreate` (whose `Item_Give`
+  null-guards make it headless-safe). The forced `NULL` defends against a stale eager-boot `gPlayState`.
+- `mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp` + `MiscBehavior.h` — `Rando_SendForeignCheck` exposed as
+  `Rando::MiscBehavior::SendForeignCheck` for reuse.
+- `mm/2s2h/Rando/ActorBehavior/EnGirlA.cpp` — `EnGirlA_RandoBuyFunc` routes `RI_COMBO_FOREIGN` through
+  `SendForeignCheck` (sets `obtained`+`cycleObtained`, skips local give).
+- `mm/2s2h/Rando/ConvertItem.cpp` — `IsItemObtainable` gains a `RI_COMBO_FOREIGN` case
+  (`!hasObtainedCheck`); without it foreign shop items stayed obtainable and restocked/re-delivered.

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -2683,12 +2683,17 @@ extern "C" __declspec(dllexport) void MM_InitRandoSaveFile(int fileNum, const ch
 
         Rando::Spoiler::ApplyToSaveContext(spoiler);
 
-        // ComboShip: record the chosen starting items in the save (mirrors OnFileCreate). NOTE: we do
-        // NOT call Rando::GrantStartingItems() — it needs gPlayState (Item_Give) and this runs headless,
-        // so starting items are stored in the rando struct but not pushed into inventory here.
+        // ComboShip: store the chosen starting items and bake them into inventory, like native
+        // OnFileCreate. Force gPlayState=NULL so GrantStartingItems takes Item_Give's null-guarded
+        // headless path (eager-MM-boot may leave a stale gPlayState); SaveManager flush below persists it.
         {
             auto startingItems = Rando::GetStartingItemsFromConfig();
             Rando::SetStartingItemsInSave(gSaveContext.save.shipSaveInfo.rando, startingItems);
+
+            PlayState* savedPlay = gPlayState;
+            gPlayState = NULL;
+            Rando::GrantStartingItems();
+            gPlayState = savedPlay;
         }
 
         // The two always-eligible starting checks (mirrors OnFileCreate tail).

--- a/mm/2s2h/Rando/ActorBehavior/EnGirlA.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGirlA.cpp
@@ -2,6 +2,9 @@
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/Rando/MiscBehavior/Traps.h"
+#ifdef COMBO_BUILD
+#include "2s2h/Rando/MiscBehavior/MiscBehavior.h" // ComboShip: SendForeignCheck for foreign shop items
+#endif
 
 extern "C" {
 #include "variables.h"
@@ -69,8 +72,17 @@ s32 EnGirlA_RandoCanBuyFunc(PlayState* play, EnGirlA* enGirlA) {
 void EnGirlA_RandoBuyFunc(PlayState* play, EnGirlA* enGirlA) {
     auto& randoSaveCheck = RANDO_SAVE_CHECKS[enGirlA->actor.world.rot.z];
     RandoItemId randoItemId = Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)enGirlA->actor.world.rot.z);
-    randoSaveCheck.obtained = true;
     Rupees_ChangeBy(-play->msgCtx.unk1206C);
+#ifdef COMBO_BUILD
+    // ComboShip: OOT-bound item — deliver cross-game instead of granting locally (mirrors CheckQueue).
+    if (randoSaveCheck.randoItemId == RI_COMBO_FOREIGN) {
+        randoSaveCheck.cycleObtained = true;
+        randoSaveCheck.obtained = true;
+        Rando::MiscBehavior::SendForeignCheck((RandoCheckId)enGirlA->actor.world.rot.z);
+        return;
+    }
+#endif
+    randoSaveCheck.obtained = true;
     if (randoItemId == RI_TRAP) {
         RollTrapType();
     }

--- a/mm/2s2h/Rando/ConvertItem.cpp
+++ b/mm/2s2h/Rando/ConvertItem.cpp
@@ -641,6 +641,11 @@ bool Rando::IsItemObtainable(RandoItemId randoItemId, RandoCheckId randoCheckId)
             ItemId itemId = StaticData::Items[randoItemId].itemId;
             return INV_CONTENT(itemId) != itemId;
         }
+#ifdef COMBO_BUILD
+        // ComboShip: foreign item is obtainable until its check is taken (keeps shops out of stock after buying).
+        case RI_COMBO_FOREIGN:
+            return !hasObtainedCheck;
+#endif
         default:
             break;
     }

--- a/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
@@ -47,10 +47,9 @@ const ComboRando::ForeignItem* Rando::MiscBehavior::MM_LookupForeign(RandoCheckI
     return it != g_mmForeignMap.end() ? &it->second : nullptr;
 }
 
-// ComboShip: divert a foreign-marked MM check into the cross-world mailbox instead of granting
-// locally. Enqueues the real item for its home game, shows a "Sent to Hyrule" toast, and persists
-// the save (the caller has already marked the check obtained).
-static void Rando_SendForeignCheck(RandoCheckId rc) {
+// ComboShip: deliver a foreign-marked check's real item to its home game, toast, and persist the
+// save (caller sets the obtained flags). Exposed so the shop buy path can reuse it.
+void Rando::MiscBehavior::SendForeignCheck(RandoCheckId rc) {
     int slot = gSaveContext.fileNum;
     if (slot != g_mmForeignSlot) {
         g_mmForeignMap = ComboRando::LoadForeignForGame(slot, ComboRando::GAME_MM);
@@ -116,7 +115,7 @@ void Rando::MiscBehavior::CheckQueue() {
                             randoSaveCheck.cycleObtained = true;
                             randoSaveCheck.obtained = true;
                             randoSaveCheck.eligible = false;
-                            Rando_SendForeignCheck((RandoCheckId)CUSTOM_ITEM_PARAM);
+                            Rando::MiscBehavior::SendForeignCheck((RandoCheckId)CUSTOM_ITEM_PARAM);
                             queued = false;
                             CUSTOM_ITEM_PARAM = RI_COMBO_FOREIGN;
                             return;

--- a/mm/2s2h/Rando/MiscBehavior/MiscBehavior.h
+++ b/mm/2s2h/Rando/MiscBehavior/MiscBehavior.h
@@ -19,6 +19,8 @@ void CheckQueueReset();
 // ComboShip: Returns the ForeignItem metadata for an MM check that holds a foreign OOT item,
 // or nullptr if the check is not foreign. Keyed by Checks[].name (RC_*), NOT CheckNames[rc].
 const ComboRando::ForeignItem* MM_LookupForeign(RandoCheckId rc);
+// ComboShip: deliver a foreign check's item to its home game + persist (caller sets obtained flags).
+void SendForeignCheck(RandoCheckId rc);
 #endif
 void InitFileSelect();
 void InitKaleidoItemPage();


### PR DESCRIPTION
Fixes #39 and #40.

## #39 — MM starting items not respected
The combo MM save is created headless by `MM_InitRandoSaveFile`, which stored the chosen starting items into `randoStartingItems[]` but never granted them into the inventory. It now calls `Rando::GrantStartingItems()` with `gPlayState` forced `NULL` — the same headless path native `OnFileCreate` uses in the file-select gamestate (`Item_Give`'s null-guards make it safe). The save flush at the end of the function persists the baked inventory.

## #40 — OOT items bought in MM shops not saved
`EnGirlA_RandoBuyFunc` granted shop items directly via `Rando::GiveItem`, bypassing the `RI_COMBO_FOREIGN` cross-delivery that `CheckQueue` uses — so an OOT item bought in an MM shop was never delivered to OOT nor saved. Now:
- `Rando_SendForeignCheck` is exposed as `Rando::MiscBehavior::SendForeignCheck` and reused by the shop buy path (single source of truth for deliver + save flush).
- `EnGirlA_RandoBuyFunc` routes `RI_COMBO_FOREIGN` through it (sets `obtained`+`cycleObtained`, skips the local give).
- `IsItemObtainable` gains an `RI_COMBO_FOREIGN` case (`!hasObtainedCheck`); without it the foreign shop item stayed obtainable and restocked/re-delivered on scene reload (dupe).

Scrubs and the racetrack already route through `eligible`→`CheckQueue`, so `EnGirlA_RandoBuyFunc` was the only broken shop path.

All deviations are `COMBO_BUILD`-guarded; changelog entry added to `docs/UPSTREAM_MERGES.md`.

## Testing
Built `2ship` in Debug (clean). In-game: configured starting items appear in a fresh MM save; an OOT item (song/boomerang) bought in an MM shop delivers to OOT and persists across the MM→OOT portal transition. Known/expected: a foreign item OOT can't hold yet (e.g. Deku Stick with stick capacity shuffled and not obtained) is silently dropped, matching vanilla `Item_Give` semantics.


<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8022687728.zip)
<!--- section:artifacts:end -->