### PR TITLE
Fix playthrough validator: credit foreign items + always report verdict

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -97,6 +97,10 @@ jobs:
         run: cmake --build build/x64 --target soh --config Release
       - name: Build 2ship
         run: cmake --build build/x64 --target 2ship --config Release
+      # Headless seed validator (pulls libultraship/soh/2ship as deps, already built above). Uploaded
+      # below so validate-seed.yml can download it from develop instead of doing its own build.
+      - name: Build comborando
+        run: cmake --build build/x64 --target comborando --config Release
       - name: Build comboui
         run: cmake --build build/x64 --target comboui --config Release
       - name: Build ComboShip
@@ -122,4 +126,15 @@ jobs:
         with:
           name: ComboShip-windows
           path: _packages/*.zip
+          if-no-files-found: error
+
+      # comborando.exe + its deployed runtime DLLs (no o2r — the reachability oracle needs none).
+      # validate-seed.yml downloads this from the latest successful develop run instead of rebuilding.
+      - name: Upload comborando validator
+        uses: actions/upload-artifact@v4
+        with:
+          name: comborando-windows
+          path: |
+            x64/Release/comborando.exe
+            x64/Release/*.dll
           if-no-files-found: error

--- a/.github/workflows/validate-seed.yml
+++ b/.github/workflows/validate-seed.yml
@@ -1,10 +1,11 @@
 name: Validate Seed
 
 # Label an issue `validate-seed` (with a ComboShip seed file attached) and this headlessly checks whether
-# the seed is completable, replying with an item-by-item verdict as a comment. Standalone from the artifact
-# build: it builds ONLY the comborando validator (which pulls libultraship/soh/2ship as deps) and runs it —
-# no window, no ROM, no o2r assets (the reachability oracle is pure logic). See docs/UPSTREAM_MERGES.md and
-# combo/ComboRandoHeadless.cpp.
+# the seed is completable, replying with an item-by-item verdict as a comment. It does NOT build: it
+# downloads the comborando validator from the latest successful develop "Build Artifacts" run and runs it
+# (no window, no ROM, no o2r assets — the reachability oracle is pure logic). If no such build is available
+# yet (e.g. a develop build is still in progress), it comments on the issue and stops. See
+# docs/UPSTREAM_MERGES.md and combo/ComboRandoHeadless.cpp.
 
 on:
   issues:
@@ -19,16 +20,15 @@ jobs:
   validate:
     if: github.event.label.name == 'validate-seed'
     runs-on: windows-2022
-    timeout-minutes: 90
+    timeout-minutes: 20
     permissions:
       issues: write
       contents: read
+      actions: read # gh run list/download from the develop Build Artifacts run
     steps:
-      - uses: actions/checkout@v5
-
       # The seed is an attachment on the issue: a save<N>-Randomizer-<hash>.json (see CrossForeign.h). Scrape
       # its user-attachments link out of the issue body and download it. No match -> comment + stop (the
-      # build is skipped via the `found` output below).
+      # download/run steps are skipped via the `found` output below).
       - name: Find & download the seed file
         id: seed
         shell: pwsh
@@ -58,43 +58,42 @@ jobs:
               issue_number: context.issue.number,
               body: "❌ **No seed file found.** Attach your `saveN-Randomizer-<hash>.json` to the issue, then re-apply the **validate-seed** label." });
 
-      - name: Set up MSVC
+      # Download the validator from the latest SUCCESSFUL develop "Build Artifacts" run — no build here.
+      # If none exists yet (or it predates the comborando artifact), ok=false -> comment + stop below.
+      - name: Fetch comborando from latest develop build
+        id: dl
         if: steps.seed.outputs.found == 'true'
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x64
-
-      - name: Set up Python
-        if: steps.seed.outputs.found == 'true'
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      # Reuse the same cache key as the artifact build so a warm develop cache primes this too; the
-      # incremental CMake build then only recompiles what actually changed (logic edits etc.).
-      - name: Cache build dir (vcpkg + CMake)
-        if: steps.seed.outputs.found == 'true'
-        uses: actions/cache@v5
-        with:
-          path: build/x64
-          key: build-x64-${{ hashFiles('CMakeLists.txt', 'CMake/**', 'libultraship/cmake/**') }}
-          restore-keys: build-x64-
-
-      - name: Configure
-        if: steps.seed.outputs.found == 'true'
+        shell: pwsh
         env:
-          VCPKG_ROOT: ${{ github.workspace }}/build/x64/vcpkg
-        run: cmake -B build/x64 -S . -G "Visual Studio 17 2022" -A x64
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $id = gh run list --repo $env:GITHUB_REPOSITORY --workflow build-artifacts.yml --branch develop --status success --limit 1 --json databaseId --jq '.[0].databaseId'
+          if (-not $id) {
+            Write-Host "No successful develop Build Artifacts run found."
+            "ok=false" | Out-File $env:GITHUB_OUTPUT -Append
+            exit 0
+          }
+          Write-Host "Downloading comborando-windows from develop run $id"
+          gh run download $id --repo $env:GITHUB_REPOSITORY --name comborando-windows --dir x64/Release
+          if (Test-Path x64/Release/comborando.exe) {
+            "ok=true" | Out-File $env:GITHUB_OUTPUT -Append
+          } else {
+            Write-Host "Artifact missing comborando.exe."
+            "ok=false" | Out-File $env:GITHUB_OUTPUT -Append
+          }
 
-      # Single target: comborando's add_dependencies pulls libultraship -> soh -> 2ship, so this one build
-      # produces the DLLs + the validator. No asset/o2r generation — unneeded for reachability.
-      - name: Build comborando
-        if: steps.seed.outputs.found == 'true'
-        run: cmake --build build/x64 --target comborando --config Release
+      - name: Comment — no develop build available
+        if: steps.seed.outputs.found == 'true' && steps.dl.outputs.ok != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: "⏳ **No `develop` validator build available yet.** A `Build Artifacts` run on `develop` may still be in progress (or hasn't produced a `comborando-windows` artifact). Re-apply the **validate-seed** label once it finishes." });
 
       - name: Run playthrough validation
         id: run
-        if: steps.seed.outputs.found == 'true'
+        if: steps.seed.outputs.found == 'true' && steps.dl.outputs.ok == 'true'
         shell: pwsh
         run: |
           Copy-Item spoiler.json x64/Release/spoiler.json -Force
@@ -108,7 +107,7 @@ jobs:
           exit 0
 
       - name: Upload full sphere log
-        if: steps.seed.outputs.found == 'true'
+        if: steps.seed.outputs.found == 'true' && steps.dl.outputs.ok == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: playthrough-log
@@ -118,7 +117,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Comment — verdict
-        if: steps.seed.outputs.found == 'true'
+        if: steps.seed.outputs.found == 'true' && steps.dl.outputs.ok == 'true'
         uses: actions/github-script@v7
         env:
           EXITCODE: ${{ steps.run.outputs.exitcode }}

--- a/.github/workflows/validate-seed.yml
+++ b/.github/workflows/validate-seed.yml
@@ -103,6 +103,9 @@ jobs:
           $code = $LASTEXITCODE
           Pop-Location
           "exitcode=$code" | Out-File $env:GITHUB_OUTPUT -Append
+          # A not-beatable (1) / tricks-only (3) verdict is a valid result, not a step failure —
+          # exit 0 so the upload + verdict-comment steps still run and report it.
+          exit 0
 
       - name: Upload full sphere log
         if: steps.seed.outputs.found == 'true'

--- a/combo/ComboRandoHeadless.cpp
+++ b/combo/ComboRandoHeadless.cpp
@@ -152,7 +152,6 @@ int main(int argc, char** argv) {
         flat["oot"] = spoiler.value("oot", nlohmann::json::object()).value("placements", nlohmann::json::object());
         flat["mm"] = spoiler.value("mm", nlohmann::json::object()).value("placements", nlohmann::json::object());
         flat["foreign"] = spoiler.value("foreign", nlohmann::json::array());
-        std::string flatStr = flat.dump();
         std::string label = SeedLabel(spoiler);
         uint32_t masterSeed = spoiler.value("masterSeed", 0u);
 
@@ -184,9 +183,23 @@ int main(int argc, char** argv) {
                 SOH_SetSeed(masterSeed);
             if (MM_SetSeed)
                 MM_SetSeed(masterSeed);
-            SOH_Dump();
-            MM_Dump();
-            return ComboRando::RunPlaythrough(flatStr, oot, mmO, label, MM_Restore);
+            // A real in-game save's placement map lists only SHUFFLED checks; non-shuffled items the
+            // oracle still gates on (OOT vanilla shop items, MM boss remains when not shuffled) live in
+            // the dump's fixed[]. Merge them in so those gates (e.g. MM RemainsCount for the Moon) resolve.
+            std::string sohDump = SOH_Dump(), mmDump = MM_Dump();
+            nlohmann::json passFlat = flat;
+            auto mergeFixed = [&](const std::string& dump, const char* game) {
+                try {
+                    for (auto& f : nlohmann::json::parse(dump).value("fixed", nlohmann::json::array())) {
+                        std::string chk = f.value("check", ""), item = f.value("item", "");
+                        if (!chk.empty() && !item.empty() && !passFlat[game].contains(chk))
+                            passFlat[game][chk] = item;
+                    }
+                } catch (...) {}
+            };
+            mergeFixed(sohDump, "oot");
+            mergeFixed(mmDump, "mm");
+            return ComboRando::RunPlaythrough(passFlat.dump(), oot, mmO, label, MM_Restore);
         };
         // Names the blocking win side from full-inventory reachability, so "stuck" is exact.
         auto blocked = [](const ComboRando::PlaythroughResult& r) -> const char* {

--- a/combo/rando/ComboPlaythrough.h
+++ b/combo/rando/ComboPlaythrough.h
@@ -51,6 +51,7 @@ inline PlaythroughResult RunPlaythrough(const std::string& spoilerJson, const Or
     std::vector<Placed> placements;
     std::unordered_set<std::string> foreignKey;
     std::unordered_map<std::string, GameId> foreignItemGame;
+    std::unordered_map<std::string, std::string> foreignItemName;
     try {
         auto j = nlohmann::json::parse(spoilerJson);
         for (auto& fm : j.value("foreign", nlohmann::json::array())) {
@@ -58,14 +59,21 @@ inline PlaythroughResult RunPlaythrough(const std::string& spoilerJson, const Or
             std::string ig = fm.value("itemGame", "");
             foreignKey.insert(cg + ":" + cn);
             foreignItemGame[cg + ":" + cn] = (ig == "mm") ? GAME_MM : GAME_OOT;
+            foreignItemName[cg + ":" + cn] = fm.value("itemName", "");
         }
         auto addGame = [&](const char* key, GameId cg) {
             if (!j.contains(key) || !j[key].is_object())
                 return;
             for (auto& [cn, iv] : j[key].items()) {
                 std::string fk = std::string(key) + ":" + cn;
-                GameId ig = foreignKey.count(fk) ? foreignItemGame[fk] : cg;
-                placements.push_back({ cg, cn, ig, iv.get<std::string>() });
+                bool isForeign = foreignKey.count(fk) > 0;
+                GameId ig = isForeign ? foreignItemGame[fk] : cg;
+                // A foreign item's placement-map value is its human DISPLAY name, but the owning game's
+                // oracle keys on its internal name (MM: RI_*). Prefer the foreign entry's itemName so the
+                // item is actually credited when handed to that oracle.
+                std::string item =
+                    (isForeign && !foreignItemName[fk].empty()) ? foreignItemName[fk] : iv.get<std::string>();
+                placements.push_back({ cg, cn, ig, item });
             }
         };
         addGame("oot", GAME_OOT);

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1640,6 +1640,26 @@ extern "C" __declspec(dllexport) void SOH_InitRandoHeadless() {
     OTRGlobals::Instance->gRandoContext->InitStaticData();
     Rando::Settings::GetInstance()->AssignContext(OTRGlobals::Instance->gRandoContext);
     Rando::StaticData::InitItemTable();
+    // These location-table registrations normally run as RegisterShipInitFunc callbacks during full boot
+    // (ShipInit::InitAll), which headless skips — so without them pots/grass/crates/freestanding/etc. checks
+    // don't exist and any seed shuffling them is massively under-modeled (the validator would call it
+    // unbeatable). They're pure data (no assets/RM), so call them directly here.
+    Rando::StaticData::RegisterSongLocations();
+    Rando::StaticData::RegisterBeehiveLocations();
+    Rando::StaticData::RegisterCowLocations();
+    Rando::StaticData::RegisterFishLocations();
+    Rando::StaticData::RegisterFairyLocations();
+    Rando::StaticData::RegisterPotLocations();
+    Rando::StaticData::RegisterFreestandingLocations();
+    Rando::StaticData::RegisterGrassLocations();
+    Rando::StaticData::RegisterCrateLocations();
+    Rando::StaticData::RegisterRockLocations();
+    Rando::StaticData::RegisterTreeLocations();
+    Rando::StaticData::RegisterSignLocations();
+    Rando::StaticData::RegisterWonderItemLocations();
+    Rando::StaticData::RegisterBeggarLocations();
+    Rando::StaticData::RegisterIcicleLocations();
+    Rando::StaticData::RegisterRedIceLocations();
     // Build the option/trick tables (normally the rando menu's job, which headless lacks) so a spoiler's
     // settings can reach the Context. Option/trick display names route through Lang::Translate, which
     // returns the raw key headless (via gComboHeadlessRando) — no assets needed.


### PR DESCRIPTION
Follow-up to #54. Three fixes surfaced by the first real `validate-seed` run (issue #55).

**1. Foreign items were credited by display name, not the oracle's internal name.**
The consolidated save stores an MM item on an OOT check by its human display name ("Deku Mask"), but the MM oracle keys on the internal `RI_*` name — so 382 MM items were never credited and MM stalled at Clock Town. `RunPlaythrough` now uses `foreign[].itemName` for foreign checks. No-op for comborando-generated spoilers (names coincide).

**2. The dump's `fixed[]` placements were ignored.**
Non-shuffled MM boss remains and OOT vanilla-shop items live in the dump's `fixed[]`, not the spoiler's placement map. The Moon's `RemainsCount` gate could never be satisfied. The `--playthrough` path now merges each dump's `fixed[]` into the placement set. Together with (1): MM unreachable 430 → 56.

**3. The action swallowed its own verdict.**
`comborando` exits 1 (not beatable) / 3 (tricks-only) as valid verdicts, which failed the run step and skipped the artifact-upload + verdict-comment steps — so no verdict was ever posted. The step now captures `$LASTEXITCODE` and `exit 0`s so the result is always reported.

**Known limitation (not addressed here):** the headless world is built from base settings, so seeds using heavy location-shuffle or entrance randomization are under-modeled and can still report a false "not beatable". Tracked separately.


<!--- section:artifacts:start -->
### Build Artifacts
  - [comborando-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8186334412.zip)
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8186333689.zip)
<!--- section:artifacts:end -->