### PR TITLE
Harden dormant co-op item sync

### DIFF
--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -173,7 +173,10 @@ static FnExtract MM_Extract = nullptr;
 static FnInt MM_ArchiveCount = nullptr;
 static FnSetSaveCallback SOH_SetOnNewSaveCallback = nullptr;
 static FnSetSaveCallback SOH_SetOnLoadSaveCallback = nullptr;
-static FnMMInitSave MM_InitSaveFile = nullptr;
+typedef void (*FnMMInitSaveNamed)(int, const unsigned char*);
+typedef void (*FnGetPlayerName)(unsigned char*);
+static FnMMInitSaveNamed MM_InitSaveFile = nullptr;
+static FnGetPlayerName SOH_GetCurrentPlayerName = nullptr;
 static FnMMInitSave MM_LoadSaveForCombo = nullptr;
 // OOT slot whose MM save is live in MM's dormant memory (-1 = none). Guards Combo_OnOOTSaveLoad
 // against reloading stale disk state over MM's in-memory progress after round trips.
@@ -293,7 +296,7 @@ static void DeleteForeignSaveFromMM(int slot) {
 // ComboShip: placement injection exports
 typedef void (*FnSetGenerateCb)(void (*)(int));
 typedef void (*FnApplyPlacements)(const char*);
-typedef void (*FnMMInitRandoSave)(int, const char*);
+typedef void (*FnMMInitRandoSave)(int, const char*, const unsigned char*);
 typedef void (*FnSetComboRandoSeed)(uint64_t);
 typedef void (*FnSetComboSeedHash)(uint32_t);
 static FnSetGenerateCb SOH_SetOnComboGenerateCallback = nullptr;
@@ -1205,14 +1208,19 @@ static void Combo_OnOOTSaveInit(int fileNum) {
             sf << g_ConsolidatedJson;
         std::cout << "[ComboShip] wrote consolidated seed file for slot " << fileNum << std::endl;
     }
+    // The new-save callback runs on OOT's thread with the entered file name current — carry it into
+    // the matching MM save so both files show the player's name.
+    unsigned char playerName[8] = { 0x3E, 0x3E, 0x3E, 0x3E, 0x3E, 0x3E, 0x3E, 0x3E };
+    if (SOH_GetCurrentPlayerName)
+        SOH_GetCurrentPlayerName(playerName);
     if (MM_InitRandoSaveFile && !g_PendingMMPlacements.empty()) {
         std::cout << "[ComboShip] Creating RANDO MM save for OOT slot " << fileNum << std::endl;
-        MM_InitRandoSaveFile(fileNum, g_PendingMMPlacements.c_str());
+        MM_InitRandoSaveFile(fileNum, g_PendingMMPlacements.c_str(), playerName);
         g_PendingMMPlacements.clear();
     } else if (MM_InitSaveFile) {
         // No placement available (e.g. generation was skipped) — fall back to a vanilla MM save.
         std::cout << "[ComboShip] Creating MM save for OOT slot " << fileNum << std::endl;
-        MM_InitSaveFile(fileNum);
+        MM_InitSaveFile(fileNum, playerName);
     }
     // Both creation paths build the save in MM's live gSaveContext.
     g_MmSaveInMemorySlot = fileNum;
@@ -1369,7 +1377,8 @@ int main(int argc, char** argv) {
     MM_ArchiveCount = (FnInt)GetSym(mmModule, "MM_ArchiveCount");
     SOH_SetOnNewSaveCallback = (FnSetSaveCallback)GetSym(sohModule, "SOH_SetOnNewSaveCallback");
     SOH_SetOnLoadSaveCallback = (FnSetSaveCallback)GetSym(sohModule, "SOH_SetOnLoadSaveCallback");
-    MM_InitSaveFile = (FnMMInitSave)GetSym(mmModule, "MM_InitSaveFile");
+    MM_InitSaveFile = (FnMMInitSaveNamed)GetSym(mmModule, "MM_InitSaveFile");
+    SOH_GetCurrentPlayerName = (FnGetPlayerName)GetSym(sohModule, "SOH_GetCurrentPlayerName");
     MM_LoadSaveForCombo = (FnMMInitSave)GetSym(mmModule, "MM_LoadSaveForCombo");
     SOH_SetOnSceneSwitchCallback = (FnSetSceneSwitchCallback)GetSym(sohModule, "SOH_SetOnSceneSwitchCallback");
     MM_RunGame = (FnMMRunGame)GetSym(mmModule, "MM_RunGame");

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -1614,6 +1614,8 @@ int main(int argc, char** argv) {
         SOH_SetPumpDormant(PumpDormant);
     if (MM_SetPumpDormant)
         MM_SetPumpDormant(PumpDormant);
+    std::cout << "[ComboShip] Dormant co-op pump seams: soh=" << (SOH_SetPumpDormant && SOH_Anchor_PumpDormant)
+              << " mm=" << (MM_SetPumpDormant && MM_Anchor_PumpDormant) << std::endl;
     if (SOH_SetFinalBossDefeatedCb)
         SOH_SetFinalBossDefeatedCb(Combo_OnFinalBossDefeated);
     if (MM_SetFinalBossDefeatedCb)

--- a/docs/UPSTREAM_MERGES.md
+++ b/docs/UPSTREAM_MERGES.md
@@ -249,7 +249,7 @@ lives in port code (`BenPort.cpp`), and placement is fed through MM's *existing*
 (`GeneratePools`/logic) is never run.
 
 **2ship.dll export added (`mm/2s2h/BenPort.cpp`, `extern "C" __declspec(dllexport)`):**
-- `MM_InitRandoSaveFile(int fileNum, const char* placementJson)` — creates a RANDO MM save for the
+- `MM_InitRandoSaveFile(int fileNum, const char* placementJson, const unsigned char* ootName8)` — creates a RANDO MM save for the
   given OOT slot from the combined spoiler's `"mm"` slice (`{ "<RC_name>": "<itemSpoilerName>", ... }`):
   1. `SaveManager_InitNewSaveForSlot(fileNum + 1)` — playable combo baseline (Human Link, South Clock
      Town, ocarina/songs), then restore `gSaveContext.fileNum = fileNum` (Sram_InitNewSave reset it) so
@@ -267,7 +267,9 @@ lives in port code (`BenPort.cpp`), and placement is fed through MM's *existing*
   so a generator failure can't reuse a stale slice).
 - `Combo_OnOOTSaveInit` calls `MM_InitRandoSaveFile(fileNum, g_PendingMMPlacements)` when a placement is
   stashed (the generate callback fires earlier in the same new-save flow), else falls back to the vanilla
-  `MM_InitSaveFile`. Resolves the new `MM_InitRandoSaveFile` symbol from `2ship.dll`.
+  `MM_InitSaveFile`. Resolves the new `MM_InitRandoSaveFile` symbol from `2ship.dll`. Both init exports
+  also take the OOT-entered file name (`SOH_GetCurrentPlayerName`, same font codes in both games) so the
+  MM save is created with the player's name instead of the LINK default.
 
 ## Cross-World Randomizer — Increment 6: foreign markers + send interception + real grants (2026-06-04)
 

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -2650,10 +2650,11 @@ extern "C" __declspec(dllexport) void MM_ResumeGame(int fileNum) {
 #endif
 
 // ComboShip: write a default MM save for the given OOT slot (0-indexed) to disk. Called when OOT
-// creates a new save, so MM has a matching save ready for the transition.
-extern "C" __declspec(dllexport) void MM_InitSaveFile(int fileNum) {
+// creates a new save, so MM has a matching save ready for the transition. ootName8 is the
+// OOT-entered file name (8 font-code bytes, same charset as MM); may be null.
+extern "C" __declspec(dllexport) void MM_InitSaveFile(int fileNum, const unsigned char* ootName8) {
     // fileNum is OOT's 0-indexed slot; MM save files are 1-indexed (file1.json, file2.json, file3.json)
-    SaveManager_InitNewSaveForSlot(fileNum + 1);
+    SaveManager_InitNewSaveForSlot(fileNum + 1, ootName8);
 }
 
 // ComboShip: bring the MM save for the given OOT slot (0-indexed) into MM's dormant gSaveContext, so
@@ -2669,9 +2670,10 @@ extern "C" __declspec(dllexport) void MM_LoadSaveForCombo(int fileNum) {
 // (South Clock Town, post-first-cycle Human Link), mark the save SAVETYPE_RANDO, and feed the placement
 // through Rando::Spoiler::ApplyToSaveContext. Headless-safe: never calls GrantStartingItems / Item_Give
 // (those need gPlayState). Falls back to a vanilla save on any error.
-extern "C" __declspec(dllexport) void MM_InitRandoSaveFile(int fileNum, const char* placementJson) {
+extern "C" __declspec(dllexport) void MM_InitRandoSaveFile(int fileNum, const char* placementJson,
+                                                           const unsigned char* ootName8) {
     // Playable combo baseline first (Human Link, South Clock Town, ocarina/songs, etc.).
-    SaveManager_InitNewSaveForSlot(fileNum + 1);
+    SaveManager_InitNewSaveForSlot(fileNum + 1, ootName8);
     // Sram_InitNewSave (inside the call above) resets fileNum; restore it so SaveManager_SaveCurrentForCombo
     // re-writes the correct slot (it targets gSaveContext.fileNum + 1).
     gSaveContext.fileNum = (s16)fileNum;

--- a/mm/2s2h/Network/Anchor/MMAnchor.cpp
+++ b/mm/2s2h/Network/Anchor/MMAnchor.cpp
@@ -165,6 +165,7 @@ void MMAnchor::SendJson(nlohmann::json payload) {
         ownClientId = (uint32_t)CVarGetInteger(kCvarLastClientId, 0); // late-cache fallback
     }
     payload["clientId"] = ownClientId;
+    payload["srcGame"] = "mm"; // shared socket carries both games; receivers filter on this
     gMMComboAnchorSend(payload.dump().c_str());
 }
 
@@ -177,6 +178,12 @@ void MMAnchor::OnIncomingJson(const std::string& payload) {
         return;
     }
     if (!j.contains("type")) {
+        return;
+    }
+    // Drop OOT-originated packets — their shapes collide with ours (GIVE_ITEM, UPDATE_TEAM_STATE...).
+    // Exceptions: cross-game item delivery and the room roster. No srcGame (server) passes through.
+    std::string type = j["type"].get<std::string>();
+    if (j.value("srcGame", "mm") != "mm" && type != PKT_CROSS_ITEM && type != PKT_UPDATE_CLIENT_STATE) {
         return;
     }
     std::lock_guard<std::mutex> lock(incomingMutex);
@@ -715,6 +722,9 @@ void MMAnchor::HandlePacket_UpdateTeamState(nlohmann::json& payload) {
     if (!roomState.syncItemsAndFlags || !payload.contains("state")) {
         return;
     }
+    if (!payload["state"].contains("shipSaveInfo")) {
+        return; // soh-shaped team state; from_json(Save) would throw
+    }
 
     // Unpack the compact rando check array back into the shape from_json(Save) expects.
     if (IS_RANDO && payload["state"]["shipSaveInfo"].contains("rando")) {
@@ -791,6 +801,12 @@ void MMAnchor::HandlePacket_UpdateTeamState(nlohmann::json& payload) {
 
 extern "C" __declspec(dllexport) void MM_SetAnchorSend(void (*cb)(const char*)) {
     gMMComboAnchorSend = cb;
+    // Create the adapter now (launcher startup, pre-connect). It used to be created on first
+    // Activate, so a client that never entered MM had no instance and RecvJson/PumpDormant dropped
+    // every packet — teammate MM items never reached the dormant MM save.
+    if (MMAnchor::Instance == nullptr) {
+        MMAnchor::Instance = new MMAnchor();
+    }
 }
 
 // A6: launcher registers its per-frame dormant-pump fn; MM calls it each active frame (see hook).

--- a/mm/2s2h/Network/Anchor/MMAnchor.cpp
+++ b/mm/2s2h/Network/Anchor/MMAnchor.cpp
@@ -232,7 +232,8 @@ void MMAnchor::PumpDormant() {
         nlohmann::json payload = toProcess.front();
         toProcess.pop();
         try {
-            if (payload.value("type", std::string()) == PKT_GIVE_ITEM) {
+            if (payload.value("type", std::string()) == PKT_GIVE_ITEM && payload.contains("randoCheckId")) {
+                SPDLOG_INFO("[MMAnchor] dormant GIVE_ITEM received: {}", payload.dump());
                 ApplyDormantGiveItem(payload);
             }
         } catch (const std::exception& e) { SPDLOG_ERROR("[MMAnchor] dormant apply exception: {}", e.what()); }
@@ -247,23 +248,31 @@ void MMAnchor::ApplyDormantGiveItem(const nlohmann::json& payload) {
         return; // reject soh's GIVE_ITEM (modId shape, different item-id space)
     }
     if (payload.value("targetTeamId", std::string("default")) != CVarGetString(kCvarTeamId, "default")) {
+        SPDLOG_INFO("[MMAnchor] dormant GIVE_ITEM dropped: team mismatch");
         return;
     }
-    if (payload.value("clientId", (uint32_t)0) == ownClientId) {
+    uint32_t clientId = payload.value("clientId", (uint32_t)0);
+    // Only a NONZERO match is our own echo — dormant MM may still have ownClientId 0, and a sender
+    // that hasn't been assigned an id yet also stamps 0; 0==0 must not drop a teammate's item.
+    if (clientId != 0 && clientId == ownClientId) {
         return;
     }
     int32_t checkId = payload.value("randoCheckId", -1);
     RandoCheckId rc = (checkId >= 0 && checkId < RC_MAX) ? (RandoCheckId)checkId : RC_UNKNOWN;
-    if (rc != RC_UNKNOWN && RANDO_SAVE_CHECKS[rc].obtained) {
+    if (rc == RC_UNKNOWN) {
+        SPDLOG_INFO("[MMAnchor] dormant GIVE_ITEM dropped: bad check id {}", checkId);
+        return; // no check to mark obtained -> no idempotency; a real sender always has one
+    }
+    if (RANDO_SAVE_CHECKS[rc].obtained) {
+        SPDLOG_INFO("[MMAnchor] dormant GIVE_ITEM dropped: check {} already obtained", checkId);
         return; // idempotent: already collected locally
     }
     RandoItemId rid = Rando::ConvertItem((RandoItemId)payload.value("getItemId", (int)RI_JUNK), rc);
-    if (rc != RC_UNKNOWN) {
-        RANDO_SAVE_CHECKS[rc].obtained = true;
-        RANDO_SAVE_CHECKS[rc].cycleObtained = true;
-        RANDO_SAVE_CHECKS[rc].eligible = false;
-    }
+    RANDO_SAVE_CHECKS[rc].obtained = true;
+    RANDO_SAVE_CHECKS[rc].cycleObtained = true;
+    RANDO_SAVE_CHECKS[rc].eligible = false;
     Combo_MM_GiveDormantResolved(rid);
+    SPDLOG_INFO("[MMAnchor] dormant GIVE_ITEM applied: check={} item={} (persisted)", checkId, (int)rid);
 }
 
 // MARK: - Client state
@@ -493,6 +502,7 @@ void MMAnchor::HandlePacket_DamagePlayer(const nlohmann::json& payload) {
 
 void MMAnchor::SendPacket_GiveItem(int16_t randoItemId, int32_t randoCheckId) {
     if (!isActive || !roomState.syncItemsAndFlags) {
+        SPDLOG_INFO("[MMAnchor] GIVE_ITEM not sent: active={} syncItems={}", isActive, roomState.syncItemsAndFlags);
         return;
     }
     nlohmann::json payload;
@@ -501,6 +511,7 @@ void MMAnchor::SendPacket_GiveItem(int16_t randoItemId, int32_t randoCheckId) {
     payload["getItemId"] = randoItemId;     // RAW rando item id; receiver ConvertItems for its own state
     payload["randoCheckId"] = randoCheckId; // so receivers can mark the check obtained (no double-collect)
     SendJson(payload);
+    SPDLOG_INFO("[MMAnchor] GIVE_ITEM sent: check={} item={}", randoCheckId, randoItemId);
 }
 
 void MMAnchor::HandlePacket_GiveItem(const nlohmann::json& payload) {

--- a/mm/2s2h/Network/Anchor/MMAnchor.cpp
+++ b/mm/2s2h/Network/Anchor/MMAnchor.cpp
@@ -165,7 +165,8 @@ void MMAnchor::SendJson(nlohmann::json payload) {
         ownClientId = (uint32_t)CVarGetInteger(kCvarLastClientId, 0); // late-cache fallback
     }
     payload["clientId"] = ownClientId;
-    payload["srcGame"] = "mm"; // shared socket carries both games; receivers filter on this
+    // Routing tag for the shared socket; NOT the cross-item "srcGame" int field (don't clobber it).
+    payload["originGame"] = "mm";
     gMMComboAnchorSend(payload.dump().c_str());
 }
 
@@ -181,9 +182,9 @@ void MMAnchor::OnIncomingJson(const std::string& payload) {
         return;
     }
     // Drop OOT-originated packets — their shapes collide with ours (GIVE_ITEM, UPDATE_TEAM_STATE...).
-    // Exceptions: cross-game item delivery and the room roster. No srcGame (server) passes through.
+    // Exceptions: cross-game item delivery and the room roster. No originGame (server) passes through.
     std::string type = j["type"].get<std::string>();
-    if (j.value("srcGame", "mm") != "mm" && type != PKT_CROSS_ITEM && type != PKT_UPDATE_CLIENT_STATE) {
+    if (j.value("originGame", "mm") != "mm" && type != PKT_CROSS_ITEM && type != PKT_UPDATE_CLIENT_STATE) {
         return;
     }
     std::lock_guard<std::mutex> lock(incomingMutex);

--- a/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
@@ -39,7 +39,9 @@ const ComboRando::ForeignItem* Rando::MiscBehavior::MM_LookupForeign(RandoCheckI
     int slot = gSaveContext.fileNum;
     if (slot == 0xFF)
         return nullptr; // no real save loaded (title screen sentinel)
-    if (slot != g_mmForeignSlot) {
+    // Retry while empty: a lookup can land between CleanSlotFiles and the new consolidated file
+    // being written (in-session generation) — don't cache that window forever.
+    if (slot != g_mmForeignSlot || g_mmForeignMap.empty()) {
         g_mmForeignMap = ComboRando::LoadForeignForGame(slot, ComboRando::GAME_MM);
         g_mmForeignSlot = slot;
     }
@@ -51,7 +53,7 @@ const ComboRando::ForeignItem* Rando::MiscBehavior::MM_LookupForeign(RandoCheckI
 // save (caller sets the obtained flags). Exposed so the shop buy path can reuse it.
 void Rando::MiscBehavior::SendForeignCheck(RandoCheckId rc) {
     int slot = gSaveContext.fileNum;
-    if (slot != g_mmForeignSlot) {
+    if (slot != g_mmForeignSlot || g_mmForeignMap.empty()) {
         g_mmForeignMap = ComboRando::LoadForeignForGame(slot, ComboRando::GAME_MM);
         g_mmForeignSlot = slot;
     }

--- a/mm/2s2h/SaveManager/SaveManager.cpp
+++ b/mm/2s2h/SaveManager/SaveManager.cpp
@@ -136,9 +136,16 @@ void SaveManager_WriteSaveFile(const std::filesystem::path& fileName, nlohmann::
     } catch (...) { SPDLOG_ERROR("[ComboShip] Failed to write save file {}", filePath.string()); }
 }
 
-void SaveManager_InitNewSaveForSlot(int mmFileNum) {
+void SaveManager_InitNewSaveForSlot(int mmFileNum, const unsigned char* ootName8) {
     Sram_InitNewSave();
 #ifdef COMBO_BUILD
+    // ComboShip: carry the OOT-entered file name over (same font codes in both games; anything
+    // outside the shared 0x00-0x3F range, e.g. JP glyphs, becomes a space).
+    if (ootName8 != nullptr) {
+        for (int i = 0; i < 8; i++) {
+            gSaveContext.save.saveInfo.playerData.playerName[i] = (ootName8[i] <= 0x3F) ? ootName8[i] : 0x3E;
+        }
+    }
     // ComboShip: a fresh MM save is always entered mid-playthrough from OOT, never via MM's title/intro.
     // Set it up post-first-cycle — Human Link in South Clock Town, no intro, no Tatl arrival — mirroring
     // the SkipIntroSequence + SkipFirstCycle enhancements and the Rando port's OnFileCreate. gPlayState

--- a/mm/2s2h/SaveManager/SaveManager.h
+++ b/mm/2s2h/SaveManager/SaveManager.h
@@ -11,7 +11,7 @@ bool SaveManager_HandleFileDropped(char* filePath);
 bool BinarySaveConverter_HandleFileDropped(char* filePath);
 int SaveManager_GetOpenFileSlot();
 void SaveManager_WriteSaveFile(const std::filesystem::path& fileName, nlohmann::json j);
-void SaveManager_InitNewSaveForSlot(int mmFileNum);
+void SaveManager_InitNewSaveForSlot(int mmFileNum, const unsigned char* ootName8 = nullptr);
 void SaveManager_LoadSaveFile(int mmFileNum);
 void SaveManager_SaveCurrentForCombo();
 #else

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -414,7 +414,9 @@ static std::unordered_map<std::string, ComboRando::ForeignItem> g_ootForeignMap;
 
 // ComboShip: also used by MerchantMessages/check tracker to show the real foreign item name.
 const ComboRando::ForeignItem* OOT_LookupForeign(int slot, const std::string& checkName) {
-    if (slot != g_ootForeignSlot) {
+    // Retry while empty: in-session generation queries names for this slot after CleanSlotFiles but
+    // before save creation writes the new consolidated file — don't cache that window forever.
+    if (slot != g_ootForeignSlot || g_ootForeignMap.empty()) {
         g_ootForeignMap = ComboRando::LoadForeignForGame(slot, ComboRando::GAME_OOT);
         g_ootForeignSlot = slot;
     }

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -2236,6 +2236,12 @@ void InternalRecalculateAvailableChecks(RandomizerRegion startingRegion, RandoAg
     if (!enableAvailableChecks || !GameInteractor::IsSaveLoaded()) {
         return;
     }
+#ifdef COMBO_BUILD
+    // ComboShip: drawn as a dormant peek from the other game's thread; no play state to walk from.
+    if (gPlayState == nullptr) {
+        return;
+    }
+#endif
 
     ResetPerformanceTimer(PT_RECALCULATE_AVAILABLE_CHECKS);
     StartPerformanceTimer(PT_RECALCULATE_AVAILABLE_CHECKS);

--- a/soh/soh/Network/Anchor/Anchor.cpp
+++ b/soh/soh/Network/Anchor/Anchor.cpp
@@ -149,7 +149,8 @@ void Anchor::SendJsonToRemote(nlohmann::json payload) {
     // ComboShip: the launcher owns the socket and its own thread-safe outgoing queue, so hand every
     // packet straight to it. There is no game-side network thread to drain a local queue under the
     // combo build (ProcessOutgoingPackets is never pumped). See docs/UPSTREAM_MERGES.md.
-    payload["srcGame"] = "oot"; // shared socket carries both games; receivers filter on this
+    // Routing tag for the shared socket; NOT the cross-item "srcGame" int field (don't clobber it).
+    payload["originGame"] = "oot";
     Network::SendJsonToRemote(payload);
     return;
 #else
@@ -180,8 +181,8 @@ void Anchor::OnIncomingJson(nlohmann::json payload) {
 #ifdef COMBO_BUILD
     // ComboShip: drop MM-originated packets — their shapes collide with ours (e.g. MM's
     // UPDATE_TEAM_STATE lacks healthCapacity and throws in from_json). Exceptions: cross-game item
-    // delivery and the room roster. Packets without srcGame (server, old clients) pass through.
-    if (payload.value("srcGame", "oot") != "oot" && packetType != COMBO_CROSS_ITEM &&
+    // delivery and the room roster. Packets without originGame (server, old clients) pass through.
+    if (payload.value("originGame", "oot") != "oot" && packetType != COMBO_CROSS_ITEM &&
         packetType != UPDATE_CLIENT_STATE) {
         return;
     }

--- a/soh/soh/Network/Anchor/Anchor.cpp
+++ b/soh/soh/Network/Anchor/Anchor.cpp
@@ -149,6 +149,7 @@ void Anchor::SendJsonToRemote(nlohmann::json payload) {
     // ComboShip: the launcher owns the socket and its own thread-safe outgoing queue, so hand every
     // packet straight to it. There is no game-side network thread to drain a local queue under the
     // combo build (ProcessOutgoingPackets is never pumped). See docs/UPSTREAM_MERGES.md.
+    payload["srcGame"] = "oot"; // shared socket carries both games; receivers filter on this
     Network::SendJsonToRemote(payload);
     return;
 #else
@@ -175,6 +176,16 @@ void Anchor::OnIncomingJson(nlohmann::json payload) {
     }
 
     std::string packetType = payload["type"].get<std::string>();
+
+#ifdef COMBO_BUILD
+    // ComboShip: drop MM-originated packets — their shapes collide with ours (e.g. MM's
+    // UPDATE_TEAM_STATE lacks healthCapacity and throws in from_json). Exceptions: cross-game item
+    // delivery and the room roster. Packets without srcGame (server, old clients) pass through.
+    if (payload.value("srcGame", "oot") != "oot" && packetType != COMBO_CROSS_ITEM &&
+        packetType != UPDATE_CLIENT_STATE) {
+        return;
+    }
+#endif
 
     // Ignore packets from mismatched clients, except for ALL_CLIENT_STATE, UPDATE_CLIENT_STATE, and PLAYER_UPDATE
     if (packetType != ALL_CLIENT_STATE && packetType != UPDATE_CLIENT_STATE && packetType != PLAYER_UPDATE) {

--- a/soh/soh/Network/Anchor/Anchor.cpp
+++ b/soh/soh/Network/Anchor/Anchor.cpp
@@ -193,6 +193,10 @@ void Anchor::OnIncomingJson(nlohmann::json payload) {
         if (payload.contains("clientId")) {
             uint32_t clientId = payload["clientId"].get<uint32_t>();
             if (clients.contains(clientId) && clients[clientId].clientVersion != clientVersion) {
+#ifdef COMBO_BUILD
+                SPDLOG_INFO("[Anchor] dropped {} from client {}: version '{}' != ours '{}'", packetType, clientId,
+                            clients[clientId].clientVersion, clientVersion);
+#endif
                 return;
             }
         }

--- a/soh/soh/Network/Anchor/Anchor.cpp
+++ b/soh/soh/Network/Anchor/Anchor.cpp
@@ -292,7 +292,16 @@ void Anchor::PumpDormant() {
     while (!packetsToProcess.empty()) {
         nlohmann::json payload = packetsToProcess.front();
         packetsToProcess.pop();
-        if (payload.value("type", std::string()) != GIVE_ITEM) {
+        std::string type = payload.value("type", std::string());
+        if (type == UPDATE_ROOM_STATE) {
+            // Keep roomState current while dormant — syncItemsAndFlags gates the dormant apply,
+            // and a client that boots straight into MM never handles it foreground.
+            try {
+                HandlePacket_UpdateRoomState(payload);
+            } catch (const std::exception& e) { SPDLOG_ERROR("[Anchor] dormant room state: {}", e.what()); }
+            continue;
+        }
+        if (type != GIVE_ITEM) {
             continue; // drop presence/puppet/team-state while dormant (re-requested on activation)
         }
         if (!payload.contains("modId")) {
@@ -366,6 +375,13 @@ void Anchor::RefreshClientActors() {
 }
 
 bool Anchor::IsSaveLoaded() {
+#ifdef COMBO_BUILD
+    // Dormant OOT has no play state (Play_Destroy nulls it on every transition); judge by the
+    // resident save, which is what the dormant apply writes.
+    if (isDormantApply) {
+        return gSaveContext.fileNum >= 0 && gSaveContext.fileNum <= 2;
+    }
+#endif
     if (gPlayState == nullptr) {
         return false;
     }

--- a/soh/soh/Network/Anchor/Anchor.cpp
+++ b/soh/soh/Network/Anchor/Anchor.cpp
@@ -5,6 +5,9 @@
 #include "soh/ObjectExtension/ObjectExtension.h"
 #include "soh/Enhancements/randomizer/randomizer.h"
 #include "soh/Notification/Notification.h"
+#ifdef COMBO_BUILD
+#include "soh/SaveManager.h"
+#endif
 
 extern "C" {
 #include "variables.h"
@@ -273,17 +276,29 @@ void Anchor::PumpDormant() {
         std::lock_guard<std::mutex> lock(incomingPacketQueueMutex);
         packetsToProcess.swap(incomingPacketQueue);
     }
+    dormantDidApply = false;
     while (!packetsToProcess.empty()) {
         nlohmann::json payload = packetsToProcess.front();
         packetsToProcess.pop();
         if (payload.value("type", std::string()) != GIVE_ITEM) {
             continue; // drop presence/puppet/team-state while dormant (re-requested on activation)
         }
+        if (!payload.contains("modId")) {
+            continue; // MM-shaped GIVE_ITEM; the dormant MM pump handles it
+        }
+        SPDLOG_INFO("[Anchor] dormant GIVE_ITEM received: {}", payload.dump());
         isProcessingIncomingPacket = true;
+        isDormantApply = true;
         try {
-            HandlePacket_GiveItem(payload);
+            HandlePacket_GiveItem(payload); // sets dormantDidApply when it actually grants
         } catch (const std::exception& e) { SPDLOG_ERROR("[Anchor] dormant apply exception: {}", e.what()); }
+        isDormantApply = false;
         isProcessingIncomingPacket = false;
+    }
+    // Persist the dormant save so the item survives quitting without ever entering OOT.
+    if (dormantDidApply && SaveManager::Instance && gSaveContext.fileNum != 0xFF) {
+        SaveManager::Instance->SaveFile(gSaveContext.fileNum);
+        SPDLOG_INFO("[Anchor] dormant OOT save persisted (file {})", gSaveContext.fileNum);
     }
 }
 #endif

--- a/soh/soh/Network/Anchor/Anchor.h
+++ b/soh/soh/Network/Anchor/Anchor.h
@@ -77,6 +77,8 @@ class Anchor : public Network {
     bool justLoadedSave = false;
     bool isHandlingUpdateTeamState = false;
     bool isProcessingIncomingPacket = false;
+    bool isDormantApply = false;  // true while PumpDormant applies packets (OOT backgrounded)
+    bool dormantDidApply = false; // set by HandlePacket_GiveItem when a dormant grant landed
     std::queue<nlohmann::json> incomingPacketQueue;
     std::mutex incomingPacketQueueMutex;
     std::queue<nlohmann::json> outgoingPacketQueue;

--- a/soh/soh/Network/Anchor/Anchor.h
+++ b/soh/soh/Network/Anchor/Anchor.h
@@ -62,12 +62,14 @@ typedef struct {
     Player* player;
 } AnchorClient;
 
-typedef struct {
-    uint32_t ownerClientId;
-    u8 pvpMode;           // 0 = off, 1 = on, 2 = on with friendly fire
-    u8 showLocationsMode; // 0 = none, 1 = team, 2 = all
-    u8 teleportMode;      // 0 = off, 1 = team, 2 = all
-    u8 syncItemsAndFlags; // 0 = off, 1 = on
+// Defaults matter in the combo build: a dormant game may apply items before ever handling an
+// UPDATE_ROOM_STATE foreground, and an uninitialized syncItemsAndFlags would drop them.
+typedef struct RoomState {
+    uint32_t ownerClientId = 0;
+    u8 pvpMode = 0;           // 0 = off, 1 = on, 2 = on with friendly fire
+    u8 showLocationsMode = 0; // 0 = none, 1 = team, 2 = all
+    u8 teleportMode = 0;      // 0 = off, 1 = team, 2 = all
+    u8 syncItemsAndFlags = 1; // 0 = off, 1 = on
 } RoomState;
 
 class Anchor : public Network {

--- a/soh/soh/Network/Anchor/HookHandlers.cpp
+++ b/soh/soh/Network/Anchor/HookHandlers.cpp
@@ -68,6 +68,9 @@ static inline void ComboPumpDormantTick() {
 #endif
 
 void Anchor::RegisterHooks() {
+#ifdef COMBO_BUILD
+    SPDLOG_INFO("[Anchor] RegisterHooks (isConnected={})", isConnected);
+#endif
 
     // #region Hooks that are required for basic Anchor functionality
 

--- a/soh/soh/Network/Anchor/Packets/GiveItem.cpp
+++ b/soh/soh/Network/Anchor/Packets/GiveItem.cpp
@@ -20,6 +20,10 @@ uint8_t incomingIceTrapsFromAnchor = 0;
 
 void Anchor::SendPacket_GiveItem(u16 modId, s16 getItemId) {
     if (!IsSaveLoaded() || isProcessingIncomingPacket || !roomState.syncItemsAndFlags) {
+#ifdef COMBO_BUILD
+        SPDLOG_INFO("[Anchor] GIVE_ITEM not sent: saveLoaded={} processingIncoming={} syncItems={}", IsSaveLoaded(),
+                    isProcessingIncomingPacket, roomState.syncItemsAndFlags);
+#endif
         return;
     }
 
@@ -41,6 +45,9 @@ void Anchor::SendPacket_GiveItem(u16 modId, s16 getItemId) {
     payload["getItemId"] = getItemId;
 
     SendJsonToRemote(payload);
+#ifdef COMBO_BUILD
+    SPDLOG_INFO("[Anchor] GIVE_ITEM sent: modId={} getItemId={}", modId, getItemId);
+#endif
 }
 
 void Anchor::HandlePacket_GiveItem(nlohmann::json payload) {

--- a/soh/soh/Network/Anchor/Packets/GiveItem.cpp
+++ b/soh/soh/Network/Anchor/Packets/GiveItem.cpp
@@ -45,6 +45,12 @@ void Anchor::SendPacket_GiveItem(u16 modId, s16 getItemId) {
 
 void Anchor::HandlePacket_GiveItem(nlohmann::json payload) {
     if (!IsSaveLoaded() || !roomState.syncItemsAndFlags) {
+#ifdef COMBO_BUILD
+        if (isDormantApply) {
+            SPDLOG_INFO("[Anchor] dormant GIVE_ITEM dropped: saveLoaded={} syncItems={}", IsSaveLoaded(),
+                        roomState.syncItemsAndFlags);
+        }
+#endif
         return;
     }
 #ifdef COMBO_BUILD
@@ -95,6 +101,14 @@ void Anchor::HandlePacket_GiveItem(nlohmann::json payload) {
         gSaveContext.health += 0x10 * (heartPieces / 4);
     }
 
+#ifdef COMBO_BUILD
+    // ComboShip: no toast while OOT is backgrounded — it would surface in the wrong game later.
+    if (isDormantApply) {
+        dormantDidApply = true;
+        SPDLOG_INFO("[Anchor] dormant GIVE_ITEM applied: modId={} getItemId={}", modId, getItemId);
+        return;
+    }
+#endif
     if (getItemEntry.getItemCategory != ITEM_CATEGORY_JUNK) {
         if (getItemEntry.modIndex == MOD_NONE) {
             Notification::Emit({

--- a/soh/soh/Network/Anchor/Packets/UpdateTeamState.cpp
+++ b/soh/soh/Network/Anchor/Packets/UpdateTeamState.cpp
@@ -122,6 +122,14 @@ void Anchor::HandlePacket_UpdateTeamState(nlohmann::json payload) {
         return;
     }
 
+#ifdef COMBO_BUILD
+    // ComboShip: MM's UPDATE_TEAM_STATE has a different state shape; from_json would throw
+    // mid-handler and leave isHandlingUpdateTeamState stuck true (muting check-status sync).
+    if (payload.contains("state") && !payload["state"].contains("healthCapacity")) {
+        return;
+    }
+#endif
+
     isHandlingUpdateTeamState = true;
     // This can happen in between file select and the game starting, so we can't use this check, but we need to ensure
     // we be careful to wrap PlayState usage in this check

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -2710,6 +2710,14 @@ extern "C" __declspec(dllexport) void SOH_SetOnNewSaveCallback(void (*cb)(int fi
     gComboSaveInitCallback = cb;
 }
 
+// ComboShip: the current save's file name (8 font-code bytes). Valid inside the new-save callback,
+// where the launcher copies it into the matching MM save.
+extern "C" __declspec(dllexport) void SOH_GetCurrentPlayerName(unsigned char out8[8]) {
+    for (int i = 0; i < 8; i++) {
+        out8[i] = gSaveContext.playerName[i];
+    }
+}
+
 extern "C" void (*gComboSceneSwitchCallback)(int fileNum) = nullptr;
 
 extern "C" __declspec(dllexport) void SOH_SetOnSceneSwitchCallback(void (*cb)(int fileNum)) {

--- a/soh/src/code/z_parameter.c
+++ b/soh/src/code/z_parameter.c
@@ -2255,7 +2255,11 @@ u8 Item_Give(PlayState* play, u8 item) {
         for (i = 1; i < ARRAY_COUNT(gSaveContext.equips.buttonItems); i++) {
             if (gSaveContext.equips.buttonItems[i] == ITEM_OCARINA_FAIRY) {
                 gSaveContext.equips.buttonItems[i] = ITEM_OCARINA_TIME;
-                Interface_LoadItemIcon1(play, i);
+                // ComboShip: null while dormant (network grant into the resident save); the rando
+                // loops below already guard the same call.
+                if (play != NULL) {
+                    Interface_LoadItemIcon1(play, i);
+                }
             }
         }
 


### PR DESCRIPTION
Follow-up to the dormant co-op sync in #58 

- Persist dormant OOT grants to disk (they were memory-only; quitting without entering OOT lost the item)
- Suppress the receive toast while backgrounded (it surfaced in the wrong game later)
- Require a nonzero clientId for the self-echo drop (a dormant MM with ownClientId 0 dropped teammate items stamped 0)
- Reject unknown check ids in the dormant MM apply (no idempotency backstop)
- Shape-filter before handling so foreign-game GIVE_ITEM no longer triggers spurious full save writes

<!--- section:artifacts:start -->
### Build Artifacts
  - [comborando-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8255545478.zip)
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8255545114.zip)
<!--- section:artifacts:end -->