### PR TITLE
Per-game OOT accessibility (No Logic / beatable-only) + hearts as junk

### DIFF
--- a/combo/ComboRandoHeadless.cpp
+++ b/combo/ComboRandoHeadless.cpp
@@ -275,6 +275,14 @@ int main(int argc, char** argv) {
                        : "both ends reachable with full inventory but the forward walk dead-ends (item cycle)";
         };
 
+        // No Logic seeds may be OOT-unbeatable by design; the verdict below tolerates that as long as
+        // MM stays fully reachable + Majora beatable.
+        bool ootNoLogic = false;
+        for (auto it = ootSettings.begin(); it != ootSettings.end(); ++it)
+            if (it.key().find("LogicRules") != std::string::npos && it.value().is_number() &&
+                it.value().get<int>() == 1)
+                ootNoLogic = true;
+
         // Pass 1 — the seed's own settings + enabled tricks: "can this player beat it?"
         std::cout << "[playthrough] seed '" << label << "' — Pass 1 (" << ootEnabledTricks.size()
                   << " enabled trick(s))\n";
@@ -298,6 +306,16 @@ int main(int argc, char** argv) {
             std::cout << "[playthrough] RESULT: beatable ONLY with tricks beyond the seed's settings (sphere "
                       << r2.beatableSphere << "). With the seed's tricks, Pass 1 got stuck: " << blocked(r1) << ".\n";
             return 3;
+        }
+        // No Logic: tolerate OOT/Ganon unbeatability, but still hard-require Majora reachable (MM's win
+        // chain intact — MM adv is assumed-filled reachably by the generator). unreachableMm is not
+        // required 0: every seed has ~1 under-modeled MM junk check (oracle evaluates MM with zeroed
+        // save options), present even under ALL_REACHABLE.
+        if (ootNoLogic && r2.majoraReachable) {
+            std::cout << "[playthrough] RESULT: PASS (No Logic) — Majora beatable (MM reachable); OOT/Ganon "
+                         "unbeatability tolerated ("
+                      << blocked(r2) << ").\n";
+            return 0;
         }
         std::cout << "[playthrough] RESULT: FAIL — not beatable even with all tricks; stuck: " << blocked(r2)
                   << " (OOT unreachable=" << r2.unreachableOot << ", MM unreachable=" << r2.unreachableMm
@@ -347,8 +365,11 @@ int main(int argc, char** argv) {
                         mmAreas.emplace(chk, region.get<std::string>());
                 } catch (...) {}
                 if (ComboRando::NeedsRequirednessPareDown(sohHintDump, mmDump))
-                    pareDownResult = ComboRando::PareDownPlaythrough(r.spoilerJson, oot, mmO, nullptr, sohDump, mmDump,
-                                                                     ootAreas, mmAreas);
+                    // NO_LOGIC: gate requiredness on MM only (OOT may be unbeatable by design).
+                    pareDownResult = ComboRando::PareDownPlaythrough(
+                        r.spoilerJson, oot, mmO, nullptr, sohDump, mmDump, ootAreas, mmAreas,
+                        ootAccess == ComboRando::OotAccess::NO_LOGIC ? ComboRando::MmOnlyMajoraGoal
+                                                                     : ComboRando::DefaultGanonMajoraGoal);
                 else
                     std::cout << "[comborando]   pare-down skipped (no enabled hint surface needs requiredness)\n";
             }

--- a/combo/ComboRandoHeadless.cpp
+++ b/combo/ComboRandoHeadless.cpp
@@ -326,7 +326,9 @@ int main(int argc, char** argv) {
             sohDump = SOH_Dump();
             mmDump = MM_Dump();
             std::string forced = SOH_GetForced ? SOH_GetForced(masterSeed) : "";
-            r = ComboRando::CrossWorldCombinedFill(sohDump, mmDump, masterSeed, oot, mmO, "", nullptr, forced);
+            ComboRando::OotAccess ootAccess = ComboRando::OotAccessFromDump(sohDump);
+            r = ComboRando::CrossWorldCombinedFill(sohDump, mmDump, masterSeed, oot, mmO, "", nullptr, forced,
+                                                   ootAccess);
             if (r.success) {
                 // Cross-hint data (Phase 2/3 mirror of RunComboFill, incl. the same area maps so the
                 // WotH/Foolish rollup matches in-game): needs this attempt's still-live oracle session.

--- a/combo/ComboRandoHeadless.cpp
+++ b/combo/ComboRandoHeadless.cpp
@@ -308,9 +308,10 @@ int main(int argc, char** argv) {
             return 3;
         }
         // No Logic: tolerate OOT/Ganon unbeatability, but still hard-require Majora reachable (MM's win
-        // chain intact — MM adv is assumed-filled reachably by the generator). unreachableMm is not
-        // required 0: every seed has ~1 under-modeled MM junk check (oracle evaluates MM with zeroed
-        // save options), present even under ALL_REACHABLE.
+        // chain intact). MM-advancement reachability is guaranteed by the GENERATOR (the fill fails/retries
+        // on mmAdvUnreachable>0 in every mode); this verdict only re-confirms the Majora win-chain — it does
+        // NOT gate on unreachableMm==0, since every seed has ~1 under-modeled MM junk check (oracle
+        // evaluates MM with zeroed save options), present even under ALL_REACHABLE.
         if (ootNoLogic && r2.majoraReachable) {
             std::cout << "[playthrough] RESULT: PASS (No Logic) — Majora beatable (MM reachable); OOT/Ganon "
                          "unbeatability tolerated ("

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -867,9 +867,12 @@ static void RunComboFill(std::string inputSeed, ComboRando::ComboGenProgress* pr
             // the WriteComboPlaythrough call below (or the loop's own restore) does that once. Skipped
             // entirely when no enabled hint surface consumes requiredness (empty result = all non-required).
             if (ComboRando::NeedsRequirednessPareDown(sohHintDump, mmDump)) {
-                pareDownResult = ComboRando::PareDownPlaythrough(result.spoilerJson, ootOracle, mmOracle, nullptr,
-                                                                 sohDump, mmDump, ootCheckAreasCache,
-                                                                 buildMmCheckAreas(mmDump));
+                // NO_LOGIC: gate requiredness on MM only (OOT may be unbeatable by design).
+                pareDownResult = ComboRando::PareDownPlaythrough(
+                    result.spoilerJson, ootOracle, mmOracle, nullptr, sohDump, mmDump, ootCheckAreasCache,
+                    buildMmCheckAreas(mmDump),
+                    ootAccess == ComboRando::OotAccess::NO_LOGIC ? ComboRando::MmOnlyMajoraGoal
+                                                                 : ComboRando::DefaultGanonMajoraGoal);
             } else {
                 std::cout << "[ComboShip] RunComboFill: pare-down skipped (no enabled hint surface needs "
                              "requiredness)\n";

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -843,8 +843,12 @@ static void RunComboFill(std::string inputSeed, ComboRando::ComboGenProgress* pr
         if (SOH_GetForcedPlacements)
             forcedOot = SOH_GetForcedPlacements(masterSeed);
 
+        // ComboShip: honor OOT's logic/ALR settings per-game (MM stays all-reachable). TODO: when the
+        // portal gets a real gate, set portalCheckName here and exempt the Mask Shop Key + its reach
+        // prerequisites from OOT relaxation (or hard-fail NO_LOGIC) — see CrossWorldRando.h guard.
+        ComboRando::OotAccess ootAccess = ComboRando::OotAccessFromDump(sohDump);
         auto result = ComboRando::CrossWorldCombinedFill(sohDump, mmDump, masterSeed, ootOracle, mmOracle, "", progress,
-                                                         forcedOot);
+                                                         forcedOot, ootAccess);
 
         if (result.success) {
             spoiler = result.spoilerJson;

--- a/combo/rando/ComboPlaythrough.h
+++ b/combo/rando/ComboPlaythrough.h
@@ -167,6 +167,16 @@ inline bool DefaultGanonMajoraGoal(const std::unordered_set<std::string>& ootRea
     return canGanon && canMajora;
 }
 
+// NO_LOGIC goal: OOT may be structurally unbeatable from empty (the combined goal would degenerate and
+// every OOT item would look "required"), so gate requiredness on MM (Majora) only. Keeps MM-side WotH
+// meaningful; OOT-side requiredness is not evaluated under No Logic (matching its semantics).
+inline bool MmOnlyMajoraGoal(const std::unordered_set<std::string>& /*ootReach*/,
+                             const std::unordered_set<std::string>& mmReach,
+                             const std::vector<std::string>& /*ownedOot*/) {
+    static const char* kMmWin = "RC_MOON_MAJORA_POT_01";
+    return mmReach.count(kMmWin) > 0;
+}
+
 struct RequirednessResult {
     // "oot:<check>"/"mm:<check>" -> required (WotH, true) or foolish-candidate (false).
     std::unordered_map<std::string, bool> requiredByCheck;

--- a/combo/rando/CrossWorldRando.h
+++ b/combo/rando/CrossWorldRando.h
@@ -538,12 +538,11 @@ inline CombinedFillResult CrossWorldCombinedFill(const std::string& sohDumpJson,
                    mmFinal.count(kMmWin) > 0;
         };
         bool goalOk = (ootAccess != OotAccess::BEATABLE_ONLY) || beatableGoal();
-        bool needRetry = mmAdvUnreachable > 0 ||
-                         (ootAccess == OotAccess::ALL_REACHABLE && ootAdvUnreachable > 0) ||
+        bool needRetry = mmAdvUnreachable > 0 || (ootAccess == OotAccess::ALL_REACHABLE && ootAdvUnreachable > 0) ||
                          (ootAccess == OotAccess::BEATABLE_ONLY && !goalOk);
         if (needRetry) {
-            std::cerr << "[ComboShip] CrossWorldCombinedFill: validation failed — mmAdvUnreachable="
-                      << mmAdvUnreachable << " ootAdvUnreachable=" << ootAdvUnreachable
+            std::cerr << "[ComboShip] CrossWorldCombinedFill: validation failed — mmAdvUnreachable=" << mmAdvUnreachable
+                      << " ootAdvUnreachable=" << ootAdvUnreachable
                       << (ootAccess == OotAccess::BEATABLE_ONLY ? (goalOk ? " goal=ok" : " goal=UNBEATABLE") : "")
                       << " (pass " << pass << ", " << passMs() << " ms) — retrying\n";
             continue;

--- a/combo/rando/CrossWorldRando.h
+++ b/combo/rando/CrossWorldRando.h
@@ -56,6 +56,26 @@ struct OracleFns {
 
 // ---------- Data types ----------
 
+// Per-game OOT accessibility, mapped from OOT's RSK_LOGIC_RULES + RSK_ALL_LOCATIONS_REACHABLE.
+// MM is always ALL_REACHABLE. See CrossWorldCombinedFill for the per-mode fill/validation behavior.
+//   ALL_REACHABLE  every OOT advancement item lands reachable (default; unchanged behavior)
+//   BEATABLE_ONLY  OOT progression may strand off-path, but the seed stays beatable (ALR-off)
+//   NO_LOGIC       OOT items land anywhere; only MM stays fully reachable
+enum class OotAccess { ALL_REACHABLE, BEATABLE_ONLY, NO_LOGIC };
+
+// Maps the OOT dump's "accessibility" block to a mode: No Logic wins; else ALR-off => BEATABLE_ONLY;
+// else ALL_REACHABLE. Missing/old dumps default to ALL_REACHABLE (unchanged behavior).
+inline OotAccess OotAccessFromDump(const std::string& sohDumpJson) {
+    try {
+        auto a = nlohmann::json::parse(sohDumpJson).value("accessibility", nlohmann::json::object());
+        if (a.value("noLogic", false))
+            return OotAccess::NO_LOGIC;
+        if (!a.value("allLocationsReachable", true))
+            return OotAccess::BEATABLE_ONLY;
+    } catch (...) {}
+    return OotAccess::ALL_REACHABLE;
+}
+
 // Reuses GameId from CrossForeign.h (GAME_OOT = 0, GAME_MM = 1)
 using Game = GameId;
 
@@ -92,7 +112,8 @@ inline CombinedFillResult CrossWorldCombinedFill(const std::string& sohDumpJson,
                                                  uint32_t masterSeed, const OracleFns& ootOracle,
                                                  const OracleFns& mmOracle, const std::string& portalCheckName = "",
                                                  ComboRando::ComboGenProgress* progress = nullptr,
-                                                 const std::string& forcedOotJson = "") {
+                                                 const std::string& forcedOotJson = "",
+                                                 OotAccess ootAccess = OotAccess::ALL_REACHABLE) {
     CombinedFillResult result;
     result.success = false;
 

--- a/combo/rando/CrossWorldRando.h
+++ b/combo/rando/CrossWorldRando.h
@@ -175,6 +175,20 @@ inline CombinedFillResult CrossWorldCombinedFill(const std::string& sohDumpJson,
         return result;
     }
 
+    // Portal-key guard: with Overworld Keys ON but Force Mask Shop Key OFF, the Mask Shop Key is
+    // OOT-AssumedFill'd (not a locked sphere-0 placement), so a relaxed OOT mode could strand its
+    // reach-path — and with portalCheckName="" the fill can't detect it, risking an MM-unreachable
+    // seed. Warn loudly (the intended combo config is Force ON, or Overworld Keys OFF).
+    if (ootAccess != OotAccess::ALL_REACHABLE && portalCheckName.empty()) {
+        try {
+            auto a = nlohmann::json::parse(sohDumpJson).value("accessibility", nlohmann::json::object());
+            if (a.value("lockOverworldDoors", false) && !a.value("forceMaskShopKey", false))
+                std::cerr << "[ComboShip] CrossWorldCombinedFill: WARNING — Overworld Keys ON + Force Mask Shop "
+                             "Key OFF under a relaxed OOT mode: the Mask Shop Key's reach-path is not guaranteed "
+                             "(portal ungated); MM may be unreachable. Enable Force Mask Shop Key.\n";
+        } catch (...) {}
+    }
+
     // Forced OOT placements (e.g. Link's Pocket): reserve each item out of the cross pool and treat
     // it as owned-from-start (auto-granted at save creation). Appended to placements after the fill.
     std::vector<CwPlacement> forcedPlacements;

--- a/combo/rando/CrossWorldRando.h
+++ b/combo/rando/CrossWorldRando.h
@@ -175,10 +175,8 @@ inline CombinedFillResult CrossWorldCombinedFill(const std::string& sohDumpJson,
         return result;
     }
 
-    // Portal-key guard: with Overworld Keys ON but Force Mask Shop Key OFF, the Mask Shop Key is
-    // OOT-AssumedFill'd (not a locked sphere-0 placement), so a relaxed OOT mode could strand its
-    // reach-path — and with portalCheckName="" the fill can't detect it, risking an MM-unreachable
-    // seed. Warn loudly (the intended combo config is Force ON, or Overworld Keys OFF).
+    // Portal-key guard: Overworld Keys ON + Force Mask Shop Key OFF under a relaxed mode may strand the
+    // Mask Shop Key (portalCheckName="" can't detect it) → MM unreachable. Warn. See docs/UPSTREAM_MERGES.
     if (ootAccess != OotAccess::ALL_REACHABLE && portalCheckName.empty()) {
         try {
             auto a = nlohmann::json::parse(sohDumpJson).value("accessibility", nlohmann::json::object());
@@ -377,11 +375,8 @@ inline CombinedFillResult CrossWorldCombinedFill(const std::string& sohDumpJson,
         for (const auto& lp : lockedPlacements)
             filledChecks.insert(checkKey(lp.check));
 
-        // Phase A: place advancement items with logic, assuming only UNPLACED ones are owned.
-        // Per-game accessibility: NO_LOGIC assumed-fills only MM advancement (OOT adv is fast-filled as
-        // junk below); ALL_REACHABLE/BEATABLE_ONLY assumed-fill the full set (BEATABLE_ONLY may later
-        // strand a stuck OOT item — see the dead-end handler). ALL_REACHABLE keeps advItems unreordered
-        // so a fixed seed reproduces bit-for-bit.
+        // Phase A: place advancement items with logic, assuming only UNPLACED ones are owned. NO_LOGIC
+        // assumed-fills only MM adv (OOT adv rides Phase B junk); other modes keep advItems unreordered.
         std::vector<CwItem> toPlace;
         if (ootAccess == OotAccess::NO_LOGIC) {
             for (const auto& it : advItems)

--- a/combo/rando/CrossWorldRando.h
+++ b/combo/rando/CrossWorldRando.h
@@ -299,8 +299,14 @@ inline CombinedFillResult CrossWorldCombinedFill(const std::string& sohDumpJson,
     // both games because an MM item at an OOT check (or vice versa) can open progress anywhere,
     // including the portal itself — so portal openness is re-evaluated every iteration.
     std::vector<CwPlacement> placements;
-    auto reachableFixpoint = [&](const std::vector<std::string>& ootBase, const std::vector<std::string>& mmBase)
-        -> std::pair<std::unordered_set<std::string>, std::unordered_set<std::string>> {
+    // ootReachable/mmReachable = reachable checks at the fixpoint; ootOwned = OOT items collected along
+    // the way (drives the BEATABLE_ONLY boss-key goal check without a second traversal).
+    struct FixResult {
+        std::unordered_set<std::string> ootReachable, mmReachable;
+        std::vector<std::string> ootOwned;
+    };
+    auto reachableFixpoint = [&](const std::vector<std::string>& ootBase,
+                                 const std::vector<std::string>& mmBase) -> FixResult {
         std::vector<std::string> ootOwned = ootBase, mmOwned = mmBase;
         // Forced placements (Link's Pocket etc.) are granted at save creation → owned from the start.
         ootOwned.insert(ootOwned.end(), ootForcedOwned.begin(), ootForcedOwned.end());
@@ -324,7 +330,7 @@ inline CombinedFillResult CrossWorldCombinedFill(const std::string& sohDumpJson,
                 }
             }
             if (!changed)
-                return { std::move(ootReachable), std::move(mmReachable) };
+                return { std::move(ootReachable), std::move(mmReachable), std::move(ootOwned) };
         }
     };
 
@@ -358,7 +364,19 @@ inline CombinedFillResult CrossWorldCombinedFill(const std::string& sohDumpJson,
             filledChecks.insert(checkKey(lp.check));
 
         // Phase A: place advancement items with logic, assuming only UNPLACED ones are owned.
-        std::vector<CwItem> toPlace = advItems;
+        // Per-game accessibility: NO_LOGIC assumed-fills only MM advancement (OOT adv is fast-filled as
+        // junk below); ALL_REACHABLE/BEATABLE_ONLY assumed-fill the full set (BEATABLE_ONLY may later
+        // strand a stuck OOT item — see the dead-end handler). ALL_REACHABLE keeps advItems unreordered
+        // so a fixed seed reproduces bit-for-bit.
+        std::vector<CwItem> toPlace;
+        if (ootAccess == OotAccess::NO_LOGIC) {
+            for (const auto& it : advItems)
+                if (it.game == GAME_MM)
+                    toPlace.push_back(it);
+        } else {
+            toPlace = advItems;
+        }
+        std::vector<CwItem> relaxedToJunk; // OOT adv stranded off-path under BEATABLE_ONLY dead-ends
         cwShuffle(toPlace, rng);
         std::vector<std::string> ootRemaining, mmRemaining;
         for (const auto& it : toPlace)
@@ -394,7 +412,9 @@ inline CombinedFillResult CrossWorldCombinedFill(const std::string& sohDumpJson,
                 removeOne(batch.back().game == GAME_OOT ? ootRemaining : mmRemaining, batch.back().name);
             }
 
-            auto [ootReachable, mmReachable] = reachableFixpoint(ootRemaining, mmRemaining);
+            auto fr = reachableFixpoint(ootRemaining, mmRemaining);
+            auto& ootReachable = fr.ootReachable;
+            auto& mmReachable = fr.mmReachable;
 
             std::vector<size_t> candidates;
             for (size_t ci = 0; ci < allChecks.size(); ++ci) {
@@ -406,6 +426,13 @@ inline CombinedFillResult CrossWorldCombinedFill(const std::string& sohDumpJson,
             }
 
             if (candidates.size() < batch.size()) {
+                // BEATABLE_ONLY: a single OOT advancement item with no reachable check may strand
+                // off-path — move it to the junk fast-fill and continue (already removed from
+                // toPlace/ootRemaining above). MM items and ALL_REACHABLE always retry instead.
+                if (batch.size() == 1 && ootAccess == OotAccess::BEATABLE_ONLY && batch.front().game == GAME_OOT) {
+                    relaxedToJunk.push_back(batch.front());
+                    continue;
+                }
                 // Put the batch back (reverse order restores the pop sequence — deterministic).
                 for (auto it = batch.rbegin(); it != batch.rend(); ++it) {
                     (it->game == GAME_OOT ? ootRemaining : mmRemaining).push_back(it->name);
@@ -438,8 +465,16 @@ inline CombinedFillResult CrossWorldCombinedFill(const std::string& sohDumpJson,
         if (deadEnd)
             continue;
 
-        // Phase B: junk fast-fill into the remaining checks — zero oracle calls.
+        // Phase B: junk fast-fill into the remaining checks — zero oracle calls. Relaxed OOT
+        // advancement (NO_LOGIC: all OOT adv; BEATABLE_ONLY: stranded dead-end items) rides this
+        // stream — placed without logic, tolerated-if-unreachable by the mode-aware validation below.
         std::vector<CwItem> junkToPlace = junkItems;
+        if (ootAccess == OotAccess::NO_LOGIC) {
+            for (const auto& it : advItems)
+                if (it.game == GAME_OOT)
+                    junkToPlace.push_back(it);
+        }
+        junkToPlace.insert(junkToPlace.end(), relaxedToJunk.begin(), relaxedToJunk.end());
         cwShuffle(junkToPlace, rng);
         size_t ji = 0;
         for (size_t ci = 0; ci < allChecks.size() && ji < junkToPlace.size(); ++ci) {
@@ -459,8 +494,13 @@ inline CombinedFillResult CrossWorldCombinedFill(const std::string& sohDumpJson,
         // (e.g. MM logic evaluated with zeroed save options), so some checks never appear
         // reachable even with full inventory — the fill can only ever put junk there. Count and
         // log those, don't fail on them.
-        auto [ootFinal, mmFinal] = reachableFixpoint({}, {});
-        size_t advUnreachable = 0, junkUnreachable = 0, junkUnreachableOot = 0;
+        auto vf = reachableFixpoint({}, {});
+        auto& ootFinal = vf.ootReachable;
+        auto& mmFinal = vf.mmReachable;
+        // Classify unreachable advancement by ITEM game: MM adv unreachable is always fatal (MM must
+        // stay all-reachable); OOT adv unreachable is fatal only under ALL_REACHABLE, tolerated under
+        // the relaxed modes (it was placed off-logic on purpose).
+        size_t mmAdvUnreachable = 0, ootAdvUnreachable = 0, junkUnreachable = 0, junkUnreachableOot = 0;
         for (const auto& p : placements) {
             // Locked placements are the game's own guaranteed-reachable vanilla/confined items — not
             // the cross-fill's responsibility, and the oracles under-model some. Don't validate them.
@@ -470,19 +510,38 @@ inline CombinedFillResult CrossWorldCombinedFill(const std::string& sohDumpJson,
             if (reach.count(p.check.name))
                 continue;
             if (p.item.advancement) {
-                ++advUnreachable;
+                (p.item.game == GAME_MM ? mmAdvUnreachable : ootAdvUnreachable)++;
             } else {
                 ++junkUnreachable;
                 if (p.check.game == GAME_OOT)
                     ++junkUnreachableOot;
             }
         }
-        if (advUnreachable > 0) {
-            std::cerr << "[ComboShip] CrossWorldCombinedFill: validation failed — " << advUnreachable
-                      << " advancement items on unreachable checks (pass " << pass << ", " << passMs()
-                      << " ms) — retrying\n";
+        // BEATABLE_ONLY additionally requires the win still holds (mirrors DefaultGanonMajoraGoal;
+        // duplicated here to keep this header free of ComboPlaythrough.h). NO_LOGIC accepts an
+        // OOT-unbeatable seed; MM stays reachable+beatable regardless.
+        auto beatableGoal = [&]() {
+            static const char* kOotTowerTop = "Ganon's Castle Tower Boss Key Chest";
+            static const char* kOotBossKey = "Ganon's Castle Boss Key";
+            static const char* kMmWin = "RC_MOON_MAJORA_POT_01";
+            return ootFinal.count(kOotTowerTop) > 0 &&
+                   std::find(vf.ootOwned.begin(), vf.ootOwned.end(), kOotBossKey) != vf.ootOwned.end() &&
+                   mmFinal.count(kMmWin) > 0;
+        };
+        bool goalOk = (ootAccess != OotAccess::BEATABLE_ONLY) || beatableGoal();
+        bool needRetry = mmAdvUnreachable > 0 ||
+                         (ootAccess == OotAccess::ALL_REACHABLE && ootAdvUnreachable > 0) ||
+                         (ootAccess == OotAccess::BEATABLE_ONLY && !goalOk);
+        if (needRetry) {
+            std::cerr << "[ComboShip] CrossWorldCombinedFill: validation failed — mmAdvUnreachable="
+                      << mmAdvUnreachable << " ootAdvUnreachable=" << ootAdvUnreachable
+                      << (ootAccess == OotAccess::BEATABLE_ONLY ? (goalOk ? " goal=ok" : " goal=UNBEATABLE") : "")
+                      << " (pass " << pass << ", " << passMs() << " ms) — retrying\n";
             continue;
         }
+        if (ootAdvUnreachable > 0)
+            std::cout << "[ComboShip] CrossWorldCombinedFill: " << ootAdvUnreachable
+                      << " OOT advancement item(s) on unreachable checks — tolerated (relaxed OOT mode)\n";
 
         std::cout << "[ComboShip] CrossWorldCombinedFill: all " << advItems.size()
                   << " advancement items reachable from scratch (pass " << pass << ", " << passMs() << " ms; "

--- a/docs/UPSTREAM_MERGES.md
+++ b/docs/UPSTREAM_MERGES.md
@@ -1928,3 +1928,16 @@ placements treat every advancement item as major (conservative — never over-ma
 no major item (`areaHasMajor`). Deliberately produces fewer barren regions than before (native parity).
 
 **If future upstream touches `Item::IsMajorItem`:** re-check the dump flag and the barren derivation.
+
+## OOT hearts as junk in the combo fill (2026-07-17)
+
+**Why:** MM already dumps hearts as non-advancement (`BenPort.cpp` `isAdvancement` skips
+`RITYPE_HEALTH`). OOT's `IsAdvancement()` marks Piece of Heart / Heart Container / Treasure-Game
+Heart as advancement, bloating the OOT advancement pool the cross-fill must place reachably. Hearts
+are never logic-required under glitchless, so treating them as junk shrinks dead-ends. Only caveat:
+high `RSK_DAMAGE_MULTIPLIER` (8x/16x) — conservative, matches MM, never a softlock.
+
+**`soh/soh/OTRGlobals.cpp` (`SOH_DumpRandoStaticData`):** a local `comboIsAdv(rg)` returns false for
+`RG_PIECE_OF_HEART`/`RG_HEART_CONTAINER`/`RG_TREASURE_GAME_HEART`, else `IsAdvancement()`. Used at
+every advancement emit site (pool, fixed, fallback, items). `item_list.cpp`/`IsAdvancement()` is NOT
+touched, so native single-game SoH is unchanged.

--- a/docs/UPSTREAM_MERGES.md
+++ b/docs/UPSTREAM_MERGES.md
@@ -1941,3 +1941,41 @@ high `RSK_DAMAGE_MULTIPLIER` (8x/16x) — conservative, matches MM, never a soft
 `RG_PIECE_OF_HEART`/`RG_HEART_CONTAINER`/`RG_TREASURE_GAME_HEART`, else `IsAdvancement()`. Used at
 every advancement emit site (pool, fixed, fallback, items). `item_list.cpp`/`IsAdvancement()` is NOT
 touched, so native single-game SoH is unchanged.
+
+## Honor OOT logic/accessibility settings in the combo fill (2026-07-17)
+
+**Why:** The cross-fill ignored OOT's `RSK_LOGIC_RULES` and `RSK_ALL_LOCATIONS_REACHABLE` — it always
+ran an all-reachable assumed fill. Native OOT relaxes: No Logic fast-fills everything; ALR-off places
+with logic only until beatable. The combo fill now honors these **per-game**: OOT relaxes, MM always
+stays all-reachable (portal is ungated at runtime, so MM reachability must never degrade).
+
+**`soh/soh/OTRGlobals.cpp` (`SOH_DumpRandoStaticData`):** the dump gains an `"accessibility"` block
+(`noLogic`, `allLocationsReachable`, `lockOverworldDoors`, `forceMaskShopKey`) read from the live
+Context. Defaults (ALL_REACHABLE) if the prep throws.
+
+**`combo/rando/CrossWorldRando.h`:** `enum class OotAccess { ALL_REACHABLE, BEATABLE_ONLY, NO_LOGIC }`
++ `OotAccessFromDump` (No Logic wins; else ALR-off => BEATABLE_ONLY). `CrossWorldCombinedFill` takes a
+defaulted `OotAccess` param. Per mode:
+- **ALL_REACHABLE:** unchanged; `toPlace = advItems` unreordered so a fixed seed is bit-identical.
+- **NO_LOGIC:** assumed-fill only MM advancement; OOT advancement rides the junk fast-fill.
+- **BEATABLE_ONLY:** assumed-fill the full set, but a single dead-ended OOT item is stranded to the
+  junk fast-fill (MM dead-ends still retry the pass).
+Validation classifies unreachable advancement by **item-game**: MM unreachable is always fatal/retry;
+OOT unreachable is fatal only under ALL_REACHABLE, tolerated (logged) under relaxed modes. BEATABLE_ONLY
+additionally requires the win still holds (`reachableFixpoint` now also returns the final `ootOwned`).
+
+**Portal-key guard:** with Overworld Keys ON + Force Mask Shop Key OFF under a relaxed mode and
+`portalCheckName=""`, the fill can't guarantee the Mask Shop Key's reach-path — it warns loudly. The
+intended combo config is Force ON (key locked at a sphere-0 KF check → exempt from relaxation) or
+Overworld Keys OFF. **Future portal:** when a real gate is wired (`portalCheckName` at
+`combo/ComboShip.cpp`), treat the Mask Shop Key + reach prerequisites as MM-advancement-equivalent
+(exempt from OOT relaxation) or hard-fail NO_LOGIC — TODO left at the call site.
+
+**`combo/rando/ComboPlaythrough.h`:** `MmOnlyMajoraGoal` — under NO_LOGIC the pare-down (WotH) gates
+requiredness on MM only, since OOT may be structurally unbeatable from empty. Wired at both
+`PareDownPlaythrough` call sites (`ComboShip.cpp`, `ComboRandoHeadless.cpp`).
+
+**`combo/ComboRandoHeadless.cpp` (`--playthrough` verdict):** a No Logic seed that is OOT/Ganon
+unbeatable but keeps MM fully reachable + Majora beatable is downgraded from FAIL to PASS (No Logic).
+
+**Hearts:** see the preceding "OOT hearts as junk" section — shrinks the OOT advancement pool.

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -3630,7 +3630,7 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoStaticData(void) {
         while (pool.size() < checks.size()) {
             RandomizerGet jg = GetJunkItem();
             pool.push_back({ { "name", Rando::StaticData::RetrieveItem(jg).GetName().GetEnglish() },
-                             { "advancement", Rando::StaticData::RetrieveItem(jg).IsAdvancement() },
+                             { "advancement", comboIsAdv(jg) },
                              { "major", isMajor(jg) } });
         }
         // Rolled prices (set by ComboFillConfined at Fill()'s native position) for every priced

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -3537,6 +3537,12 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoStaticData(void) {
     nlohmann::json fixed = nlohmann::json::array();
     nlohmann::json items = nlohmann::json::array();
     nlohmann::json prices = nlohmann::json::object();
+    // ComboShip: OOT accessibility settings the combo fill honors per-game. Defaults = ALL_REACHABLE
+    // (safe: unchanged fill behavior) if the prep throws before these are read.
+    nlohmann::json accessibility = { { "noLogic", false },
+                                     { "allLocationsReachable", true },
+                                     { "lockOverworldDoors", false },
+                                     { "forceMaskShopKey", false } };
 
     // ComboShip: mirror MM (BenPort isAdvancement) — hearts are never logic-required under glitchless,
     // so class PoH/HC/treasure-game heart as junk. Shrinks the OOT advancement pool (fewer dead-ends).
@@ -3638,6 +3644,12 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoStaticData(void) {
                 prices[loc->GetName()] = ctx->GetItemLocation(rc)->GetPrice();
         }
 
+        // ComboShip: accessibility settings the combo fill maps to an OotAccess mode (per-game relax).
+        accessibility["noLogic"] = ctx->GetOption(RSK_LOGIC_RULES).Is(RO_LOGIC_NO_LOGIC);
+        accessibility["allLocationsReachable"] = static_cast<bool>(ctx->GetOption(RSK_ALL_LOCATIONS_REACHABLE));
+        accessibility["lockOverworldDoors"] = static_cast<bool>(ctx->GetOption(RSK_LOCK_OVERWORLD_DOORS));
+        accessibility["forceMaskShopKey"] = static_cast<bool>(ctx->GetOption(RSK_COMBO_FORCE_MASK_SHOP_KEY));
+
         usedPool = true;
 #else
         // Non-combo (unused outside ComboShip): old vanilla-per-check emission.
@@ -3712,7 +3724,8 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoStaticData(void) {
         { "pool", std::move(pool) },
         { "fixed", std::move(fixed) },
         { "items", std::move(items) },
-        { "prices", std::move(prices) }
+        { "prices", std::move(prices) },
+        { "accessibility", std::move(accessibility) }
     }.dump();
     return cached.c_str();
 }

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -3538,6 +3538,14 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoStaticData(void) {
     nlohmann::json items = nlohmann::json::array();
     nlohmann::json prices = nlohmann::json::object();
 
+    // ComboShip: mirror MM (BenPort isAdvancement) — hearts are never logic-required under glitchless,
+    // so class PoH/HC/treasure-game heart as junk. Shrinks the OOT advancement pool (fewer dead-ends).
+    auto comboIsAdv = [](RandomizerGet rg) {
+        if (rg == RG_PIECE_OF_HEART || rg == RG_HEART_CONTAINER || rg == RG_TREASURE_GAME_HEART)
+            return false;
+        return Rando::StaticData::RetrieveItem(rg).IsAdvancement();
+    };
+
     bool usedPool = false;
     try {
         auto ctx = OTRGlobals::Instance->gRandoContext;
@@ -3590,7 +3598,7 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoStaticData(void) {
                 if (!in.empty())
                     fixed.push_back({ { "check", name },
                                       { "item", in },
-                                      { "advancement", Rando::StaticData::RetrieveItem(placed).IsAdvancement() },
+                                      { "advancement", comboIsAdv(placed) },
                                       { "major", isMajor(placed) } });
             } else {
                 // A real fillable check. GenerateLocationPool already decided what's shuffled and the
@@ -3608,7 +3616,7 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoStaticData(void) {
             if (in.empty())
                 continue;
             pool.push_back({ { "name", in },
-                             { "advancement", Rando::StaticData::RetrieveItem(rg).IsAdvancement() },
+                             { "advancement", comboIsAdv(rg) },
                              { "major", isMajor(rg) } });
         }
         // itemPool excludes shop slots (CountEmptyLocations(false)); shuffled shop checks are covered
@@ -3648,7 +3656,7 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoStaticData(void) {
                 continue;
             checks.push_back({ { "name", name },
                                { "vanillaItem", vigName },
-                               { "advancement", Rando::StaticData::RetrieveItem(vanillaRG).IsAdvancement() } });
+                               { "advancement", comboIsAdv(vanillaRG) } });
         }
         usedPool = true;
 #endif
@@ -3682,7 +3690,7 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoStaticData(void) {
             // ComboShip: advancement flag — same as the pool path above.
             checks.push_back({ { "name", name },
                                { "vanillaItem", vigName },
-                               { "advancement", Rando::StaticData::RetrieveItem(vanillaRG).IsAdvancement() } });
+                               { "advancement", comboIsAdv(vanillaRG) } });
         }
     }
 
@@ -3695,7 +3703,8 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoStaticData(void) {
         // ComboShip: OOT item names are already human English; displayName == name keeps the
         // dump schema symmetric with MM's (which needs the distinction: RI_* vs human).
         // advancement drives whether a foreign item plays the held-up pickup animation.
-        items.push_back({ { "name", name }, { "displayName", name }, { "advancement", item.IsAdvancement() } });
+        items.push_back(
+            { { "name", name }, { "displayName", name }, { "advancement", comboIsAdv(static_cast<RandomizerGet>(rg)) } });
     }
 
     cached = nlohmann::json{

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -3619,9 +3619,7 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoStaticData(void) {
             const std::string& in = Rando::StaticData::RetrieveItem(rg).GetName().GetEnglish();
             if (in.empty())
                 continue;
-            pool.push_back({ { "name", in },
-                             { "advancement", comboIsAdv(rg) },
-                             { "major", isMajor(rg) } });
+            pool.push_back({ { "name", in }, { "advancement", comboIsAdv(rg) }, { "major", isMajor(rg) } });
         }
         // itemPool excludes shop slots (CountEmptyLocations(false)); shuffled shop checks are covered
         // by junk, exactly like native FastFill's GetJunkItem() padding — Buy items stay shop-only.
@@ -3664,9 +3662,8 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoStaticData(void) {
             const std::string& vigName = Rando::StaticData::RetrieveItem(vanillaRG).GetName().GetEnglish();
             if (vigName.empty())
                 continue;
-            checks.push_back({ { "name", name },
-                               { "vanillaItem", vigName },
-                               { "advancement", comboIsAdv(vanillaRG) } });
+            checks.push_back(
+                { { "name", name }, { "vanillaItem", vigName }, { "advancement", comboIsAdv(vanillaRG) } });
         }
         usedPool = true;
 #endif
@@ -3698,9 +3695,8 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoStaticData(void) {
                 continue;
 
             // ComboShip: advancement flag — same as the pool path above.
-            checks.push_back({ { "name", name },
-                               { "vanillaItem", vigName },
-                               { "advancement", comboIsAdv(vanillaRG) } });
+            checks.push_back(
+                { { "name", name }, { "vanillaItem", vigName }, { "advancement", comboIsAdv(vanillaRG) } });
         }
     }
 
@@ -3713,17 +3709,14 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoStaticData(void) {
         // ComboShip: OOT item names are already human English; displayName == name keeps the
         // dump schema symmetric with MM's (which needs the distinction: RI_* vs human).
         // advancement drives whether a foreign item plays the held-up pickup animation.
-        items.push_back(
-            { { "name", name }, { "displayName", name }, { "advancement", comboIsAdv(static_cast<RandomizerGet>(rg)) } });
+        items.push_back({ { "name", name },
+                          { "displayName", name },
+                          { "advancement", comboIsAdv(static_cast<RandomizerGet>(rg)) } });
     }
 
     cached = nlohmann::json{
-        { "checks", std::move(checks) },
-        { "pool", std::move(pool) },
-        { "fixed", std::move(fixed) },
-        { "items", std::move(items) },
-        { "prices", std::move(prices) },
-        { "accessibility", std::move(accessibility) }
+        { "checks", std::move(checks) }, { "pool", std::move(pool) },     { "fixed", std::move(fixed) },
+        { "items", std::move(items) },   { "prices", std::move(prices) }, { "accessibility", std::move(accessibility) }
     }.dump();
     return cached.c_str();
 }


### PR DESCRIPTION
## Overview

Makes the combo cross-world fill honor OOT's **logic/accessibility settings per-game** (previously inert — GAP-8), and marks OOT hearts as junk. Combo-owned; vendored soh edits are minimal and `COMBO_BUILD`-guarded.

Stacks on the cross-hint work (#71). The diff here is only the accessibility changes.

## What it does

- **Per-game accessibility.** OOT can now be **All-Locations-Reachable** (default), **Beatable-Only** (ALR-off), or **No Logic**; **MM is always all-reachable** (MM has no such setting and its generator is intrinsically all-reachable). Rule: *protect by item-game* (MM advancement items must land reachable, even on OOT checks), *relax by item-game* (OOT advancement may strand). Settings are read from the OOT dump into the fill.
- **Hearts as junk.** OOT Piece of Heart / Heart Container / Treasure-Game Heart are marked non-advancement in the dump (mirroring MM), shrinking the advancement set and easing fill dead-ends. Safe under glitchless (hearts are never logically required); conservative under high damage-multiplier, matching MM. Native `IsAdvancement()` is untouched (single-game SoH unaffected).
- **Portal-key handling.** The Mask Shop Key that gates MM (Overworld Keys) is a locked placement immune to relaxation, so relaxed modes can't strand it in the intended config. A loud warning fires on the one exposed combination (Overworld Keys on + Force-Mask-Shop-Key off + relaxed mode), and a TODO marks the seam for a future real portal.
- Under No Logic the WotH pare-down uses an MM-only goal predicate so hints stay meaningful; the headless verdict tolerates an unbeatable OOT/Ganon side while still requiring MM/Majora reachable.

## Verification

All three modes driven headless (`comborando`): MM stays all-reachable in each, OOT relaxes correctly, goals handled per mode. **ALL_REACHABLE is byte-identical to before** (normal generation untouched). Hearts confirmed non-advancement and never hinted WotH. Release generation ~12.8s.

**Playtest-gated** (not exercisable headlessly): the in-game save-apply path for relaxed modes, the Overworld-Keys-on + Force-off combination, and the beatable-only dead-end path on a heavily-constrained OOT seed.


<!--- section:artifacts:start -->
### Build Artifacts
  - [comborando-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8395200942.zip)
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8395200183.zip)
<!--- section:artifacts:end -->