### PR TITLE
Combo plandomizer, foreign-draw portability, and cross-game fixes

### DIFF
--- a/combo/ComboRandoHeadless.cpp
+++ b/combo/ComboRandoHeadless.cpp
@@ -412,9 +412,8 @@ int main(int argc, char** argv) {
                     // RunComboFill's consolidated writer) so the headless spoiler shows "(OOT)"/"(MM)".
                     nlohmann::json ootPl = fillSpoiler.value("oot", nlohmann::json::object());
                     nlohmann::json mmPl = fillSpoiler.value("mm", nlohmann::json::object());
-                    ComboRando::SuffixCrossGameItems(ootPl, mmPl,
-                                                     fillSpoiler.value("foreign", nlohmann::json::array()), sohDump,
-                                                     mmDump);
+                    ComboRando::SuffixCrossGameItems(ootPl, mmPl, fillSpoiler.value("foreign", nlohmann::json::array()),
+                                                     sohDump, mmDump);
                     consolidated["oot"] = { { "settings", nlohmann::json::parse(SOH_DumpSettings()) },
                                             { "enabledTricks", SOH_DumpEnabledTricks
                                                                    ? nlohmann::json::parse(SOH_DumpEnabledTricks())

--- a/combo/ComboRandoHeadless.cpp
+++ b/combo/ComboRandoHeadless.cpp
@@ -246,11 +246,12 @@ int main(int argc, char** argv) {
                                       << owS << " wallet(s) at sphere " << sph.value("sphere", -1) << "\n";
                         }
                     } else if (game == "mm" && mmPrices.contains(chk) &&
-                               (chk.find("SHOP_ITEM") != std::string::npos ||
-                                chk.find("TINGLE_MAP") != std::string::npos ||
-                                chk.find("GORMAN_MILK") != std::string::npos ||
-                                chk.find("MILK_BAR") != std::string::npos ||
-                                chk.find("CURIOSITY") != std::string::npos)) {
+                               // ComboShip: friendly (prettified) forms of the MM purchase check names.
+                               (chk.find("Shop Item") != std::string::npos ||
+                                chk.find("Tingle Map") != std::string::npos ||
+                                chk.find("Gorman Milk") != std::string::npos ||
+                                chk.find("Milk Bar") != std::string::npos ||
+                                chk.find("Curiosity") != std::string::npos)) {
                         int p = mmPrices[chk].get<int>();
                         if (!(p < 100 || (p <= 200 && mwS >= 1) || mwS >= 2)) {
                             ++bad;
@@ -258,10 +259,17 @@ int main(int argc, char** argv) {
                                       << mwS << " wallet(s) at sphere " << sph.value("sphere", -1) << "\n";
                         }
                     }
-                    if (item == "Progressive Wallet")
-                        ++ow;
-                    if (item == "RI_PROGRESSIVE_WALLET")
-                        ++mw;
+                    // ComboShip: both games' wallet now normalizes to "Progressive Wallet"; attribute to
+                    // the item's HOME game (itemGame), derived from the check game + foreign flag, so a
+                    // cross-placed wallet still credits its owner's tier (matches the pre-rename semantics).
+                    if (item == "Progressive Wallet") {
+                        bool fgn = st.value("foreign", false);
+                        std::string homeGame = fgn ? (game == "oot" ? "mm" : "oot") : game;
+                        if (homeGame == "oot")
+                            ++ow;
+                        else
+                            ++mw;
+                    }
                 }
             }
             return bad;
@@ -400,14 +408,21 @@ int main(int argc, char** argv) {
                     consolidated["fileType"] = "ComboShipRandomizer";
                     consolidated["seed"] = seed;
                     consolidated["masterSeed"] = masterSeed;
+                    // ComboShip: suffix cross-game item-name collisions in the placements (parity with
+                    // RunComboFill's consolidated writer) so the headless spoiler shows "(OOT)"/"(MM)".
+                    nlohmann::json ootPl = fillSpoiler.value("oot", nlohmann::json::object());
+                    nlohmann::json mmPl = fillSpoiler.value("mm", nlohmann::json::object());
+                    ComboRando::SuffixCrossGameItems(ootPl, mmPl,
+                                                     fillSpoiler.value("foreign", nlohmann::json::array()), sohDump,
+                                                     mmDump);
                     consolidated["oot"] = { { "settings", nlohmann::json::parse(SOH_DumpSettings()) },
                                             { "enabledTricks", SOH_DumpEnabledTricks
                                                                    ? nlohmann::json::parse(SOH_DumpEnabledTricks())
                                                                    : nlohmann::json::array() },
-                                            { "placements", fillSpoiler.value("oot", nlohmann::json::object()) },
+                                            { "placements", ootPl },
                                             { "prices", pricesOf(sohDump) } };
                     consolidated["mm"] = { { "settings", nlohmann::json::parse(MM_DumpSettings()) },
-                                           { "placements", fillSpoiler.value("mm", nlohmann::json::object()) },
+                                           { "placements", mmPl },
                                            { "prices", pricesOf(mmDump) } };
                     // ComboShip: enrich the foreign array exactly like RunComboFill (displayName game
                     // suffix + oot checkArea) so the headless consolidated file matches the in-game one.

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -1013,6 +1013,11 @@ static void RunComboFill(std::string inputSeed, ComboRando::ComboGenProgress* pr
                 return nlohmann::json::parse(fn());
             } catch (...) { return nlohmann::json::object(); }
         };
+        // ComboShip: suffix cross-game item-name collisions (e.g. "Mirror Shield") in the human-readable
+        // placements so the consolidated file / plandomizer read unambiguously; each game strips its own
+        // "(OOT)"/"(MM)" on apply. Foreign checks are skipped (carried by foreign[]).
+        ComboRando::SuffixCrossGameItems(ootSpoiler, mmSpoiler, foreignArr, sohDump, mmDump);
+
         nlohmann::json consolidated;
         consolidated["fileType"] = "ComboShipRandomizer";
         consolidated["version"] = 1;

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -609,25 +609,8 @@ void DrawNetworkSharedPanel() {
     const ImVec4 theme = ComboRando::ComboMenu_ThemeColor();
     ResolveAnchorResyncSyms();
 
-    // Render the Ship of Harkinian "Network > Anchor" settings (host/port/connect) from the game
-    // model, so the full Anchor config lives here with the team-sync control.
-    auto& model = ComboMenuModel::Get();
-    model.EnsureLoaded();
-    const ComboRando::GameMenu& oot = model.Oot();
-    if (oot.loaded && oot.menu) {
-        for (int s = 0; s < oot.menu->sectionCount; ++s) {
-            const CwSection& sec = oot.menu->sections[s];
-            if (!sec.sectionLabel || strcmp(sec.sectionLabel, "Network") != 0)
-                continue;
-            for (int sb = 0; sb < sec.sidebarCount; ++sb) {
-                if (sec.sidebars[sb].sidebarName && strcmp(sec.sidebars[sb].sidebarName, "Anchor") == 0)
-                    RenderSidebarWidgets(sec.sidebars[sb], oot);
-            }
-            break;
-        }
-    }
-
-    // Team sync is an Anchor feature (covers both games), so it lives in this Anchor panel.
+    // Team sync is an Anchor feature (covers both games) — keep it at the top of the Anchor panel so
+    // it's immediately visible, above the Ship of Harkinian Anchor connection settings.
     ImGui::SeparatorText("Team Sync");
     ImGui::TextWrapped("Pull the latest team progress from your Anchor teammates for BOTH games.");
     ComboRando::ComboMenu_PushButton(theme);
@@ -639,6 +622,26 @@ void DrawNetworkSharedPanel() {
     }
     ComboRando::ComboMenu_PopButton();
     ImGui::TextDisabled("Use this if you're missing items/flags a teammate has collected in either game.");
+
+    // Below it, the Ship of Harkinian "Network > Anchor" settings (host/port/connect) rendered from the
+    // game model, so the full Anchor config lives here too.
+    auto& model = ComboMenuModel::Get();
+    model.EnsureLoaded();
+    const ComboRando::GameMenu& oot = model.Oot();
+    if (oot.loaded && oot.menu) {
+        for (int s = 0; s < oot.menu->sectionCount; ++s) {
+            const CwSection& sec = oot.menu->sections[s];
+            if (!sec.sectionLabel || strcmp(sec.sectionLabel, "Network") != 0)
+                continue;
+            for (int sb = 0; sb < sec.sidebarCount; ++sb) {
+                if (sec.sidebars[sb].sidebarName && strcmp(sec.sidebars[sb].sidebarName, "Anchor") == 0) {
+                    ImGui::SeparatorText("Anchor Connection");
+                    RenderSidebarWidgets(sec.sidebars[sb], oot);
+                }
+            }
+            break;
+        }
+    }
 }
 
 // Build the combined item picker list from both games' static-data dumps (items[] = full item table

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -7,6 +7,7 @@
 #include "ComboTrackerBridge.h"
 #include "ComboTrackerCommon.h" // kKinds (HideBackground CVars for the tracker panels)
 #include "ComboTrackerSwap.h"
+#include "rando/ComboPlaythrough.h" // plando: ParseSpoilerPlacements + Suffix/BuildForeignArray + slot paths
 #include <imgui.h>
 #include <ship/window/gui/IconsFontAwesome4.h> // ICON_FA_* for the header action buttons
 #include <memory>
@@ -60,6 +61,54 @@ void ResolveAnchorResyncSyms() {
     }
 #endif
 }
+
+// Combo plandomizer exports: each game's static-data dump (friendly item names) + the reload trigger
+// that plays an edited consolidated spoiler back verbatim. Resolved like the combo-gen syms above.
+typedef const char* (*FnDump)(void);
+typedef int (*FnRequestReload)(const char*);
+typedef int (*FnGetActiveFileNum)(void);
+FnDump sSohDump = nullptr;
+FnDump sMmDump = nullptr;
+FnRequestReload sRequestReload = nullptr;
+FnGetActiveFileNum sGetActiveFileNum = nullptr;
+void ResolvePlandoSyms() {
+#ifdef _WIN32
+    if (HMODULE h = GetModuleHandleA("soh.dll")) {
+        if (!sSohDump)
+            sSohDump = (FnDump)GetProcAddress(h, "SOH_DumpRandoStaticData");
+        if (!sRequestReload)
+            sRequestReload = (FnRequestReload)GetProcAddress(h, "SOH_RequestComboReload");
+        if (!sGetActiveFileNum)
+            sGetActiveFileNum = (FnGetActiveFileNum)GetProcAddress(h, "SOH_GetActiveFileNum");
+    }
+    if (HMODULE h = GetModuleHandleA("2ship.dll")) {
+        if (!sMmDump)
+            sMmDump = (FnDump)GetProcAddress(h, "MM_DumpRandoStaticData");
+    }
+#endif
+}
+
+// Combo plandomizer editable state (single ComboMenu instance -> file-static). rows is the edited
+// placement model; loadedJson is the original consolidated file, preserved on write-back so only
+// placements/foreign change. items is the combined per-game picker list (bare name + game + display).
+struct PlandoPickItem {
+    std::string name; // bare friendly name (item's own game namespace)
+    ComboRando::GameId game;
+    bool advancement;
+    std::string display; // "name (OOT)" / "name (MM)"
+};
+struct PlandoState {
+    bool loaded = false;
+    bool statusError = false;
+    std::string status;
+    std::string loadedJson; // original consolidated file text (write-back base)
+    std::string sohDump, mmDump;
+    std::vector<ComboRando::CwPlacedItem> rows;
+    std::vector<PlandoPickItem> items;
+    char filter[128] = { 0 };
+    char pickerFilter[128] = { 0 };
+};
+static PlandoState sPlando;
 } // namespace
 
 namespace ComboRando {
@@ -293,7 +342,16 @@ namespace {
 struct HubEntry {
     std::string label; // shown in the left panel
     std::string group; // owning group label (for the unique key)
-    enum Kind { ENGINE, OOT_RANDO, MM_RANDO, COMBO_GEN, COMBO_TRACKER, COMBO_CHECK_TRACKER, COMBO_NETWORK } kind;
+    enum Kind {
+        ENGINE,
+        OOT_RANDO,
+        MM_RANDO,
+        COMBO_GEN,
+        COMBO_PLANDO,
+        COMBO_TRACKER,
+        COMBO_CHECK_TRACKER,
+        COMBO_NETWORK
+    } kind;
     const ComboRando::GameMenu* game = nullptr; // ENGINE/OOT_RANDO/MM_RANDO
     int sectionIndex = -1;
     int sidebarIndex = -1;
@@ -534,6 +592,252 @@ void DrawNetworkSharedPanel() {
     ComboRando::ComboMenu_PopButton();
     ImGui::TextDisabled("Use this if you're missing items/flags a teammate has collected in either game.");
 }
+
+// Build the combined item picker list from both games' static-data dumps (items[] = full item table
+// with friendly name + advancement). Each game's items get its own "(OOT)"/"(MM)" display tag.
+void PlandoBuildItems() {
+    sPlando.items.clear();
+    auto add = [&](const std::string& dump, ComboRando::GameId g, const char* suf) {
+        try {
+            auto d = nlohmann::json::parse(dump);
+            std::unordered_set<std::string> seen;
+            for (auto& it : d.value("items", nlohmann::json::array())) {
+                std::string n = it.value("name", std::string{});
+                if (n.empty() || !seen.insert(n).second)
+                    continue;
+                sPlando.items.push_back({ n, g, it.value("advancement", true), n + suf });
+            }
+        } catch (...) {}
+    };
+    add(sPlando.sohDump, ComboRando::GAME_OOT, " (OOT)");
+    add(sPlando.mmDump, ComboRando::GAME_MM, " (MM)");
+}
+
+// Load the current pending/slot consolidated spoiler into the editable model (the #73 fix — the
+// vendored OOT plando can't parse the consolidated schema). Flattens oot/mm.placements + foreign[]
+// into the shape ParseSpoilerPlacements expects, resolving foreign checks to their real cross-game item.
+void PlandoLoad() {
+    ResolvePlandoSyms();
+    sPlando.loaded = false;
+    sPlando.rows.clear();
+    int slot = sGetActiveFileNum ? sGetActiveFileNum() : -1;
+    std::filesystem::path path = (slot >= 0) ? ComboRando::SlotReadPath(slot) : std::filesystem::path{};
+    if (path.empty())
+        path = ComboRando::PendingPath();
+    std::ifstream in(path);
+    if (!in.is_open()) {
+        sPlando.status = "No generated seed found to load.";
+        sPlando.statusError = true;
+        return;
+    }
+    std::stringstream ss;
+    ss << in.rdbuf();
+    sPlando.loadedJson = ss.str();
+    nlohmann::json j;
+    try {
+        j = nlohmann::json::parse(sPlando.loadedJson);
+    } catch (...) {
+        sPlando.status = "Failed to parse the spoiler file.";
+        sPlando.statusError = true;
+        return;
+    }
+    if (j.value("fileType", std::string()) != "ComboShipRandomizer") {
+        sPlando.status = "Not a ComboShip seed (regenerate with this build).";
+        sPlando.statusError = true;
+        return;
+    }
+    sPlando.sohDump = sSohDump ? sSohDump() : "";
+    sPlando.mmDump = sMmDump ? sMmDump() : "";
+    PlandoBuildItems();
+
+    nlohmann::json flat;
+    flat["oot"] = j.value("oot", nlohmann::json::object()).value("placements", nlohmann::json::object());
+    flat["mm"] = j.value("mm", nlohmann::json::object()).value("placements", nlohmann::json::object());
+    flat["foreign"] = j.value("foreign", nlohmann::json::array());
+    sPlando.rows = ComboRando::ParseSpoilerPlacements(flat.dump(), sPlando.sohDump, sPlando.mmDump);
+    std::sort(sPlando.rows.begin(), sPlando.rows.end(), [](const auto& a, const auto& b) {
+        if (a.checkGame != b.checkGame)
+            return a.checkGame < b.checkGame;
+        return a.check < b.check;
+    });
+    sPlando.loaded = true;
+    sPlando.statusError = false;
+    sPlando.status = "Loaded " + std::to_string(sPlando.rows.size()) + " placements from " + path.filename().string();
+}
+
+// Serialize the edited model back to the consolidated schema and play it verbatim. Preserves the
+// original file and replaces only oot/mm.placements + foreign[], mirroring the generator's emit
+// (SuffixCrossGameItems on native collisions + BuildForeignArray for cross-game entries).
+void PlandoSavePlay() {
+    ResolvePlandoSyms();
+    nlohmann::json j;
+    try {
+        j = nlohmann::json::parse(sPlando.loadedJson);
+    } catch (...) {
+        sPlando.status = "Internal parse error.";
+        sPlando.statusError = true;
+        return;
+    }
+
+    nlohmann::json ootPl = nlohmann::json::object();
+    nlohmann::json mmPl = nlohmann::json::object();
+    nlohmann::json foreignRaw = nlohmann::json::array();
+    for (const auto& r : sPlando.rows) {
+        // The check's own game stores the REAL foreign item's bare name; the sentinel is injected at
+        // apply time by Combo_OnReloadRequest, never written here.
+        (r.checkGame == ComboRando::GAME_OOT ? ootPl : mmPl)[r.check] = r.item;
+        if (r.checkGame != r.itemGame) {
+            foreignRaw.push_back({ { "checkGame", r.checkGame == ComboRando::GAME_OOT ? "oot" : "mm" },
+                                   { "checkName", r.check },
+                                   { "itemGame", r.itemGame == ComboRando::GAME_OOT ? "oot" : "mm" },
+                                   { "itemName", r.item },
+                                   { "displayName", r.item }, // BuildForeignArray appends the game suffix
+                                   { "advancement", r.advancement } });
+        }
+    }
+    // Native cross-game name collisions get their own-game suffix; foreign checks are skipped (their
+    // real item travels in foreign[]). Exactly the generator's write path.
+    ComboRando::SuffixCrossGameItems(ootPl, mmPl, foreignRaw, sPlando.sohDump, sPlando.mmDump);
+    nlohmann::json foreign = ComboRando::BuildForeignArray(foreignRaw);
+
+    j["oot"]["placements"] = ootPl;
+    j["mm"]["placements"] = mmPl;
+    j["foreign"] = foreign;
+
+    std::error_code ec;
+    std::filesystem::create_directories(ComboRando::ConsolidatedDir(), ec);
+    auto path = ComboRando::PendingPath();
+    {
+        std::ofstream out(path, std::ios::trunc);
+        if (!out.is_open()) {
+            sPlando.status = "Failed to write the pending file.";
+            sPlando.statusError = true;
+            return;
+        }
+        out << j.dump(2);
+    }
+    sPlando.loadedJson = j.dump(2); // keep in sync for a follow-up edit
+    if (!sRequestReload) {
+        sPlando.status = "Reload export unavailable (soh.dll not loaded).";
+        sPlando.statusError = true;
+        return;
+    }
+    int ok = sRequestReload(path.string().c_str());
+    if (ok) {
+        sPlando.status = "Saved. Start a file to play it.";
+        sPlando.statusError = false;
+    } else {
+        sPlando.status = "Reload rejected (be on the file-select screen; no generation running).";
+        sPlando.statusError = true;
+    }
+}
+
+// Combo > Plandomizer: load a generated combo seed, edit item placements (native OR cross-game),
+// then Save & Play. Placements-only MVP; prices/settings/tricks/hints are preserved read-only.
+void DrawComboPlandoPanel() {
+    const ImVec4 theme = ComboRando::ComboMenu_ThemeColor();
+    ResolvePlandoSyms();
+    ResolveComboGenSyms(); // sIsOnFileSelect gates Save & Play (reload mutates save state)
+    ImGui::TextWrapped("Load a generated combo seed, edit item placements (assign any item to any check "
+                       "in either game, including cross-game), then Save & Play. Use on the file-select screen.");
+    ImGui::Separator();
+
+    ComboRando::ComboMenu_PushButton(theme);
+    if (ImGui::Button("Load"))
+        PlandoLoad();
+    ComboRando::ComboMenu_PopButton();
+
+    if (sPlando.loaded) {
+        ImGui::SameLine();
+        const bool onFileSelect = sIsOnFileSelect && sIsOnFileSelect();
+        const bool canPlay = sRequestReload && onFileSelect;
+        if (!canPlay)
+            ImGui::BeginDisabled();
+        ComboRando::ComboMenu_PushButton(theme);
+        if (ImGui::Button("Save"))
+            PlandoSavePlay();
+        ComboRando::ComboMenu_PopButton();
+        if (!canPlay)
+            ImGui::EndDisabled();
+        if (sRequestReload && !onFileSelect) {
+            ImGui::SameLine();
+            ImGui::TextDisabled("(available on the file-select screen)");
+        }
+    }
+
+    if (!sPlando.status.empty()) {
+        ImVec4 c = sPlando.statusError ? ImVec4(1.0f, 0.4f, 0.4f, 1.0f) : ImVec4(0.5f, 1.0f, 0.5f, 1.0f);
+        ImGui::TextColored(c, "%s", sPlando.status.c_str());
+    }
+    if (!sPlando.loaded)
+        return;
+
+    ImGui::Separator();
+    ImGui::SetNextItemWidth(320.0f);
+    ComboRando::ComboMenu_PushInput(theme);
+    ImGui::InputTextWithHint("##plandofilter", "Filter by check or item name...", sPlando.filter, sizeof(sPlando.filter));
+    ComboRando::ComboMenu_PopInput();
+
+    const std::string q = NormalizeSearch(sPlando.filter);
+
+    ImGui::BeginChild("##plandotable", ImVec2(0, 0));
+    const ImGuiTableFlags tf = ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersInnerH | ImGuiTableFlags_ScrollY |
+                               ImGuiTableFlags_NoSavedSettings | ImGuiTableFlags_SizingStretchProp;
+    if (ImGui::BeginTable("##plandorows", 3, tf)) {
+        ImGui::TableSetupColumn("Game", ImGuiTableColumnFlags_WidthFixed, 48.0f);
+        ImGui::TableSetupColumn("Check", ImGuiTableColumnFlags_WidthStretch, 0.5f);
+        ImGui::TableSetupColumn("Item", ImGuiTableColumnFlags_WidthStretch, 0.5f);
+        ImGui::TableSetupScrollFreeze(0, 1);
+        ImGui::TableHeadersRow();
+        for (int i = 0; i < (int)sPlando.rows.size(); ++i) {
+            auto& r = sPlando.rows[i];
+            if (!q.empty() && NormalizeSearch(r.check + r.item).find(q) == std::string::npos)
+                continue;
+            const bool cross = r.checkGame != r.itemGame;
+            const char* itag = r.itemGame == ComboRando::GAME_OOT ? " (OOT)" : " (MM)";
+            ImGui::TableNextRow();
+            ImGui::TableSetColumnIndex(0);
+            ImGui::TextUnformatted(r.checkGame == ComboRando::GAME_OOT ? "OOT" : "MM");
+            ImGui::TableSetColumnIndex(1);
+            ImGui::TextUnformatted(r.check.c_str());
+            ImGui::TableSetColumnIndex(2);
+            ImGui::PushID(i);
+            std::string label = r.item + itag;
+            if (cross) // highlight cross-game placements (the harness's whole point)
+                ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.85f, 0.4f, 1.0f));
+            ComboRando::ComboMenu_PushButton(theme);
+            if (ImGui::Button(label.c_str(), ImVec2(-1.0f, 0.0f))) {
+                sPlando.pickerFilter[0] = '\0';
+                ImGui::OpenPopup("##itempicker");
+            }
+            ComboRando::ComboMenu_PopButton();
+            if (cross)
+                ImGui::PopStyleColor();
+            if (ImGui::BeginPopup("##itempicker")) {
+                ImGui::SetNextItemWidth(300.0f);
+                ImGui::InputTextWithHint("##pickfilter", "Search items...", sPlando.pickerFilter,
+                                         sizeof(sPlando.pickerFilter));
+                const std::string pq = NormalizeSearch(sPlando.pickerFilter);
+                ImGui::BeginChild("##pickerlist", ImVec2(340.0f, 380.0f));
+                for (const auto& pit : sPlando.items) {
+                    if (!pq.empty() && NormalizeSearch(pit.name).find(pq) == std::string::npos)
+                        continue;
+                    if (ImGui::Selectable(pit.display.c_str())) {
+                        r.item = pit.name;
+                        r.itemGame = pit.game;
+                        r.advancement = pit.advancement;
+                        ImGui::CloseCurrentPopup();
+                    }
+                }
+                ImGui::EndChild();
+                ImGui::EndPopup();
+            }
+            ImGui::PopID();
+        }
+        ImGui::EndTable();
+    }
+    ImGui::EndChild();
+}
 } // namespace
 
 void ComboMenu::DrawSharedPanel() {
@@ -592,11 +896,18 @@ void ComboMenu::DrawSharedPanel() {
                 groups.push_back({ "MM Randomizer", std::move(e) });
         }
         {
+            std::vector<HubEntry> e;
             HubEntry gen;
             gen.label = "Generate";
             gen.group = "Combo";
             gen.kind = HubEntry::COMBO_GEN;
-            groups.push_back({ "Combo", { std::move(gen) } });
+            e.push_back(std::move(gen));
+            HubEntry pl;
+            pl.label = "Plandomizer";
+            pl.group = "Combo";
+            pl.kind = HubEntry::COMBO_PLANDO;
+            e.push_back(std::move(pl));
+            groups.push_back({ "Combo", std::move(e) });
         }
     }
 
@@ -673,6 +984,8 @@ void ComboMenu::DrawSharedPanel() {
         ImGui::TextUnformatted("Select an option.");
     } else if (active->kind == HubEntry::COMBO_GEN) {
         DrawComboPanel();
+    } else if (active->kind == HubEntry::COMBO_PLANDO) {
+        DrawComboPlandoPanel();
     } else if (active->kind == HubEntry::COMBO_TRACKER) {
         DrawTrackerSharedPanel();
     } else if (active->kind == HubEntry::COMBO_CHECK_TRACKER) {

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -608,6 +608,27 @@ void DrawCheckTrackerSharedPanel() {
 void DrawNetworkSharedPanel() {
     const ImVec4 theme = ComboRando::ComboMenu_ThemeColor();
     ResolveAnchorResyncSyms();
+
+    // Render the Ship of Harkinian "Network > Anchor" settings (host/port/connect) from the game
+    // model, so the full Anchor config lives here with the team-sync control.
+    auto& model = ComboMenuModel::Get();
+    model.EnsureLoaded();
+    const ComboRando::GameMenu& oot = model.Oot();
+    if (oot.loaded && oot.menu) {
+        for (int s = 0; s < oot.menu->sectionCount; ++s) {
+            const CwSection& sec = oot.menu->sections[s];
+            if (!sec.sectionLabel || strcmp(sec.sectionLabel, "Network") != 0)
+                continue;
+            for (int sb = 0; sb < sec.sidebarCount; ++sb) {
+                if (sec.sidebars[sb].sidebarName && strcmp(sec.sidebars[sb].sidebarName, "Anchor") == 0)
+                    RenderSidebarWidgets(sec.sidebars[sb], oot);
+            }
+            break;
+        }
+    }
+
+    // Team sync is an Anchor feature (covers both games), so it lives in this Anchor panel.
+    ImGui::SeparatorText("Team Sync");
     ImGui::TextWrapped("Pull the latest team progress from your Anchor teammates for BOTH games.");
     ComboRando::ComboMenu_PushButton(theme);
     if (ImGui::Button("Resync team state", ImVec2(-1.0f, 0.0f))) {
@@ -933,12 +954,15 @@ void ComboMenu::DrawSharedPanel() {
         // OOT tab so all network settings live in one shared place.
         {
             std::vector<HubEntry> netE;
-            HubEntry sync;
-            sync.label = "Team Sync";
-            sync.group = "Network";
-            sync.kind = HubEntry::COMBO_NETWORK;
-            netE.push_back(std::move(sync));
-            AppendSectionEntries(netE, "Network", HubEntry::ENGINE, model.Oot(), "Network", {});
+            // Anchor panel = SoH Network "Anchor" settings + the team-sync resync (both combo-owned draw).
+            HubEntry anchor;
+            anchor.label = "Anchor";
+            anchor.group = "Network";
+            anchor.kind = HubEntry::COMBO_NETWORK;
+            netE.push_back(std::move(anchor));
+            // The Anchor sidebar is drawn inside the panel above; surface only the other SoH Network
+            // sidebars (Sail, Crowd Control) as their own entries.
+            AppendSectionEntries(netE, "Network", HubEntry::ENGINE, model.Oot(), "Network", { "Anchor" });
             groups.push_back({ "Network", std::move(netE) });
         }
     } else {

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -105,10 +105,37 @@ struct PlandoState {
     std::string sohDump, mmDump;
     std::vector<ComboRando::CwPlacedItem> rows;
     std::vector<PlandoPickItem> items;
+    std::vector<std::string> spoilerNames; // selectable spoilers in the Randomizer folder (display stems)
+    std::vector<std::string> spoilerPaths; // parallel full paths
+    int spoilerSel = -1;
     char filter[128] = { 0 };
     char pickerFilter[128] = { 0 };
 };
 static PlandoState sPlando;
+
+// List every *.json in the Randomizer folder (PendingPath's parent) as a loadable spoiler; default the
+// selection to Last-Generated when present.
+void PlandoRefreshSpoilerList() {
+    sPlando.spoilerNames.clear();
+    sPlando.spoilerPaths.clear();
+    std::error_code ec;
+    auto dir = ComboRando::PendingPath().parent_path();
+    if (std::filesystem::exists(dir, ec)) {
+        for (const auto& e : std::filesystem::directory_iterator(dir, ec)) {
+            if (e.is_regular_file() && e.path().extension() == ".json") {
+                sPlando.spoilerPaths.push_back(e.path().string());
+                sPlando.spoilerNames.push_back(e.path().stem().string());
+            }
+        }
+    }
+    sPlando.spoilerSel = sPlando.spoilerPaths.empty() ? -1 : 0;
+    for (int i = 0; i < (int)sPlando.spoilerNames.size(); i++) {
+        if (sPlando.spoilerNames[i].find("Last-Generated") != std::string::npos) {
+            sPlando.spoilerSel = i;
+            break;
+        }
+    }
+}
 } // namespace
 
 namespace ComboRando {
@@ -576,8 +603,8 @@ void DrawCheckTrackerSharedPanel() {
     }
 }
 
-// Shared > Network: launcher-orchestrated Anchor resync (bug 2). Full "Ship of Harkinian ->
-// Network" settings migration is a separate follow-up; this is just the resync control.
+// Shared > Network "Team Sync": launcher-orchestrated Anchor resync (bug 2). The Ship of Harkinian
+// Network settings (Sail, Crowd Control) sit beside this as their own entries in the Network group.
 void DrawNetworkSharedPanel() {
     const ImVec4 theme = ComboRando::ComboMenu_ThemeColor();
     ResolveAnchorResyncSyms();
@@ -620,10 +647,16 @@ void PlandoLoad() {
     ResolvePlandoSyms();
     sPlando.loaded = false;
     sPlando.rows.clear();
-    int slot = sGetActiveFileNum ? sGetActiveFileNum() : -1;
-    std::filesystem::path path = (slot >= 0) ? ComboRando::SlotReadPath(slot) : std::filesystem::path{};
-    if (path.empty())
-        path = ComboRando::PendingPath();
+    // Load the spoiler picked in the dropdown; fall back to the active slot's newest / pending file.
+    std::filesystem::path path;
+    if (sPlando.spoilerSel >= 0 && sPlando.spoilerSel < (int)sPlando.spoilerPaths.size()) {
+        path = sPlando.spoilerPaths[sPlando.spoilerSel];
+    } else {
+        int slot = sGetActiveFileNum ? sGetActiveFileNum() : -1;
+        path = (slot >= 0) ? ComboRando::SlotReadPath(slot) : std::filesystem::path{};
+        if (path.empty())
+            path = ComboRando::PendingPath();
+    }
     std::ifstream in(path);
     if (!in.is_open()) {
         sPlando.status = "No generated seed found to load.";
@@ -738,11 +771,32 @@ void DrawComboPlandoPanel() {
     const ImVec4 theme = ComboRando::ComboMenu_ThemeColor();
     ResolvePlandoSyms();
     ResolveComboGenSyms(); // sIsOnFileSelect gates Save & Play (reload mutates save state)
-    ImGui::TextWrapped("Load a generated combo seed, edit item placements (assign any item to any check "
-                       "in either game, including cross-game), then Save & Play. Use on the file-select screen.");
+    ImGui::TextWrapped("Load a spoiler from the Randomizer folder, edit item placements (assign any item to "
+                       "any check in either game, including cross-game), then Save. Use on the file-select screen.");
     ImGui::Separator();
 
+    if (sPlando.spoilerPaths.empty())
+        PlandoRefreshSpoilerList(); // lazy first fill; the Refresh button re-scans on demand
+
+    // Spoiler picker: every *.json in the Randomizer folder is loadable, not just Last-Generated.
+    const char* preview = (sPlando.spoilerSel >= 0 && sPlando.spoilerSel < (int)sPlando.spoilerNames.size())
+                              ? sPlando.spoilerNames[sPlando.spoilerSel].c_str()
+                              : "(no spoilers found)";
+    ImGui::SetNextItemWidth(360.0f);
+    ComboRando::ComboMenu_PushCombobox(theme);
+    if (ImGui::BeginCombo("##plandospoiler", preview)) {
+        for (int i = 0; i < (int)sPlando.spoilerNames.size(); i++) {
+            if (ImGui::Selectable(sPlando.spoilerNames[i].c_str(), i == sPlando.spoilerSel))
+                sPlando.spoilerSel = i;
+        }
+        ImGui::EndCombo();
+    }
+    ComboRando::ComboMenu_PopCombobox();
+    ImGui::SameLine();
     ComboRando::ComboMenu_PushButton(theme);
+    if (ImGui::Button("Refresh"))
+        PlandoRefreshSpoilerList();
+    ImGui::SameLine();
     if (ImGui::Button("Load"))
         PlandoLoad();
     ComboRando::ComboMenu_PopButton();
@@ -872,14 +926,21 @@ void ComboMenu::DrawSharedPanel() {
         chk.group = "Settings";
         chk.kind = HubEntry::COMBO_CHECK_TRACKER;
         e.push_back(std::move(chk));
-        // Combo-owned Network panel: launcher-orchestrated Anchor resync (bug 2).
-        HubEntry net;
-        net.label = "Network";
-        net.group = "Settings";
-        net.kind = HubEntry::COMBO_NETWORK;
-        e.push_back(std::move(net));
         if (!e.empty())
             groups.push_back({ "Settings", std::move(e) });
+        // Network group: the Anchor team-sync control (covers BOTH games) plus the Ship of Harkinian
+        // Network settings (Sail, Crowd Control) surfaced from the OOT menu model — moved here from the
+        // OOT tab so all network settings live in one shared place.
+        {
+            std::vector<HubEntry> netE;
+            HubEntry sync;
+            sync.label = "Team Sync";
+            sync.group = "Network";
+            sync.kind = HubEntry::COMBO_NETWORK;
+            netE.push_back(std::move(sync));
+            AppendSectionEntries(netE, "Network", HubEntry::ENGINE, model.Oot(), "Network", {});
+            groups.push_back({ "Network", std::move(netE) });
+        }
     } else {
         {
             std::vector<HubEntry> e;
@@ -1025,6 +1086,11 @@ void ComboMenu::DrawGamePanel(const char* gameKey) {
     auto sidebarShown = [&](const char* section, const char* sidebar) -> bool {
         if (isOot && section && strcmp(section, "Settings") == 0) {
             return sidebar && (strcmp(sidebar, "Mod Menu") == 0 || strcmp(sidebar, "Presets") == 0);
+        }
+        // OOT Network (Sail, Crowd Control) is surfaced in the shared Network group next to the Anchor
+        // team-sync control, so hide it from the OOT per-game tab.
+        if (isOot && section && strcmp(section, "Network") == 0) {
+            return false;
         }
         // MM's Graphics/Audio/Controls/General are consolidated into the Shared tab — Graphics applies via
         // the single shared window, Controls via the shared gSettings.Controllers.* CVars, Audio via the

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -775,7 +775,8 @@ void DrawComboPlandoPanel() {
     ImGui::Separator();
     ImGui::SetNextItemWidth(320.0f);
     ComboRando::ComboMenu_PushInput(theme);
-    ImGui::InputTextWithHint("##plandofilter", "Filter by check or item name...", sPlando.filter, sizeof(sPlando.filter));
+    ImGui::InputTextWithHint("##plandofilter", "Filter by check or item name...", sPlando.filter,
+                             sizeof(sPlando.filter));
     ComboRando::ComboMenu_PopInput();
 
     const std::string q = NormalizeSearch(sPlando.filter);

--- a/combo/menu/ComboForeignDrawMM.h
+++ b/combo/menu/ComboForeignDrawMM.h
@@ -48,11 +48,11 @@ struct ComboForeignDrawInfoOOT {
     float scale = 0.0f;    // extra uniform model scale; 0 = none (OOT rupees: 0.7)
     bool hasEnvColor = false;
     uint8_t envColor[4] = { 0, 0, 0, 0 };
-    int32_t drawKind = CW_DRAW_KIND_SIMPLE; // non-SIMPLE = replicate a specific OOT draw func
-    uint8_t primColorXlu[4] = { 0, 0, 0, 0 }; // JEWEL gem prim / MUSIC_NOTE tint
-    uint8_t envColorXlu[4] = { 0, 0, 0, 0 };  // JEWEL gem env
-    uint8_t primColorOpa[4] = { 0, 0, 0, 0 }; // JEWEL setting prim
-    uint8_t envColorOpa[4] = { 0, 0, 0, 0 };  // JEWEL setting env
+    int32_t drawKind = CW_DRAW_KIND_SIMPLE;            // non-SIMPLE = replicate a specific OOT draw func
+    uint8_t primColorXlu[4] = { 0, 0, 0, 0 };          // JEWEL gem prim / MUSIC_NOTE tint
+    uint8_t envColorXlu[4] = { 0, 0, 0, 0 };           // JEWEL gem env
+    uint8_t primColorOpa[4] = { 0, 0, 0, 0 };          // JEWEL setting prim
+    uint8_t envColorOpa[4] = { 0, 0, 0, 0 };           // JEWEL setting env
     const char* dls[CW_DRAW_MAX_DLISTS] = { nullptr }; // interned "__OTR__@oot:..." routed paths
 };
 
@@ -193,8 +193,9 @@ inline void MM_DrawForeignGoronSword(const ComboForeignDrawInfoOOT* info) {
     OPEN_DISPS(gfxCtx);
     Gfx_SetupDL25_Opa(gfxCtx);
     gSPSegment(POLY_OPA_DISP++, 0x08,
-               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, play->state.frames * 1, play->state.frames * 0, 32, 32, 1,
-                                  play->state.frames * 0, play->state.frames * 0, 32, 32, 1, 0, 0, 0));
+               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, play->state.frames * 1, play->state.frames * 0,
+                                             32, 32, 1, play->state.frames * 0, play->state.frames * 0, 32, 32, 1, 0, 0,
+                                             0));
     MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, gfxCtx);
     gSPDisplayList(POLY_OPA_DISP++, (Gfx*)info->dls[0]);
     CLOSE_DISPS(gfxCtx);
@@ -209,8 +210,9 @@ inline void MM_DrawForeignDekuNuts(const ComboForeignDrawInfoOOT* info) {
     OPEN_DISPS(gfxCtx);
     Gfx_SetupDL25_Opa(gfxCtx);
     gSPSegment(POLY_OPA_DISP++, 0x08,
-               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, play->state.frames * 6, play->state.frames * 6, 32, 32, 1,
-                                  play->state.frames * 6, play->state.frames * 6, 32, 32, 6, 6, 6, 6));
+               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, play->state.frames * 6, play->state.frames * 6,
+                                             32, 32, 1, play->state.frames * 6, play->state.frames * 6, 32, 32, 6, 6, 6,
+                                             6));
     MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, gfxCtx);
     gSPDisplayList(POLY_OPA_DISP++, (Gfx*)info->dls[0]);
     CLOSE_DISPS(gfxCtx);
@@ -225,8 +227,9 @@ inline void MM_DrawForeignRecoveryHeart(const ComboForeignDrawInfoOOT* info) {
     OPEN_DISPS(gfxCtx);
     Gfx_SetupDL25_Xlu(gfxCtx);
     gSPSegment(POLY_XLU_DISP++, 0x08,
-               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, play->state.frames * 0, -(play->state.frames * 3), 32, 32, 1,
-                                  play->state.frames * 0, -(play->state.frames * 2), 32, 32, 0, -3, 0, -2));
+               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, play->state.frames * 0, -(play->state.frames * 3),
+                                             32, 32, 1, play->state.frames * 0, -(play->state.frames * 2), 32, 32, 0,
+                                             -3, 0, -2));
     MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
     gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[0]);
     CLOSE_DISPS(gfxCtx);
@@ -241,8 +244,9 @@ inline void MM_DrawForeignFish(const ComboForeignDrawInfoOOT* info) {
     OPEN_DISPS(gfxCtx);
     Gfx_SetupDL25_Xlu(gfxCtx);
     gSPSegment(POLY_XLU_DISP++, 0x08,
-               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, play->state.frames * 0, play->state.frames * 1, 32, 32, 1,
-                                  play->state.frames * 0, play->state.frames * 1, 32, 32, 0, 1, 0, 1));
+               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, play->state.frames * 0, play->state.frames * 1,
+                                             32, 32, 1, play->state.frames * 0, play->state.frames * 1, 32, 32, 0, 1, 0,
+                                             1));
     MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
     gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[0]);
     CLOSE_DISPS(gfxCtx);
@@ -257,8 +261,8 @@ inline void MM_DrawForeignPotion(const ComboForeignDrawInfoOOT* info) {
     OPEN_DISPS(gfxCtx);
     Gfx_SetupDL25_Opa(gfxCtx);
     gSPSegment(POLY_OPA_DISP++, 0x08,
-               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, -play->state.frames, play->state.frames, 32, 32, 1,
-                                  -play->state.frames, play->state.frames, 32, 32, -1, 1, -1, 1));
+               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, -play->state.frames, play->state.frames, 32, 32,
+                                             1, -play->state.frames, play->state.frames, 32, 32, -1, 1, -1, 1));
     MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, gfxCtx);
     gSPDisplayList(POLY_OPA_DISP++, (Gfx*)info->dls[1]);
     gSPDisplayList(POLY_OPA_DISP++, (Gfx*)info->dls[0]);
@@ -281,7 +285,7 @@ inline void MM_DrawForeignMirrorShield(const ComboForeignDrawInfoOOT* info) {
     Gfx_SetupDL25_Opa(gfxCtx);
     gSPSegment(POLY_OPA_DISP++, 0x08,
                (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, 0, play->state.frames * 2 % 256, 64, 64, 1, 0,
-                                  play->state.frames * 1 % 128, 32, 32, 0, 2, 0, 1));
+                                             play->state.frames * 1 % 128, 32, 32, 0, 2, 0, 1));
     MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, gfxCtx);
     gSPDisplayList(POLY_OPA_DISP++, (Gfx*)info->dls[0]);
     Gfx_SetupDL25_Xlu(gfxCtx);
@@ -303,7 +307,7 @@ inline void MM_DrawForeignBlueFire(const ComboForeignDrawInfoOOT* info) {
     Gfx_SetupDL25_Xlu(gfxCtx);
     gSPSegment(POLY_XLU_DISP++, 0x08,
                (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, 0, 0, 16, 32, 1, play->state.frames * 1,
-                                  -(play->state.frames * 8), 16, 32, 0, 0, 1, -8));
+                                             -(play->state.frames * 8), 16, 32, 0, 0, 1, -8));
     Matrix_Push();
     Matrix_Translate(-8.0f, -2.0f, 0.0f, MTXMODE_APPLY);
     Matrix_ReplaceRotation(&play->billboardMtxF);
@@ -328,7 +332,7 @@ inline void MM_DrawForeignPoes(const ComboForeignDrawInfoOOT* info) {
     gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[1]);
     gSPSegment(POLY_XLU_DISP++, 0x08,
                (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, 0, 0, 16, 32, 1, play->state.frames * 1,
-                                  -(play->state.frames * 6), 16, 32, 0, 0, 1, -6));
+                                             -(play->state.frames * 6), 16, 32, 0, 0, 1, -6));
     Matrix_Push();
     Matrix_ReplaceRotation(&play->billboardMtxF);
     MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
@@ -353,7 +357,7 @@ inline void MM_DrawForeignFairy(const ComboForeignDrawInfoOOT* info) {
     gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[1]);
     gSPSegment(POLY_XLU_DISP++, 0x08,
                (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, 0, 0, 32, 32, 1, play->state.frames * 1,
-                                  -(play->state.frames * 6), 32, 32, 0, 0, 1, -6));
+                                             -(play->state.frames * 6), 32, 32, 0, 0, 1, -6));
     Matrix_Push();
     Matrix_ReplaceRotation(&play->billboardMtxF);
     MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
@@ -371,8 +375,8 @@ inline void MM_DrawForeignJewel(const ComboForeignDrawInfoOOT* info) {
     GraphicsContext* gfxCtx = play->state.gfxCtx;
     OPEN_DISPS(gfxCtx);
     gSPSegment(POLY_XLU_DISP++, 9,
-               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, 0, 0 % 256, (256 - (0 % 256)) - 1, 64, 64, 1, 0 % 256, (256 - (0 % 256)) - 1,
-                                  16, 16, 0, 0, 0, 0));
+               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, 0, 0 % 256, (256 - (0 % 256)) - 1, 64, 64, 1, 0 % 256,
+                                             (256 - (0 % 256)) - 1, 16, 16, 0, 0, 0, 0));
     gSPSegment(POLY_OPA_DISP++, 8, (uintptr_t)Gfx_TexScrollEx(gfxCtx, 0, 0, 16, 16, 0, 0));
     Matrix_Push();
     Matrix_RotateZYX(0, -0x4000, 0x4000, MTXMODE_APPLY);
@@ -399,8 +403,9 @@ inline void MM_DrawForeignMagicSpell(const ComboForeignDrawInfoOOT* info) {
     OPEN_DISPS(gfxCtx);
     Gfx_SetupDL25_Xlu(gfxCtx);
     gSPSegment(POLY_XLU_DISP++, 0x08,
-               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, play->state.frames * 2, -(play->state.frames * 6), 32, 32, 1,
-                                  play->state.frames * 1, -(play->state.frames * 2), 32, 32, 2, -6, 1, -2));
+               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, play->state.frames * 2, -(play->state.frames * 6),
+                                             32, 32, 1, play->state.frames * 1, -(play->state.frames * 2), 32, 32, 2,
+                                             -6, 1, -2));
     MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
     gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[0]);
     gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[1]);
@@ -417,8 +422,9 @@ inline void MM_DrawForeignScale(const ComboForeignDrawInfoOOT* info) {
     OPEN_DISPS(gfxCtx);
     Gfx_SetupDL25_Xlu(gfxCtx);
     gSPSegment(POLY_XLU_DISP++, 0x08,
-               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, play->state.frames * 2, -(play->state.frames * 2), 64, 64, 1,
-                                  play->state.frames * 4, -(play->state.frames * 4), 32, 32, 2, -2, 4, -4));
+               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, play->state.frames * 2, -(play->state.frames * 2),
+                                             64, 64, 1, play->state.frames * 4, -(play->state.frames * 4), 32, 32, 2,
+                                             -2, 4, -4));
     MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
     gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[2]);
     gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[3]);
@@ -439,8 +445,9 @@ inline void MM_DrawForeignSkullToken(const ComboForeignDrawInfoOOT* info) {
     gSPDisplayList(POLY_OPA_DISP++, (Gfx*)info->dls[0]);
     Gfx_SetupDL25_Xlu(gfxCtx);
     gSPSegment(POLY_XLU_DISP++, 0x08,
-               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, play->state.frames * 0, -(play->state.frames * 5), 32, 32, 1,
-                                  play->state.frames * 0, play->state.frames * 0, 32, 64, 0, -5, 0, 0));
+               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, play->state.frames * 0, -(play->state.frames * 5),
+                                             32, 32, 1, play->state.frames * 0, play->state.frames * 0, 32, 64, 0, -5,
+                                             0, 0));
     MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
     gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[1]);
     CLOSE_DISPS(gfxCtx);
@@ -473,22 +480,52 @@ inline void MM_DrawComboForeign(RandoCheckId randoCheckId) {
     }
 
     switch (info->drawKind) {
-        case CW_DRAW_KIND_GORON_SWORD:    MM_DrawForeignGoronSword(info); break;
-        case CW_DRAW_KIND_DEKU_NUTS:      MM_DrawForeignDekuNuts(info); break;
-        case CW_DRAW_KIND_RECOVERY_HEART: MM_DrawForeignRecoveryHeart(info); break;
-        case CW_DRAW_KIND_FISH:           MM_DrawForeignFish(info); break;
-        case CW_DRAW_KIND_POTION:         MM_DrawForeignPotion(info); break;
-        case CW_DRAW_KIND_MIRROR_SHIELD:  MM_DrawForeignMirrorShield(info); break;
-        case CW_DRAW_KIND_BLUE_FIRE:      MM_DrawForeignBlueFire(info); break;
-        case CW_DRAW_KIND_POES:           MM_DrawForeignPoes(info); break;
-        case CW_DRAW_KIND_FAIRY:          MM_DrawForeignFairy(info); break;
-        case CW_DRAW_KIND_JEWEL:          MM_DrawForeignJewel(info); break;
-        case CW_DRAW_KIND_MAGIC_SPELL:    MM_DrawForeignMagicSpell(info); break;
-        case CW_DRAW_KIND_SCALE:          MM_DrawForeignScale(info); break;
-        case CW_DRAW_KIND_SKULL_TOKEN:    MM_DrawForeignSkullToken(info); break;
-        case CW_DRAW_KIND_MUSIC_NOTE:     MM_DrawForeignMusicNote(info); break;
+        case CW_DRAW_KIND_GORON_SWORD:
+            MM_DrawForeignGoronSword(info);
+            break;
+        case CW_DRAW_KIND_DEKU_NUTS:
+            MM_DrawForeignDekuNuts(info);
+            break;
+        case CW_DRAW_KIND_RECOVERY_HEART:
+            MM_DrawForeignRecoveryHeart(info);
+            break;
+        case CW_DRAW_KIND_FISH:
+            MM_DrawForeignFish(info);
+            break;
+        case CW_DRAW_KIND_POTION:
+            MM_DrawForeignPotion(info);
+            break;
+        case CW_DRAW_KIND_MIRROR_SHIELD:
+            MM_DrawForeignMirrorShield(info);
+            break;
+        case CW_DRAW_KIND_BLUE_FIRE:
+            MM_DrawForeignBlueFire(info);
+            break;
+        case CW_DRAW_KIND_POES:
+            MM_DrawForeignPoes(info);
+            break;
+        case CW_DRAW_KIND_FAIRY:
+            MM_DrawForeignFairy(info);
+            break;
+        case CW_DRAW_KIND_JEWEL:
+            MM_DrawForeignJewel(info);
+            break;
+        case CW_DRAW_KIND_MAGIC_SPELL:
+            MM_DrawForeignMagicSpell(info);
+            break;
+        case CW_DRAW_KIND_SCALE:
+            MM_DrawForeignScale(info);
+            break;
+        case CW_DRAW_KIND_SKULL_TOKEN:
+            MM_DrawForeignSkullToken(info);
+            break;
+        case CW_DRAW_KIND_MUSIC_NOTE:
+            MM_DrawForeignMusicNote(info);
+            break;
         case CW_DRAW_KIND_SIMPLE:
-        default:                          MM_DrawForeignSimple(info); break;
+        default:
+            MM_DrawForeignSimple(info);
+            break;
     }
 }
 

--- a/combo/menu/ComboForeignDrawMM.h
+++ b/combo/menu/ComboForeignDrawMM.h
@@ -48,6 +48,11 @@ struct ComboForeignDrawInfoOOT {
     float scale = 0.0f;    // extra uniform model scale; 0 = none (OOT rupees: 0.7)
     bool hasEnvColor = false;
     uint8_t envColor[4] = { 0, 0, 0, 0 };
+    int32_t drawKind = CW_DRAW_KIND_SIMPLE; // non-SIMPLE = replicate a specific OOT draw func
+    uint8_t primColorXlu[4] = { 0, 0, 0, 0 }; // JEWEL gem prim / MUSIC_NOTE tint
+    uint8_t envColorXlu[4] = { 0, 0, 0, 0 };  // JEWEL gem env
+    uint8_t primColorOpa[4] = { 0, 0, 0, 0 }; // JEWEL setting prim
+    uint8_t envColorOpa[4] = { 0, 0, 0, 0 };  // JEWEL setting env
     const char* dls[CW_DRAW_MAX_DLISTS] = { nullptr }; // interned "__OTR__@oot:..." routed paths
 };
 
@@ -107,8 +112,13 @@ inline const ComboForeignDrawInfoOOT* ComboResolveForeignDrawInfoOOT(RandoCheckI
     info.xluStart = raw.xluStartIndex;
     info.scale = raw.scale;
     info.hasEnvColor = raw.hasEnvColor != 0;
+    info.drawKind = raw.drawKind;
     for (int32_t i = 0; i < 4; i++) {
         info.envColor[i] = raw.envColor[i];
+        info.primColorXlu[i] = raw.primColorXlu[i];
+        info.envColorXlu[i] = raw.envColorXlu[i];
+        info.primColorOpa[i] = raw.primColorOpa[i];
+        info.envColorOpa[i] = raw.envColorOpa[i];
     }
     info.ok = true;
     return &info;
@@ -118,6 +128,338 @@ inline const ComboForeignDrawInfoOOT* ComboResolveForeignDrawInfoOOT(RandoCheckI
 }
 
 } // namespace
+
+// ---- Non-portable OOT draw funcs (segment-8/9 texture scrolls, billboard rotation, per-instance
+// prim/env color). Each handler is a 1:1 port of the OOT get-item func (soh/src/code/z_draw.c),
+// re-binding the required segment(s) in MM's frame with MM's own gbi BEFORE submitting the routed
+// @oot: DLs, then restoring the segment(s). The scroll/matrix params are constant per func and taken
+// verbatim from the OOT source; only the JEWEL/MUSIC_NOTE colors are carried as data. HARD INVARIANT:
+// every DL that samples a segment is preceded by a bind of that segment in the same stream, so we
+// never submit a DL against an unbound segment (crash). Free (non-namespaced) inline functions so the
+// OPEN_DISPS block-scope decls keep C linkage — see combo/menu/ComboForeignAnim.h.
+
+// Restore the segments a handler bound (8 and/or 9) to a benign empty DL so later same-frame commands
+// don't sample our scroll DLs. Restores on both streams (harmless where a segment wasn't bound).
+// Mirrors the segment hygiene in ComboForeignAnim.h.
+inline void MM_RestoreForeignSegs(const int32_t* segs, int32_t count) {
+    GraphicsContext* gfxCtx = gPlayState->state.gfxCtx;
+    Gfx* empty = (Gfx*)GRAPH_ALLOC(gfxCtx, sizeof(Gfx));
+    Gfx* e = empty;
+    gSPEndDisplayList(e++);
+    OPEN_DISPS(gfxCtx);
+    for (int32_t i = 0; i < count; i++) {
+        gSPSegment(POLY_OPA_DISP++, segs[i], (uintptr_t)empty);
+        gSPSegment(POLY_XLU_DISP++, segs[i], (uintptr_t)empty);
+    }
+    CLOSE_DISPS(gfxCtx);
+}
+
+// Simple path: OPA layers then XLU layers (self-contained funcs, rupees, wallets, Triforce/rod scale).
+inline void MM_DrawForeignSimple(const ComboForeignDrawInfoOOT* info) {
+    int32_t n = info->count;
+    int32_t xs = (info->xluStart < 0 || info->xluStart > n) ? n : info->xluStart;
+    GraphicsContext* gfxCtx = gPlayState->state.gfxCtx;
+    OPEN_DISPS(gfxCtx);
+    if (info->scale > 0.0f) {
+        Matrix_Scale(info->scale, info->scale, info->scale, MTXMODE_APPLY);
+    }
+    if (xs > 0) {
+        Gfx_SetupDL25_Opa(gfxCtx);
+        MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, gfxCtx);
+        if (info->hasEnvColor) {
+            gDPSetEnvColor(POLY_OPA_DISP++, info->envColor[0], info->envColor[1], info->envColor[2], info->envColor[3]);
+        }
+        for (int32_t i = 0; i < xs; i++) {
+            gSPDisplayList(POLY_OPA_DISP++, (Gfx*)info->dls[i]);
+        }
+    }
+    if (xs < n) {
+        Gfx_SetupDL25_Xlu(gfxCtx);
+        MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
+        if (info->hasEnvColor) {
+            gDPSetEnvColor(POLY_XLU_DISP++, info->envColor[0], info->envColor[1], info->envColor[2], info->envColor[3]);
+        }
+        for (int32_t i = xs; i < n; i++) {
+            gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[i]);
+        }
+    }
+    CLOSE_DISPS(gfxCtx);
+}
+
+// Biggoron's / Broken Goron's Sword: seg8 OPA scroll (z_draw.c GetItem_DrawGoronSword).
+inline void MM_DrawForeignGoronSword(const ComboForeignDrawInfoOOT* info) {
+    PlayState* play = gPlayState;
+    GraphicsContext* gfxCtx = play->state.gfxCtx;
+    OPEN_DISPS(gfxCtx);
+    Gfx_SetupDL25_Opa(gfxCtx);
+    gSPSegment(POLY_OPA_DISP++, 0x08,
+               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, play->state.frames * 1, play->state.frames * 0, 32, 32, 1,
+                                  play->state.frames * 0, play->state.frames * 0, 32, 32, 1, 0, 0, 0));
+    MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, gfxCtx);
+    gSPDisplayList(POLY_OPA_DISP++, (Gfx*)info->dls[0]);
+    CLOSE_DISPS(gfxCtx);
+    int32_t segs[] = { 0x08 };
+    MM_RestoreForeignSegs(segs, 1);
+}
+
+// Deku Nuts: seg8 OPA scroll (GetItem_DrawDekuNuts).
+inline void MM_DrawForeignDekuNuts(const ComboForeignDrawInfoOOT* info) {
+    PlayState* play = gPlayState;
+    GraphicsContext* gfxCtx = play->state.gfxCtx;
+    OPEN_DISPS(gfxCtx);
+    Gfx_SetupDL25_Opa(gfxCtx);
+    gSPSegment(POLY_OPA_DISP++, 0x08,
+               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, play->state.frames * 6, play->state.frames * 6, 32, 32, 1,
+                                  play->state.frames * 6, play->state.frames * 6, 32, 32, 6, 6, 6, 6));
+    MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, gfxCtx);
+    gSPDisplayList(POLY_OPA_DISP++, (Gfx*)info->dls[0]);
+    CLOSE_DISPS(gfxCtx);
+    int32_t segs[] = { 0x08 };
+    MM_RestoreForeignSegs(segs, 1);
+}
+
+// Recovery Heart: seg8 XLU scroll (GetItem_DrawRecoveryHeart; cosmetic grayscale recolor omitted).
+inline void MM_DrawForeignRecoveryHeart(const ComboForeignDrawInfoOOT* info) {
+    PlayState* play = gPlayState;
+    GraphicsContext* gfxCtx = play->state.gfxCtx;
+    OPEN_DISPS(gfxCtx);
+    Gfx_SetupDL25_Xlu(gfxCtx);
+    gSPSegment(POLY_XLU_DISP++, 0x08,
+               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, play->state.frames * 0, -(play->state.frames * 3), 32, 32, 1,
+                                  play->state.frames * 0, -(play->state.frames * 2), 32, 32, 0, -3, 0, -2));
+    MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
+    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[0]);
+    CLOSE_DISPS(gfxCtx);
+    int32_t segs[] = { 0x08 };
+    MM_RestoreForeignSegs(segs, 1);
+}
+
+// Fish: seg8 XLU scroll (GetItem_DrawFish).
+inline void MM_DrawForeignFish(const ComboForeignDrawInfoOOT* info) {
+    PlayState* play = gPlayState;
+    GraphicsContext* gfxCtx = play->state.gfxCtx;
+    OPEN_DISPS(gfxCtx);
+    Gfx_SetupDL25_Xlu(gfxCtx);
+    gSPSegment(POLY_XLU_DISP++, 0x08,
+               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, play->state.frames * 0, play->state.frames * 1, 32, 32, 1,
+                                  play->state.frames * 0, play->state.frames * 1, 32, 32, 0, 1, 0, 1));
+    MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
+    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[0]);
+    CLOSE_DISPS(gfxCtx);
+    int32_t segs[] = { 0x08 };
+    MM_RestoreForeignSegs(segs, 1);
+}
+
+// Potions: seg8 OPA scroll, OPA dl[1,0,2,3] + XLU dl[4,5] (GetItem_DrawPotion).
+inline void MM_DrawForeignPotion(const ComboForeignDrawInfoOOT* info) {
+    PlayState* play = gPlayState;
+    GraphicsContext* gfxCtx = play->state.gfxCtx;
+    OPEN_DISPS(gfxCtx);
+    Gfx_SetupDL25_Opa(gfxCtx);
+    gSPSegment(POLY_OPA_DISP++, 0x08,
+               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, -play->state.frames, play->state.frames, 32, 32, 1,
+                                  -play->state.frames, play->state.frames, 32, 32, -1, 1, -1, 1));
+    MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, gfxCtx);
+    gSPDisplayList(POLY_OPA_DISP++, (Gfx*)info->dls[1]);
+    gSPDisplayList(POLY_OPA_DISP++, (Gfx*)info->dls[0]);
+    gSPDisplayList(POLY_OPA_DISP++, (Gfx*)info->dls[2]);
+    gSPDisplayList(POLY_OPA_DISP++, (Gfx*)info->dls[3]);
+    Gfx_SetupDL25_Xlu(gfxCtx);
+    MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
+    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[4]);
+    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[5]);
+    CLOSE_DISPS(gfxCtx);
+    int32_t segs[] = { 0x08 };
+    MM_RestoreForeignSegs(segs, 1);
+}
+
+// Mirror Shield: seg8 OPA scroll, OPA dl0 + XLU dl1 (GetItem_DrawMirrorShield).
+inline void MM_DrawForeignMirrorShield(const ComboForeignDrawInfoOOT* info) {
+    PlayState* play = gPlayState;
+    GraphicsContext* gfxCtx = play->state.gfxCtx;
+    OPEN_DISPS(gfxCtx);
+    Gfx_SetupDL25_Opa(gfxCtx);
+    gSPSegment(POLY_OPA_DISP++, 0x08,
+               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, 0, play->state.frames * 2 % 256, 64, 64, 1, 0,
+                                  play->state.frames * 1 % 128, 32, 32, 0, 2, 0, 1));
+    MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, gfxCtx);
+    gSPDisplayList(POLY_OPA_DISP++, (Gfx*)info->dls[0]);
+    Gfx_SetupDL25_Xlu(gfxCtx);
+    MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
+    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[1]);
+    CLOSE_DISPS(gfxCtx);
+    int32_t segs[] = { 0x08 };
+    MM_RestoreForeignSegs(segs, 1);
+}
+
+// Blue Fire: OPA dl0; XLU seg8 flame scroll + billboard dl1 (GetItem_DrawBlueFire).
+inline void MM_DrawForeignBlueFire(const ComboForeignDrawInfoOOT* info) {
+    PlayState* play = gPlayState;
+    GraphicsContext* gfxCtx = play->state.gfxCtx;
+    OPEN_DISPS(gfxCtx);
+    Gfx_SetupDL25_Opa(gfxCtx);
+    MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, gfxCtx);
+    gSPDisplayList(POLY_OPA_DISP++, (Gfx*)info->dls[0]);
+    Gfx_SetupDL25_Xlu(gfxCtx);
+    gSPSegment(POLY_XLU_DISP++, 0x08,
+               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, 0, 0, 16, 32, 1, play->state.frames * 1,
+                                  -(play->state.frames * 8), 16, 32, 0, 0, 1, -8));
+    Matrix_Push();
+    Matrix_Translate(-8.0f, -2.0f, 0.0f, MTXMODE_APPLY);
+    Matrix_ReplaceRotation(&play->billboardMtxF);
+    MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
+    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[1]);
+    Matrix_Pop();
+    CLOSE_DISPS(gfxCtx);
+    int32_t segs[] = { 0x08 };
+    MM_RestoreForeignSegs(segs, 1);
+}
+
+// Poe / Big Poe: OPA dl0; XLU dl1; seg8 scroll; billboard dl3,dl2 (GetItem_DrawPoes).
+inline void MM_DrawForeignPoes(const ComboForeignDrawInfoOOT* info) {
+    PlayState* play = gPlayState;
+    GraphicsContext* gfxCtx = play->state.gfxCtx;
+    OPEN_DISPS(gfxCtx);
+    Gfx_SetupDL25_Opa(gfxCtx);
+    MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, gfxCtx);
+    gSPDisplayList(POLY_OPA_DISP++, (Gfx*)info->dls[0]);
+    Gfx_SetupDL25_Xlu(gfxCtx);
+    MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
+    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[1]);
+    gSPSegment(POLY_XLU_DISP++, 0x08,
+               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, 0, 0, 16, 32, 1, play->state.frames * 1,
+                                  -(play->state.frames * 6), 16, 32, 0, 0, 1, -6));
+    Matrix_Push();
+    Matrix_ReplaceRotation(&play->billboardMtxF);
+    MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
+    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[3]);
+    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[2]);
+    Matrix_Pop();
+    CLOSE_DISPS(gfxCtx);
+    int32_t segs[] = { 0x08 };
+    MM_RestoreForeignSegs(segs, 1);
+}
+
+// Fairy (bottled): OPA dl0; XLU dl1; seg8 scroll; billboard dl2 (GetItem_DrawFairy).
+inline void MM_DrawForeignFairy(const ComboForeignDrawInfoOOT* info) {
+    PlayState* play = gPlayState;
+    GraphicsContext* gfxCtx = play->state.gfxCtx;
+    OPEN_DISPS(gfxCtx);
+    Gfx_SetupDL25_Opa(gfxCtx);
+    MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, gfxCtx);
+    gSPDisplayList(POLY_OPA_DISP++, (Gfx*)info->dls[0]);
+    Gfx_SetupDL25_Xlu(gfxCtx);
+    MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
+    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[1]);
+    gSPSegment(POLY_XLU_DISP++, 0x08,
+               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, 0, 0, 32, 32, 1, play->state.frames * 1,
+                                  -(play->state.frames * 6), 32, 32, 0, 0, 1, -6));
+    Matrix_Push();
+    Matrix_ReplaceRotation(&play->billboardMtxF);
+    MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
+    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[2]);
+    Matrix_Pop();
+    CLOSE_DISPS(gfxCtx);
+    int32_t segs[] = { 0x08 };
+    MM_RestoreForeignSegs(segs, 1);
+}
+
+// Spiritual stones: seg9 XLU + seg8 OPA (static binds), rotate, per-layer prim/env colors, gem dl0
+// (XLU) + setting dl1 (OPA) (GetItem_DrawJewel + the Kokiri/Goron/Zora color wrappers).
+inline void MM_DrawForeignJewel(const ComboForeignDrawInfoOOT* info) {
+    PlayState* play = gPlayState;
+    GraphicsContext* gfxCtx = play->state.gfxCtx;
+    OPEN_DISPS(gfxCtx);
+    gSPSegment(POLY_XLU_DISP++, 9,
+               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, 0, 0 % 256, (256 - (0 % 256)) - 1, 64, 64, 1, 0 % 256, (256 - (0 % 256)) - 1,
+                                  16, 16, 0, 0, 0, 0));
+    gSPSegment(POLY_OPA_DISP++, 8, (uintptr_t)Gfx_TexScrollEx(gfxCtx, 0, 0, 16, 16, 0, 0));
+    Matrix_Push();
+    Matrix_RotateZYX(0, -0x4000, 0x4000, MTXMODE_APPLY);
+    MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
+    MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, gfxCtx);
+    Gfx_SetupDL25_Xlu(gfxCtx);
+    gDPSetPrimColor(POLY_XLU_DISP++, 0, 128, info->primColorXlu[0], info->primColorXlu[1], info->primColorXlu[2], 255);
+    gDPSetEnvColor(POLY_XLU_DISP++, info->envColorXlu[0], info->envColorXlu[1], info->envColorXlu[2], 255);
+    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[0]);
+    Gfx_SetupDL25_Opa(gfxCtx);
+    gDPSetPrimColor(POLY_OPA_DISP++, 0, 128, info->primColorOpa[0], info->primColorOpa[1], info->primColorOpa[2], 255);
+    gDPSetEnvColor(POLY_OPA_DISP++, info->envColorOpa[0], info->envColorOpa[1], info->envColorOpa[2], 255);
+    gSPDisplayList(POLY_OPA_DISP++, (Gfx*)info->dls[1]);
+    Matrix_Pop();
+    CLOSE_DISPS(gfxCtx);
+    int32_t segs[] = { 0x08, 0x09 };
+    MM_RestoreForeignSegs(segs, 2);
+}
+
+// Din's Fire / Farore's Wind / Nayru's Love: XLU seg8 scroll, dl0,1,2 (GetItem_DrawMagicSpell).
+inline void MM_DrawForeignMagicSpell(const ComboForeignDrawInfoOOT* info) {
+    PlayState* play = gPlayState;
+    GraphicsContext* gfxCtx = play->state.gfxCtx;
+    OPEN_DISPS(gfxCtx);
+    Gfx_SetupDL25_Xlu(gfxCtx);
+    gSPSegment(POLY_XLU_DISP++, 0x08,
+               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, play->state.frames * 2, -(play->state.frames * 6), 32, 32, 1,
+                                  play->state.frames * 1, -(play->state.frames * 2), 32, 32, 2, -6, 1, -2));
+    MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
+    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[0]);
+    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[1]);
+    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[2]);
+    CLOSE_DISPS(gfxCtx);
+    int32_t segs[] = { 0x08 };
+    MM_RestoreForeignSegs(segs, 1);
+}
+
+// Silver / Gold Scale: XLU seg8 scroll, dl2,3,1,0 (GetItem_DrawScale).
+inline void MM_DrawForeignScale(const ComboForeignDrawInfoOOT* info) {
+    PlayState* play = gPlayState;
+    GraphicsContext* gfxCtx = play->state.gfxCtx;
+    OPEN_DISPS(gfxCtx);
+    Gfx_SetupDL25_Xlu(gfxCtx);
+    gSPSegment(POLY_XLU_DISP++, 0x08,
+               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, play->state.frames * 2, -(play->state.frames * 2), 64, 64, 1,
+                                  play->state.frames * 4, -(play->state.frames * 4), 32, 32, 2, -2, 4, -4));
+    MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
+    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[2]);
+    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[3]);
+    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[1]);
+    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[0]);
+    CLOSE_DISPS(gfxCtx);
+    int32_t segs[] = { 0x08 };
+    MM_RestoreForeignSegs(segs, 1);
+}
+
+// Skulltula Token: body OPA dl0 + XLU seg8 flame dl1 (GetItem_DrawSkullToken, full flame).
+inline void MM_DrawForeignSkullToken(const ComboForeignDrawInfoOOT* info) {
+    PlayState* play = gPlayState;
+    GraphicsContext* gfxCtx = play->state.gfxCtx;
+    OPEN_DISPS(gfxCtx);
+    Gfx_SetupDL25_Opa(gfxCtx);
+    MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, gfxCtx);
+    gSPDisplayList(POLY_OPA_DISP++, (Gfx*)info->dls[0]);
+    Gfx_SetupDL25_Xlu(gfxCtx);
+    gSPSegment(POLY_XLU_DISP++, 0x08,
+               (uintptr_t)Gfx_TwoTexScrollEx(gfxCtx, G_TX_RENDERTILE, play->state.frames * 0, -(play->state.frames * 5), 32, 32, 1,
+                                  play->state.frames * 0, play->state.frames * 0, 32, 64, 0, -5, 0, 0));
+    MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
+    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[1]);
+    CLOSE_DISPS(gfxCtx);
+    int32_t segs[] = { 0x08 };
+    MM_RestoreForeignSegs(segs, 1);
+}
+
+// Generic rando song note: grayscale-tinted note DL (GetItem_DrawGenericMusicNote). No segments.
+inline void MM_DrawForeignMusicNote(const ComboForeignDrawInfoOOT* info) {
+    GraphicsContext* gfxCtx = gPlayState->state.gfxCtx;
+    OPEN_DISPS(gfxCtx);
+    MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
+    gDPSetGrayscaleColor(POLY_XLU_DISP++, info->primColorXlu[0], info->primColorXlu[1], info->primColorXlu[2], 255);
+    gSPGrayscale(POLY_XLU_DISP++, true);
+    Gfx_SetupDL25_Opa(gfxCtx);
+    gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[0]);
+    gSPGrayscale(POLY_XLU_DISP++, false);
+    CLOSE_DISPS(gfxCtx);
+}
 
 // Draw a foreign (OOT-bound) item's real OOT model at the current model matrix. Any resolution
 // failure falls back to the sentinel blue rupee (the RI_COMBO_FOREIGN item's GID_RUPEE_BLUE), so we
@@ -130,40 +472,24 @@ inline void MM_DrawComboForeign(RandoCheckId randoCheckId) {
         return;
     }
 
-    int32_t n = info->count;
-    int32_t xs = (info->xluStart < 0 || info->xluStart > n) ? n : info->xluStart;
-
-    OPEN_DISPS(gPlayState->state.gfxCtx);
-
-    // Extra uniform model scale carried from OOT's draw func (e.g. small rupees: 0.7).
-    if (info->scale > 0.0f) {
-        Matrix_Scale(info->scale, info->scale, info->scale, MTXMODE_APPLY);
+    switch (info->drawKind) {
+        case CW_DRAW_KIND_GORON_SWORD:    MM_DrawForeignGoronSword(info); break;
+        case CW_DRAW_KIND_DEKU_NUTS:      MM_DrawForeignDekuNuts(info); break;
+        case CW_DRAW_KIND_RECOVERY_HEART: MM_DrawForeignRecoveryHeart(info); break;
+        case CW_DRAW_KIND_FISH:           MM_DrawForeignFish(info); break;
+        case CW_DRAW_KIND_POTION:         MM_DrawForeignPotion(info); break;
+        case CW_DRAW_KIND_MIRROR_SHIELD:  MM_DrawForeignMirrorShield(info); break;
+        case CW_DRAW_KIND_BLUE_FIRE:      MM_DrawForeignBlueFire(info); break;
+        case CW_DRAW_KIND_POES:           MM_DrawForeignPoes(info); break;
+        case CW_DRAW_KIND_FAIRY:          MM_DrawForeignFairy(info); break;
+        case CW_DRAW_KIND_JEWEL:          MM_DrawForeignJewel(info); break;
+        case CW_DRAW_KIND_MAGIC_SPELL:    MM_DrawForeignMagicSpell(info); break;
+        case CW_DRAW_KIND_SCALE:          MM_DrawForeignScale(info); break;
+        case CW_DRAW_KIND_SKULL_TOKEN:    MM_DrawForeignSkullToken(info); break;
+        case CW_DRAW_KIND_MUSIC_NOTE:     MM_DrawForeignMusicNote(info); break;
+        case CW_DRAW_KIND_SIMPLE:
+        default:                          MM_DrawForeignSimple(info); break;
     }
-
-    // Mirror OOT's GetItem_DrawOpa*/Xlu* structure: one 25Opa setup + matrix for the OPA layers,
-    // then one 25Xlu setup + matrix for the XLU layers.
-    if (xs > 0) {
-        Gfx_SetupDL25_Opa(gPlayState->state.gfxCtx);
-        MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, gPlayState->state.gfxCtx);
-        if (info->hasEnvColor) {
-            gDPSetEnvColor(POLY_OPA_DISP++, info->envColor[0], info->envColor[1], info->envColor[2], info->envColor[3]);
-        }
-        for (int32_t i = 0; i < xs; i++) {
-            gSPDisplayList(POLY_OPA_DISP++, (Gfx*)info->dls[i]);
-        }
-    }
-    if (xs < n) {
-        Gfx_SetupDL25_Xlu(gPlayState->state.gfxCtx);
-        MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gPlayState->state.gfxCtx);
-        if (info->hasEnvColor) {
-            gDPSetEnvColor(POLY_XLU_DISP++, info->envColor[0], info->envColor[1], info->envColor[2], info->envColor[3]);
-        }
-        for (int32_t i = xs; i < n; i++) {
-            gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->dls[i]);
-        }
-    }
-
-    CLOSE_DISPS(gPlayState->state.gfxCtx);
 }
 
 #endif // COMBO_FOREIGN_DRAW_MM_H

--- a/combo/menu/ComboItemDrawABI.h
+++ b/combo/menu/ComboItemDrawABI.h
@@ -13,6 +13,33 @@ extern "C" {
 
 #define CW_DRAW_MAX_DLISTS 8
 
+/* ComboShip: which OOT get-item draw func the consumer must replicate. SIMPLE (0) = the plain
+ * OPA-then-XLU submission the consumer already does (self-contained funcs + rupees/wallets/etc). The
+ * rest are the non-portable OOT funcs (segment-8/9 texture scrolls, billboard rotation, per-instance
+ * prim/env color) that draw as the sentinel today; each has a 1:1 handler in ComboForeignDrawMM.h
+ * that re-binds the segment(s) in the host frame before submitting the routed @oot: DLs. When drawKind
+ * != SIMPLE the consumer ignores xluStartIndex and dlists[] are carried in the OOT TABLE order (the
+ * handler reorders exactly as the OOT func does). */
+typedef enum {
+    CW_DRAW_KIND_SIMPLE = 0,
+    CW_DRAW_KIND_GORON_SWORD,    /* Biggoron/Broken sword: seg8 OPA scroll, dl0 */
+    CW_DRAW_KIND_DEKU_NUTS,      /* seg8 OPA scroll, dl0 */
+    CW_DRAW_KIND_RECOVERY_HEART, /* seg8 XLU scroll, dl0 */
+    CW_DRAW_KIND_FISH,           /* seg8 XLU scroll, dl0 */
+    CW_DRAW_KIND_POTION,         /* seg8 OPA scroll, OPA dl[1,0,2,3] + XLU dl[4,5] */
+    CW_DRAW_KIND_MIRROR_SHIELD,  /* seg8 OPA scroll, OPA dl0 + XLU dl1 */
+    CW_DRAW_KIND_BLUE_FIRE,      /* OPA dl0; XLU seg8 scroll + billboard flame dl1 */
+    CW_DRAW_KIND_POES,           /* OPA dl0; XLU dl1; seg8 scroll; billboard dl3,dl2 */
+    CW_DRAW_KIND_FAIRY,          /* OPA dl0; XLU dl1; seg8 scroll; billboard dl2 */
+    CW_DRAW_KIND_JEWEL,          /* spiritual stones: seg9 XLU + seg8 OPA + rotate + per-layer colors */
+    CW_DRAW_KIND_MAGIC_SPELL,    /* Din/Farore/Nayru: XLU seg8 scroll, dl0,1,2 */
+    CW_DRAW_KIND_SCALE,          /* silver/gold scale: XLU seg8 scroll, dl2,3,1,0 */
+    CW_DRAW_KIND_SKULL_TOKEN,    /* body OPA dl0 + XLU seg8 flame dl1 (full, flame included) */
+    CW_DRAW_KIND_MUSIC_NOTE,     /* generic rando song note: grayscale tint (primColorXlu), dl0 */
+    /* Triforce Piece / Fishing Pole are plain scaled-OPA draws with no extra GPU state, so they ride
+     * the SIMPLE path (dlists[0] + scale) rather than a dedicated kind. */
+} CwDrawKind;
+
 typedef struct {
     const char* dlists[CW_DRAW_MAX_DLISTS]; /* OTR path strings, in SUBMISSION order */
     int32_t dlistCount;
@@ -30,6 +57,18 @@ typedef struct {
     const char* matAnimPath;  /* TextureAnimation resource, or NULL */
     int32_t matAnimBindOpa;   /* 1 = also bind the animated segment on the OPA layer (item body samples it) */
     int32_t matAnimBillboard; /* 1 = Matrix_ReplaceRotation(billboardMtxF) before the XLU layer (glow) */
+
+    /* ComboShip: kind-tagged draw recipe for the non-portable OOT funcs (OOT->MM foreign-draw
+     * portability). drawKind selects the consumer handler; when != CW_DRAW_KIND_SIMPLE, dlists[] are
+     * the raw OOT table row (submission order handled by the handler) and xluStartIndex is ignored.
+     * The scroll/matrix params are constant per kind and embedded in the consumer handler (1:1 port of
+     * the OOT func); only the JEWEL per-layer colors and the MUSIC_NOTE tint vary, so they are carried
+     * here as data. Colors are RGBA (alpha always 255). */
+    int32_t drawKind;         /* CwDrawKind */
+    uint8_t primColorXlu[4];  /* JEWEL gem (XLU) prim; MUSIC_NOTE grayscale tint */
+    uint8_t envColorXlu[4];   /* JEWEL gem (XLU) env */
+    uint8_t primColorOpa[4];  /* JEWEL setting (OPA) prim */
+    uint8_t envColorOpa[4];   /* JEWEL setting (OPA) env */
 } CwItemDrawInfo;
 
 /* Returns 1 and fills out on success; 0 if the item is unknown/undrawable.

--- a/combo/menu/ComboItemDrawABI.h
+++ b/combo/menu/ComboItemDrawABI.h
@@ -64,11 +64,11 @@ typedef struct {
      * The scroll/matrix params are constant per kind and embedded in the consumer handler (1:1 port of
      * the OOT func); only the JEWEL per-layer colors and the MUSIC_NOTE tint vary, so they are carried
      * here as data. Colors are RGBA (alpha always 255). */
-    int32_t drawKind;         /* CwDrawKind */
-    uint8_t primColorXlu[4];  /* JEWEL gem (XLU) prim; MUSIC_NOTE grayscale tint */
-    uint8_t envColorXlu[4];   /* JEWEL gem (XLU) env */
-    uint8_t primColorOpa[4];  /* JEWEL setting (OPA) prim */
-    uint8_t envColorOpa[4];   /* JEWEL setting (OPA) env */
+    int32_t drawKind;        /* CwDrawKind */
+    uint8_t primColorXlu[4]; /* JEWEL gem (XLU) prim; MUSIC_NOTE grayscale tint */
+    uint8_t envColorXlu[4];  /* JEWEL gem (XLU) env */
+    uint8_t primColorOpa[4]; /* JEWEL setting (OPA) prim */
+    uint8_t envColorOpa[4];  /* JEWEL setting (OPA) env */
 } CwItemDrawInfo;
 
 /* Returns 1 and fills out on success; 0 if the item is unknown/undrawable.

--- a/combo/menu/ComboItemDrawMM.h
+++ b/combo/menu/ComboItemDrawMM.h
@@ -134,16 +134,19 @@ static int32_t MM_FillOwlDrawInfo(RandoItemId id, CwItemDrawInfo* out) {
 
 // Cross-game item draw info. OOT resolves this via GetProcAddress to learn which MM display lists
 // render a foreign item, then submits them through "__OTR__@mm:"-routed paths resolved against
-// MM's ResourceManager (CrossRMRegistry). itemName is the MM RI_* spoilerName — the same grant key
-// the foreign map carries (GetItemIdFromName keys spoilerName, see Rando/StaticData/Items.cpp).
-// The returned dlists point at MM's static OTR asset-path string literals, valid for process
-// lifetime. Returns 0 for unknown items / non-portable draw funcs; the caller falls back to its
-// sentinel.
+// MM's ResourceManager (CrossRMRegistry). itemName is the friendly combo-spoiler name the foreign
+// map carries (resolve via GetItemIdFromDisplayName; fall back to the RI_ spoilerName for the
+// sentinel / any raw id). The returned dlists point at MM's static OTR asset-path string literals,
+// valid for process lifetime. Returns 0 for unknown items / non-portable draw funcs; the caller
+// falls back to its sentinel.
 extern "C" __declspec(dllexport) int32_t MM_GetItemDrawInfo(const char* itemName, CwItemDrawInfo* out) {
     if (itemName == nullptr || out == nullptr) {
         return 0;
     }
-    RandoItemId id = Rando::StaticData::GetItemIdFromName(itemName);
+    RandoItemId id = Rando::StaticData::GetItemIdFromDisplayName(itemName);
+    if (id == RI_UNKNOWN) {
+        id = Rando::StaticData::GetItemIdFromName(itemName); // sentinel / raw RI_
+    }
     if (id == RI_UNKNOWN) {
         return 0;
     }
@@ -196,7 +199,12 @@ extern "C" __declspec(dllexport) int32_t MM_GetItemAnimDrawInfo(const char* item
         return 0;
     }
     const char* texAnim;
-    switch (Rando::StaticData::GetItemIdFromName(itemName)) {
+    // ComboShip: itemName is the friendly combo-spoiler name; fall back to the RI_ spoilerName.
+    RandoItemId animId = Rando::StaticData::GetItemIdFromDisplayName(itemName);
+    if (animId == RI_UNKNOWN) {
+        animId = Rando::StaticData::GetItemIdFromName(itemName);
+    }
+    switch (animId) {
         case RI_WOODFALL_STRAY_FAIRY:
             texAnim = gStrayFairyWoodfallTexAnim;
             break;

--- a/combo/menu/ComboItemDrawOOT.h
+++ b/combo/menu/ComboItemDrawOOT.h
@@ -18,7 +18,10 @@
 #include "ComboItemDrawABI.h"
 
 // Portable slice of one sDrawItemTable row (defined COMBO_BUILD-guarded in soh/src/code/z_draw.c).
-extern "C" s32 GetItem_GetDrawTableEntry(s32 drawId, void** outDlists, s32 maxDlists, s32* outXluStart, f32* outScale);
+// outDrawKind = CwDrawKind (0 = simple OPA/XLU submission; else a non-portable func the consumer
+// replicates). outColors is 16 bytes: primXlu[4], envXlu[4], primOpa[4], envOpa[4] (JEWEL/MUSIC_NOTE).
+extern "C" s32 GetItem_GetDrawTableEntry(s32 drawId, void** outDlists, s32 maxDlists, s32* outXluStart, f32* outScale,
+                                         s32* outDrawKind, uint8_t* outColors);
 
 // Cross-game item draw info. MM resolves this via GetProcAddress to learn which OOT display lists
 // render a foreign item, then submits them through "__OTR__@oot:"-routed paths resolved against OOT's
@@ -44,7 +47,9 @@ extern "C" __declspec(dllexport) int32_t OOT_GetItemDrawInfo(const char* itemNam
     void* dls[CW_DRAW_MAX_DLISTS] = {};
     int32_t xluStart = -1;
     f32 scale = 0.0f;
-    int32_t n = GetItem_GetDrawTableEntry((s32)gi.gid, dls, CW_DRAW_MAX_DLISTS, &xluStart, &scale);
+    int32_t drawKind = CW_DRAW_KIND_SIMPLE;
+    uint8_t colors[16] = {};
+    int32_t n = GetItem_GetDrawTableEntry((s32)gi.gid, dls, CW_DRAW_MAX_DLISTS, &xluStart, &scale, &drawKind, colors);
     if (n <= 0) {
         return 0; // unsupported/non-portable draw func
     }
@@ -52,6 +57,13 @@ extern "C" __declspec(dllexport) int32_t OOT_GetItemDrawInfo(const char* itemNam
     out->xluStartIndex = xluStart;
     out->scale = scale;
     out->hasEnvColor = 0; // OOT's portable funcs bake color into their DLs (no separate env color)
+    out->drawKind = drawKind;
+    for (int32_t i = 0; i < 4; i++) {
+        out->primColorXlu[i] = colors[i];
+        out->envColorXlu[i] = colors[4 + i];
+        out->primColorOpa[i] = colors[8 + i];
+        out->envColorOpa[i] = colors[12 + i];
+    }
     for (int32_t i = 0; i < n; i++) {
         out->dlists[i] = (const char*)dls[i];
     }

--- a/combo/rando/ComboPlaythrough.h
+++ b/combo/rando/ComboPlaythrough.h
@@ -78,12 +78,22 @@ inline std::vector<CwPlacedItem> ParseSpoilerPlacements(const std::string& spoil
         auto it = majorByName[g].find(item);
         return it == majorByName[g].end() ? lookupAdv(g, item) : it->second;
     };
+    // ComboShip: the consolidated file suffixes cross-game item-name collisions "(OOT)"/"(MM)"; strip
+    // that here so oracle name resolution (bare friendly) works. No-op on the bare fill output.
+    auto stripSuffix = [](std::string s) {
+        for (const char* suf : { " (OOT)", " (MM)" }) {
+            size_t n = std::string(suf).size();
+            if (s.size() >= n && s.compare(s.size() - n, n, suf) == 0)
+                return s.substr(0, s.size() - n);
+        }
+        return s;
+    };
     try {
         auto j = nlohmann::json::parse(spoilerJson);
         for (auto& fm : j.value("foreign", nlohmann::json::array())) {
             std::string cg = fm.value("checkGame", ""), cn = fm.value("checkName", "");
             std::string ig = fm.value("itemGame", "");
-            foreign[cg + ":" + cn] = { (ig == "mm") ? GAME_MM : GAME_OOT, fm.value("itemName", ""),
+            foreign[cg + ":" + cn] = { (ig == "mm") ? GAME_MM : GAME_OOT, stripSuffix(fm.value("itemName", "")),
                                        fm.value("advancement", true) };
         }
         auto addGame = [&](const char* key, GameId cg) {
@@ -93,8 +103,8 @@ inline std::vector<CwPlacedItem> ParseSpoilerPlacements(const std::string& spoil
                 auto fit = foreign.find(std::string(key) + ":" + cn);
                 bool isForeign = fit != foreign.end();
                 GameId ig = isForeign ? fit->second.itemGame : cg;
-                std::string item =
-                    (isForeign && !fit->second.itemName.empty()) ? fit->second.itemName : iv.get<std::string>();
+                std::string item = (isForeign && !fit->second.itemName.empty()) ? fit->second.itemName
+                                                                                : stripSuffix(iv.get<std::string>());
                 bool adv = isForeign ? fit->second.advancement : lookupAdv(ig, item);
                 bool major = isForeign ? fit->second.advancement : lookupMajor(ig, item);
                 placements.push_back({ cg, cn, ig, item, adv, major });
@@ -158,7 +168,7 @@ inline bool DefaultGanonMajoraGoal(const std::unordered_set<std::string>& ootRea
                                    const std::vector<std::string>& ownedOot) {
     static const char* kOotTowerTop = "Ganon's Castle Tower Boss Key Chest";
     static const char* kOotBossKey = "Ganon's Castle Boss Key";
-    static const char* kMmWin = "RC_MOON_MAJORA_POT_01";
+    static const char* kMmWin = "Moon Majora Pot 01"; // ComboShip: friendly form of RC_MOON_MAJORA_POT_01
     bool canGanon =
         ootReach.count(kOotTowerTop) > 0 && std::find(ownedOot.begin(), ownedOot.end(), kOotBossKey) != ownedOot.end();
     bool canMajora = mmReach.count(kMmWin) > 0;
@@ -333,7 +343,7 @@ inline PlaythroughResult RunPlaythrough(const std::string& spoilerJson, const Or
                                         const std::string& mmDumpJson = "") {
     static const char* kOotTowerTop = "Ganon's Castle Tower Boss Key Chest";
     static const char* kOotBossKey = "Ganon's Castle Boss Key";
-    static const char* kMmWin = "RC_MOON_MAJORA_POT_01";
+    static const char* kMmWin = "Moon Majora Pot 01"; // ComboShip: friendly form of RC_MOON_MAJORA_POT_01
 
     PlaythroughResult result;
 

--- a/combo/rando/CrossForeign.h
+++ b/combo/rando/CrossForeign.h
@@ -8,13 +8,14 @@
 // gSaveContext.fileNum, so a save and its consolidated file share one slot number.
 //
 // "foreign" array element:
-//   { "checkGame":"oot|mm", "checkName":"<RC name>", "itemGame":"oot|mm",
-//     "itemName":"<item key in itemGame's namespace>", "displayName":"<human name + (MM)/(OOT)>" }
+//   { "checkGame":"oot|mm", "checkName":"<friendly check name>", "itemGame":"oot|mm",
+//     "itemName":"<friendly item name>", "displayName":"<human name + (MM)/(OOT)>" }
 //
-// Note: itemName is in the DESTINATION game's namespace (the item's home game), since that is the
-// game that ultimately grants it. OOT uses English item names; MM uses RI_* spoiler names.
+// Note: checkName/itemName are the friendly combo-spoiler names (bare, no suffix) — the home game
+// resolves itemName to grant it, so both must match that game's friendly name maps exactly.
 #pragma once
 
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -28,14 +29,14 @@ namespace ComboRando {
 // Game identity used across the cross-world rando layer (soh.dll, 2ship.dll, ComboShip.exe).
 enum GameId : uint8_t { GAME_OOT = 0, GAME_MM = 1 };
 
-// Sentinel item names written into each game's own placement table for a foreign check.
-// They differ because the two games use different item-name namespaces (see header note).
+// Sentinel item names written into each game's own APPLY payload (not the persisted spoiler) for a
+// foreign check; each game resolves its own sentinel to the RG_/RI_COMBO_FOREIGN item.
 inline constexpr const char* kForeignSentinelNameOOT = "Combo Foreign Item"; // OOT English name
-inline constexpr const char* kForeignSentinelNameMM = "RI_COMBO_FOREIGN";    // MM spoilerName
+inline constexpr const char* kForeignSentinelNameMM = "RI_COMBO_FOREIGN";    // MM RI_ spoilerName
 
 struct ForeignItem {
     GameId itemGame;          // the game the item belongs to / must be delivered to
-    std::string itemName;     // item key in itemGame's namespace (English for OOT, RI_* for MM)
+    std::string itemName;     // friendly item name in itemGame (bare; resolved by that game's map)
     std::string displayName;  // human string for the "sent"/"received" text
     bool advancement = false; // progression in its home game -> drives the held-up pickup animation
 };
@@ -137,6 +138,57 @@ inline nlohmann::json BuildForeignArray(const nlohmann::json& foreignArray,
         out.push_back(std::move(entry));
     }
     return out;
+}
+
+// Suffix cross-game ITEM-name collisions in the consolidated placements so a name like "Mirror Shield"
+// (in both games) reads unambiguously in the file / plandomizer. Only NATIVE placements are suffixed
+// (item's game == check's game), with that game's "(OOT)"/"(MM)" tag; each game strips its own suffix
+// on apply. Foreign checks are skipped (their real cross-game item is carried by the foreign[] array,
+// whose displayName already carries the tag). Check names are never suffixed: they live in per-game
+// objects (oot/mm) and a game DLL can't reproduce a cross-game-aware suffix at runtime.
+inline void SuffixCrossGameItems(nlohmann::json& ootPlacements, nlohmann::json& mmPlacements,
+                                 const nlohmann::json& foreignArray, const std::string& sohDump,
+                                 const std::string& mmDump) {
+    auto itemNames = [](const std::string& dump) {
+        std::set<std::string> s;
+        try {
+            auto d = nlohmann::json::parse(dump);
+            for (auto& it : d.value("pool", nlohmann::json::array()))
+                if (auto n = it.value("name", std::string{}); !n.empty())
+                    s.insert(std::move(n));
+            for (auto& it : d.value("items", nlohmann::json::array()))
+                if (auto n = it.value("name", std::string{}); !n.empty())
+                    s.insert(std::move(n));
+            for (auto& f : d.value("fixed", nlohmann::json::array()))
+                if (auto n = f.value("item", std::string{}); !n.empty())
+                    s.insert(std::move(n));
+        } catch (...) {}
+        return s;
+    };
+    std::set<std::string> ootSet = itemNames(sohDump), mmSet = itemNames(mmDump), shared;
+    for (const auto& n : ootSet)
+        if (mmSet.count(n))
+            shared.insert(n);
+    if (shared.empty())
+        return;
+    std::set<std::string> ootForeign, mmForeign;
+    for (const auto& fm : foreignArray) {
+        std::string cg = fm.value("checkGame", ""), cn = fm.value("checkName", "");
+        if (cn.empty())
+            continue;
+        (cg == "oot" ? ootForeign : mmForeign).insert(cn);
+    }
+    auto process = [&](nlohmann::json& pl, const std::set<std::string>& foreign, const char* suf) {
+        for (auto it = pl.begin(); it != pl.end(); ++it) {
+            if (!it.value().is_string() || foreign.count(it.key()))
+                continue;
+            std::string v = it.value().get<std::string>();
+            if (shared.count(v))
+                it.value() = v + suf;
+        }
+    };
+    process(ootPlacements, ootForeign, " (OOT)");
+    process(mmPlacements, mmForeign, " (MM)");
 }
 
 // Load one game's foreign-check section from slot N's consolidated file, keyed by check name.

--- a/combo/rando/CrossHints.h
+++ b/combo/rando/CrossHints.h
@@ -270,7 +270,7 @@ inline nlohmann::json Generate(uint32_t masterSeed, const std::string& sohDumpJs
     };
 
     // Family-B upgrade data (Phase 4 consumes this): MM items placed at an OOT check, keyed by the
-    // MM item's own RI_* name -> "in <area> (OOT)".
+    // MM item's own friendly name -> "in <area> (OOT)".
     for (auto& fm : foreignArray) {
         if (fm.value("checkGame", "") != "oot" || fm.value("itemGame", "") != "mm")
             continue;

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -33,6 +33,13 @@
 #define COMBO_MM_WINDOW_SUFFIX ""
 #endif
 
+// ComboShip: MM's own debug CVar so MM debug mode can't leak into OOT (shared CVar store, issue #67)
+#ifdef COMBO_BUILD
+#define COMBO_MM_DEBUG_MODE_NAME "gDeveloperTools.DebugEnabledMM"
+#else
+#define COMBO_MM_DEBUG_MODE_NAME "gDeveloperTools.DebugEnabled"
+#endif
+
 #ifdef COMBO_BUILD
 bool Combo_MmIsForeground(void); // defined in BenPort.cpp
 
@@ -2057,7 +2064,7 @@ void BenMenu::AddDevTools() {
         .CVar("gSettings.Menu.Popout")
         .Options(CheckboxOptions().Tooltip("Changes the menu display from overlay to windowed."));
     AddWidget(path, "Debug Mode", WIDGET_CVAR_CHECKBOX)
-        .CVar("gDeveloperTools.DebugEnabled")
+        .CVar(COMBO_MM_DEBUG_MODE_NAME)
         .Options(CheckboxOptions().Tooltip("Enables Debug Mode, allowing the following:\n\n"
                                            "- Open debug warp menu with L + R + Z\n"
                                            "- Enable debug no-clip mode with L + D-Right\n"
@@ -2316,7 +2323,7 @@ void BenMenu::InitElement() {
         { DISABLE_FOR_NULL_PLAY_STATE,
           { [](disabledInfo& info) -> bool { return gPlayState == NULL; }, "Not in game" } },
         { DISABLE_FOR_DEBUG_MODE_OFF,
-          { [](disabledInfo& info) -> bool { return !CVarGetInteger("gDeveloperTools.DebugEnabled", 0); },
+          { [](disabledInfo& info) -> bool { return !CVarGetInteger(COMBO_MM_DEBUG_MODE_NAME, 0); },
             "Debug Mode is Disabled" } },
         { DISABLE_FOR_NO_VSYNC,
           { [](disabledInfo& info) -> bool {

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -2714,7 +2714,36 @@ extern "C" __declspec(dllexport) void MM_InitRandoSaveFile(int fileNum, const ch
         // ComboShip: mirror native OnFileCreate's use of the player's configured priority list.
         auto sariaPriorityItems = Rando::GetSariaPriorityItemsFromConfig();
         Rando::SetSariaPriorityItemsInSpoiler(spoiler, sariaPriorityItems);
-        spoiler["checks"] = nlohmann::json::parse(placementJson); // { "RC_*": "<spoilerName>", ... }
+        // ComboShip: the combo spoiler is friendly-named (check + item), cross-game collisions suffixed
+        // "(MM)". Translate to the RC_/RI_ shape ApplyToSaveContext consumes so that shared code stays
+        // untouched. Strip our own "(MM)" suffix; the foreign sentinel + any raw RI_ pass through.
+        auto stripMM = [](std::string s) {
+            static const std::string suf = " (MM)";
+            if (s.size() >= suf.size() && s.compare(s.size() - suf.size(), suf.size(), suf) == 0)
+                s.resize(s.size() - suf.size());
+            return s;
+        };
+        nlohmann::json checks = nlohmann::json::object();
+        nlohmann::json rawPlacements = nlohmann::json::parse(placementJson); // bind before .items() (no dangling temp)
+        for (auto& [friendlyCheck, val] : rawPlacements.items()) {
+            if (!val.is_string())
+                continue;
+            RandoCheckId cid = Rando::StaticData::GetCheckIdFromDisplayName(stripMM(friendlyCheck).c_str());
+            if (cid == RC_UNKNOWN) {
+                SPDLOG_WARN("[ComboShip] MM_InitRandoSaveFile: unknown check '{}'", friendlyCheck);
+                continue;
+            }
+            std::string v = stripMM(val.get<std::string>());
+            RandoItemId iid = Rando::StaticData::GetItemIdFromDisplayName(v.c_str());
+            if (iid == RI_UNKNOWN)
+                iid = Rando::StaticData::GetItemIdFromName(v.c_str()); // foreign sentinel / raw RI_
+            if (iid == RI_UNKNOWN) {
+                SPDLOG_WARN("[ComboShip] MM_InitRandoSaveFile: unknown item '{}' at '{}'", v, friendlyCheck);
+                continue;
+            }
+            checks[Rando::StaticData::Checks[cid].name] = Rando::StaticData::Items[iid].spoilerName;
+        }
+        spoiler["checks"] = std::move(checks);
 
         Rando::Spoiler::ApplyToSaveContext(spoiler);
 
@@ -2987,8 +3016,9 @@ extern "C" __declspec(dllexport) const char* MM_DumpRandoStaticData(void) {
         uint16_t p = saveInfo.randoSaveChecks[id].price;
         if (p != 0) {
             sMMComboCheckPrices[id] = p;
-            if (chk.name && chk.name[0] != '\0')
-                prices[chk.name] = p;
+            const std::string& cn = Rando::StaticData::GetCheckDisplayName(id); // ComboShip: friendly name
+            if (!cn.empty())
+                prices[cn] = p;
         }
     }
 
@@ -3017,8 +3047,9 @@ extern "C" __declspec(dllexport) const char* MM_DumpRandoStaticData(void) {
         auto iit = Rando::StaticData::Items.find(RANDO_SAVE_CHECKS[id].randoItemId);
         if (iit == Rando::StaticData::Items.end() || !iit->second.spoilerName || iit->second.spoilerName[0] == '\0')
             continue;
-        fixed.push_back({ { "check", chkIt->second.name },
-                          { "item", iit->second.spoilerName },
+        // ComboShip: friendly check + item names for the normalized combo spoiler.
+        fixed.push_back({ { "check", Rando::StaticData::GetCheckDisplayName(id) },
+                          { "item", Rando::StaticData::GetItemDisplayName(iit->first) },
                           { "advancement", isAdvancement(iit->second) } });
     }
 
@@ -3033,7 +3064,10 @@ extern "C" __declspec(dllexport) const char* MM_DumpRandoStaticData(void) {
             auto iit = Rando::StaticData::Items.find(chk.randoItemId);
             if (iit == Rando::StaticData::Items.end() || !iit->second.spoilerName || iit->second.spoilerName[0] == '\0')
                 continue;
-            fixed.push_back({ { "check", chk.name }, { "item", iit->second.spoilerName }, { "advancement", true } });
+            // ComboShip: friendly check + item names for the normalized combo spoiler.
+            fixed.push_back({ { "check", Rando::StaticData::GetCheckDisplayName(id) },
+                              { "item", Rando::StaticData::GetItemDisplayName(iit->first) },
+                              { "advancement", true } });
         }
     }
 
@@ -3048,11 +3082,12 @@ extern "C" __declspec(dllexport) const char* MM_DumpRandoStaticData(void) {
             skippedNoStatic++;
             continue;
         }
-        if (!chkIt->second.name || chkIt->second.name[0] == '\0') {
+        const std::string& cn = Rando::StaticData::GetCheckDisplayName(id); // ComboShip: friendly name
+        if (cn.empty()) {
             skippedNoName++;
             continue;
         }
-        checks.push_back({ { "name", chkIt->second.name } });
+        checks.push_back({ { "name", cn } });
     }
 
     // Pool = the real free item pool (every settings-added item; confined items already removed).
@@ -3062,7 +3097,8 @@ extern "C" __declspec(dllexport) const char* MM_DumpRandoStaticData(void) {
             poolNoName++;
             continue;
         }
-        pool.push_back({ { "name", it->second.spoilerName }, { "advancement", isAdvancement(it->second) } });
+        // ComboShip: friendly item name for the normalized combo spoiler.
+        pool.push_back({ { "name", Rando::StaticData::GetItemDisplayName(iid) }, { "advancement", isAdvancement(it->second) } });
     }
 
     // ComboShip canary: written to a file because 2ship.dll's spdlog default logger is never
@@ -3097,10 +3133,11 @@ extern "C" __declspec(dllexport) const char* MM_DumpRandoStaticData(void) {
     for (auto& [id, item] : Rando::StaticData::Items) {
         if (!item.spoilerName || item.spoilerName[0] == '\0')
             continue;
-        // ComboShip: "name" MUST stay spoilerName (RI_*) — grant lookup keys on it. "displayName"
-        // is the human string (StaticData's unused .name field) for toasts/shops in the OTHER game.
+        // ComboShip: "name" is the friendly combo-spoiler key the grant/apply paths resolve.
+        // "displayName" is the human string for toasts/shops in the OTHER game (suffixed there).
         // advancement drives whether a foreign item plays the held-up pickup animation.
-        nlohmann::json entry = { { "name", item.spoilerName }, { "advancement", isAdvancement(item) } };
+        nlohmann::json entry = { { "name", Rando::StaticData::GetItemDisplayName(id) },
+                                 { "advancement", isAdvancement(item) } };
         if (item.name && item.name[0] != '\0') {
             entry["displayName"] = item.name;
         }
@@ -3121,9 +3158,10 @@ extern "C" __declspec(dllexport) const char* MM_DumpRandoStaticData(void) {
     // hint layer's cross-game text composition needs the same "region" phrasing MM's own hints use.
     nlohmann::json locationHints = nlohmann::json::object();
     for (auto& [id, chk] : Rando::StaticData::Checks) {
-        if (!chk.name || chk.name[0] == '\0')
+        const std::string& cn = Rando::StaticData::GetCheckDisplayName(id); // ComboShip: friendly name
+        if (cn.empty())
             continue;
-        locationHints[chk.name] = Rando::StaticData::GetLocationNameForHint(id, false);
+        locationHints[cn] = Rando::StaticData::GetLocationNameForHint(id, false);
     }
 
     // ComboShip: the two hint options that decide whether the combo hint layer's cross gossip pool is
@@ -3152,6 +3190,18 @@ static uint64_t sMM_OracleSavedRegionTime;
 // so Restore would write garbage (zeros) back into MM's live save after generation.
 static bool sMM_OracleActive = false;
 using Rando::Logic::gCurrentRegionTime;
+
+// ComboShip (#61): cross-grant only set the trade item's obtained flag, leaving the shared trade
+// slot's main item empty (item stuck as a rotatable offset, invisible to the tracker). Populate the
+// main slot when empty, dormant-safe (no gPlayState), mirroring real pickup's Item_Give.
+static void ComboGrantTradeSlot(u8 itemId) {
+    if (itemId >= ARRAY_COUNT(gItemSlots) || gItemSlots[itemId] == SLOT_NONE) {
+        return;
+    }
+    if (INV_CONTENT(itemId) == ITEM_NONE) {
+        INV_CONTENT(itemId) = itemId;
+    }
+}
 
 // Headless item-give: sets gSaveContext fields without ever touching gPlayState.
 // Covers the save-context mutations that logic conditions read (INV_CONTENT, equipment,
@@ -3317,33 +3367,42 @@ static void GiveItemForOracle(RandoItemId ri) {
             gSaveContext.save.saveInfo.inventory.strayFairies[DUNGEON_SCENE_INDEX_STONE_TOWER_TEMPLE]++;
             break;
 
-        // Rando-flag items (deeds, keys, letters, etc.)
+        // Rando-flag items (deeds, keys, letters, etc.) — also populate the shared trade slot (#61).
         case RI_MOONS_TEAR:
             Flags_SetRandoInf(RANDO_INF_OBTAINED_MOONS_TEAR);
+            ComboGrantTradeSlot(ITEM_MOONS_TEAR);
             break;
         case RI_DEED_LAND:
             Flags_SetRandoInf(RANDO_INF_OBTAINED_DEED_LAND);
+            ComboGrantTradeSlot(ITEM_DEED_LAND);
             break;
         case RI_DEED_SWAMP:
             Flags_SetRandoInf(RANDO_INF_OBTAINED_DEED_SWAMP);
+            ComboGrantTradeSlot(ITEM_DEED_SWAMP);
             break;
         case RI_DEED_MOUNTAIN:
             Flags_SetRandoInf(RANDO_INF_OBTAINED_DEED_MOUNTAIN);
+            ComboGrantTradeSlot(ITEM_DEED_MOUNTAIN);
             break;
         case RI_DEED_OCEAN:
             Flags_SetRandoInf(RANDO_INF_OBTAINED_DEED_OCEAN);
+            ComboGrantTradeSlot(ITEM_DEED_OCEAN);
             break;
         case RI_ROOM_KEY:
             Flags_SetRandoInf(RANDO_INF_OBTAINED_ROOM_KEY);
+            ComboGrantTradeSlot(ITEM_ROOM_KEY);
             break;
         case RI_LETTER_TO_MAMA:
             Flags_SetRandoInf(RANDO_INF_OBTAINED_LETTER_TO_MAMA);
+            ComboGrantTradeSlot(ITEM_LETTER_MAMA);
             break;
         case RI_LETTER_TO_KAFEI:
             Flags_SetRandoInf(RANDO_INF_OBTAINED_LETTER_TO_KAFEI);
+            ComboGrantTradeSlot(ITEM_LETTER_TO_KAFEI);
             break;
         case RI_PENDANT_OF_MEMORIES:
             Flags_SetRandoInf(RANDO_INF_OBTAINED_PENDANT_OF_MEMORIES);
+            ComboGrantTradeSlot(ITEM_PENDANT_OF_MEMORIES);
             break;
         case RI_POWDER_KEG:
             Flags_SetWeekEventReg(WEEKEVENTREG_HAS_POWDERKEG_PRIVILEGES);
@@ -3568,12 +3627,15 @@ extern "C" __declspec(dllexport) void Combo_MM_Rando_Reset(void) {
 // ComboShip: name->id lookup maps for the oracle hot path, replacing per-name linear scans over
 // StaticData that dominated fill time. StaticData is immutable after eager boot and the oracle runs
 // single-threaded, so build-once function-local statics are safe.
+// ComboShip: keyed on the FRIENDLY combo-spoiler names (GetItemDisplayName / GetCheckDisplayName), so
+// the oracle, cross-item grant and price/apply paths all resolve the same normalized names the dump emits.
 static const std::unordered_map<std::string, RandoItemId>& Combo_MM_SpoilerNameToItemId() {
     static const std::unordered_map<std::string, RandoItemId> map = [] {
         std::unordered_map<std::string, RandoItemId> m;
         for (auto& [id, item] : Rando::StaticData::Items) {
-            if (item.spoilerName && item.spoilerName[0] != '\0')
-                m.emplace(item.spoilerName, id);
+            const std::string& n = Rando::StaticData::GetItemDisplayName(id);
+            if (!n.empty())
+                m.emplace(n, id);
         }
         return m;
     }();
@@ -3584,8 +3646,9 @@ static const std::unordered_map<std::string, RandoCheckId>& Combo_MM_CheckNameTo
     static const std::unordered_map<std::string, RandoCheckId> map = [] {
         std::unordered_map<std::string, RandoCheckId> m;
         for (auto& [id, chk] : Rando::StaticData::Checks) {
-            if (chk.name && chk.name[0] != '\0')
-                m.emplace(chk.name, id);
+            const std::string& n = Rando::StaticData::GetCheckDisplayName(id);
+            if (!n.empty())
+                m.emplace(n, id);
         }
         return m;
     }();
@@ -3739,10 +3802,10 @@ extern "C" __declspec(dllexport) const char* Combo_MM_Rando_GetReachableChecks(v
 
         for (auto& [checkId, checkLogic] : region.checks) {
             if (checkLogic.first()) {
-                auto chkIt = Rando::StaticData::Checks.find(checkId);
-                if (chkIt != Rando::StaticData::Checks.end() && chkIt->second.name) {
-                    out.push_back(chkIt->second.name);
-                }
+                // ComboShip: emit the friendly combo-spoiler name the fill/oracle key on.
+                const std::string& n = Rando::StaticData::GetCheckDisplayName(checkId);
+                if (!n.empty())
+                    out.push_back(n);
             }
         }
     }

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -3098,7 +3098,8 @@ extern "C" __declspec(dllexport) const char* MM_DumpRandoStaticData(void) {
             continue;
         }
         // ComboShip: friendly item name for the normalized combo spoiler.
-        pool.push_back({ { "name", Rando::StaticData::GetItemDisplayName(iid) }, { "advancement", isAdvancement(it->second) } });
+        pool.push_back(
+            { { "name", Rando::StaticData::GetItemDisplayName(iid) }, { "advancement", isAdvancement(it->second) } });
     }
 
     // ComboShip canary: written to a file because 2ship.dll's spdlog default logger is never

--- a/mm/2s2h/CustomItem/CustomItem.h
+++ b/mm/2s2h/CustomItem/CustomItem.h
@@ -4,6 +4,9 @@ extern "C" {
 
 #define CUSTOM_ITEM_FLAGS (actor->home.rot.x)
 #define CUSTOM_ITEM_PARAM (actor->home.rot.z)
+// ComboShip (#66): spare field used to keep a foreign check id alive after CUSTOM_ITEM_PARAM is
+// overwritten with the item id on pickup, so the held-up foreign model still resolves.
+#define CUSTOM_ITEM_PARAM2 (actor->home.rot.y)
 
 namespace CustomItem {
 

--- a/mm/2s2h/DeveloperTools/DeveloperTools.cpp
+++ b/mm/2s2h/DeveloperTools/DeveloperTools.cpp
@@ -20,7 +20,12 @@ void Inventory_SetWorldMapCloudVisibility(s16 tingleIndex);
 extern u16 sPersistentCycleWeekEventRegs[ARRAY_COUNT(gSaveContext.save.saveInfo.weekEventReg)];
 }
 
+#ifdef COMBO_BUILD
+// ComboShip: MM gets its own debug CVar so MM debug mode can't leak into OOT (shared CVar store, issue #67)
+#define CVAR_DEBUG_MODE_NAME "gDeveloperTools.DebugEnabledMM"
+#else
 #define CVAR_DEBUG_MODE_NAME "gDeveloperTools.DebugEnabled"
+#endif
 #define CVAR_DEBUG_MODE CVarGetInteger(CVAR_DEBUG_MODE_NAME, 0)
 
 #define CVAR_SAVE_FILE_MODE_NAME "gDeveloperTools.DebugSaveFileMode"

--- a/mm/2s2h/Enhancements/Fixes/BgmReplay.cpp
+++ b/mm/2s2h/Enhancements/Fixes/BgmReplay.cpp
@@ -10,7 +10,12 @@ extern u8 sStartSeqDisabled;
 
 #define CVAR_NAME_FASTER_SCENE_TRANSITIONS "gEnhancements.Timesavers.FasterSceneTransitions"
 #define CVAR_NAME_PAUSE_SAVE "gEnhancements.Saving.PauseSave"
+#ifdef COMBO_BUILD
+// ComboShip: MM's own debug CVar so MM debug can't leak into OOT (shared CVar store, issue #67)
+#define CVAR_NAME_DEBUG_MODE "gDeveloperTools.DebugEnabledMM"
+#else
 #define CVAR_NAME_DEBUG_MODE "gDeveloperTools.DebugEnabled"
+#endif
 
 #define CVAR_FASTER_SCENE_TRANSITIONS CVarGetInteger(CVAR_NAME_FASTER_SCENE_TRANSITIONS, 0)
 #define CVAR_PAUSE_SAVE CVarGetInteger(CVAR_NAME_PAUSE_SAVE, 0)

--- a/mm/2s2h/PresetManager/PresetManager.cpp
+++ b/mm/2s2h/PresetManager/PresetManager.cpp
@@ -584,6 +584,14 @@ void PresetManager_RefreshPresets() {
     presets.clear();
     presets.insert(
         { "Defaults (Everything Off)", { defaultsPresetJ, { "Developer Tools", "Enhancements", "HUD", "Rando" } } });
+#ifdef COMBO_BUILD
+    // ComboShip: curated preset must set MM's namespaced debug key, not OOT's shared one (issue #67)
+    if (curatedPresetJ["CVars"]["gDeveloperTools"].contains("DebugEnabled")) {
+        auto& devTools = curatedPresetJ["CVars"]["gDeveloperTools"];
+        devTools["DebugEnabledMM"] = devTools["DebugEnabled"];
+        devTools.erase("DebugEnabled");
+    }
+#endif
     presets.insert({ "Curated", { curatedPresetJ, { "Developer Tools", "Enhancements", "HUD" } } });
     presets.insert({ "Voyage 3", { voyage3PresetJ, { "Developer Tools", "Enhancements", "Rando" } } });
 

--- a/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
@@ -45,7 +45,7 @@ const ComboRando::ForeignItem* Rando::MiscBehavior::MM_LookupForeign(RandoCheckI
         g_mmForeignMap = ComboRando::LoadForeignForGame(slot, ComboRando::GAME_MM);
         g_mmForeignSlot = slot;
     }
-    auto it = g_mmForeignMap.find(Rando::StaticData::Checks[rc].name);
+    auto it = g_mmForeignMap.find(Rando::StaticData::GetCheckDisplayName(rc)); // ComboShip: friendly key
     return it != g_mmForeignMap.end() ? &it->second : nullptr;
 }
 
@@ -57,10 +57,9 @@ void Rando::MiscBehavior::SendForeignCheck(RandoCheckId rc) {
         g_mmForeignMap = ComboRando::LoadForeignForGame(slot, ComboRando::GAME_MM);
         g_mmForeignSlot = slot;
     }
-    // ComboShip: key by StaticData::Checks[].name (the "RC_*" identifier) — the SAME name the MM
-    // dump emits and the fill writes into the foreign map. CheckNames[rc] is the human-readable
-    // display name ("Termina Field Grass 160") and never matches the map keys.
-    const std::string checkName = Rando::StaticData::Checks[rc].name;
+    // ComboShip: key by the friendly combo-spoiler name (GetCheckDisplayName) — the SAME name the MM
+    // dump emits and the fill/foreign array carry. Must match foreign[].checkName exactly.
+    const std::string checkName = Rando::StaticData::GetCheckDisplayName(rc);
     auto it = g_mmForeignMap.find(checkName);
     if (it != g_mmForeignMap.end()) {
         // Grant straight into the dormant target game's resident save (and persist it there), then
@@ -166,6 +165,9 @@ void Rando::MiscBehavior::CheckQueue() {
                                 Rando::MiscBehavior::SendForeignCheck(cid); // cross-deliver + toast + save
                             }
                             queued = false;
+                            // ComboShip (#66): keep the check id (the held-up foreign model resolves
+                            // by check id) before CUSTOM_ITEM_PARAM is repurposed as the item id.
+                            CUSTOM_ITEM_PARAM2 = cid;
                             CUSTOM_ITEM_PARAM = RI_COMBO_FOREIGN;
                             return;
                         }
@@ -241,6 +243,7 @@ void Rando::MiscBehavior::CheckQueue() {
                 .drawItem =
                     [](Actor* actor, PlayState* play) {
                         RandoItemId randoItemId;
+                        RandoCheckId randoCheckId = (RandoCheckId)CUSTOM_ITEM_PARAM;
 
                         // If the item has been given, the CUSTOM_ITEM_PARAM is set to the RI, prior to that it's the RC
                         if (CUSTOM_ITEM_FLAGS & CustomItem::CALLED_ACTION) {
@@ -249,14 +252,20 @@ void Rando::MiscBehavior::CheckQueue() {
                             } else {
                                 randoItemId = (RandoItemId)CUSTOM_ITEM_PARAM;
                             }
+#ifdef COMBO_BUILD
+                            // ComboShip (#66): post-pickup CUSTOM_ITEM_PARAM is the item id, but the
+                            // foreign model resolves by check id, stashed in CUSTOM_ITEM_PARAM2.
+                            if (randoItemId == RI_COMBO_FOREIGN) {
+                                randoCheckId = (RandoCheckId)CUSTOM_ITEM_PARAM2;
+                            }
+#endif
                         } else {
                             auto& randoSaveCheck = RANDO_SAVE_CHECKS[CUSTOM_ITEM_PARAM];
-                            randoItemId =
-                                Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM);
+                            randoItemId = Rando::ConvertItem(randoSaveCheck.randoItemId, randoCheckId);
                         }
 
                         Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                        Rando::DrawItem(randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM, actor);
+                        Rando::DrawItem(randoItemId, randoCheckId, actor);
                     } });
             return;
         }

--- a/mm/2s2h/Rando/Rando.cpp
+++ b/mm/2s2h/Rando/Rando.cpp
@@ -65,15 +65,16 @@ std::string Rando::GetItemLocationHintName(RandoItemId randoItemId, bool exact) 
     // generated before hints.mm.itemLocations existed.
     int slot = gSaveContext.fileNum;
     if (slot != 0xFF) {
-        const char* spoilerName = Rando::StaticData::Items[randoItemId].spoilerName;
-        if (spoilerName && spoilerName[0] != '\0') {
+        // ComboShip: the consolidated file keys foreign items by the friendly combo-spoiler name.
+        const std::string& friendlyName = Rando::StaticData::GetItemDisplayName(randoItemId);
+        if (!friendlyName.empty()) {
             static int s_hintsSlot = -1;
             static ComboRando::MmHints s_hints;
             if (slot != s_hintsSlot) {
                 s_hints = ComboRando::LoadHintsMM(slot);
                 s_hintsSlot = slot;
             }
-            auto hintIt = s_hints.itemLocations.find(spoilerName);
+            auto hintIt = s_hints.itemLocations.find(friendlyName);
             if (hintIt != s_hints.itemLocations.end()) {
                 return hintIt->second;
             }
@@ -84,7 +85,7 @@ std::string Rando::GetItemLocationHintName(RandoItemId randoItemId, bool exact) 
                 s_map = ComboRando::LoadForeignByItem(slot, ComboRando::GAME_MM);
                 s_slot = slot;
             }
-            auto it = s_map.find(spoilerName);
+            auto it = s_map.find(friendlyName);
             if (it != s_map.end()) {
                 return "at " + it->second.checkName + " (OOT)";
             }

--- a/mm/2s2h/Rando/StaticData/Checks.cpp
+++ b/mm/2s2h/Rando/StaticData/Checks.cpp
@@ -1,5 +1,9 @@
 #include "StaticData.h"
 #include "ShipUtils.h"
+#include <algorithm>
+#include <cctype>
+#include <sstream>
+#include <unordered_map>
 
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/Rando/Logic/Logic.h"
@@ -2382,6 +2386,59 @@ RandoCheckId GetCheckIdFromName(const char* name) {
     }
     return RC_UNKNOWN;
 }
+
+#ifdef COMBO_BUILD
+// ComboShip: friendly form of an RC_ enum for the normalized combo spoiler. Reuse the same helper that
+// builds CheckNames[] (shown in MM's tracker/menu) so the spoiler/plando names match MM's own UI.
+static std::string ComboPrettifyCheck(const char* rcName) {
+    return convertEnumToReadableName(rcName ? rcName : "", "RC_");
+}
+
+// Friendly check name <-> id. Two RCs that prettify to the same string fall back to the RC_ enum name
+// for both (lookup stays 1:1); reversibility is verified via this map, not a string inverse.
+static const std::unordered_map<RandoCheckId, std::string>& ComboCheckEmitNames() {
+    static const std::unordered_map<RandoCheckId, std::string> map = [] {
+        std::unordered_map<std::string, int> cnt;
+        std::unordered_map<RandoCheckId, std::string> pretty;
+        for (auto& [id, chk] : Checks) {
+            if (!chk.name || chk.name[0] == '\0')
+                continue;
+            std::string p = ComboPrettifyCheck(chk.name);
+            pretty[id] = p;
+            cnt[p]++;
+        }
+        std::unordered_map<RandoCheckId, std::string> m;
+        for (auto& [id, chk] : Checks) {
+            if (!chk.name || chk.name[0] == '\0')
+                continue;
+            m[id] = (cnt[pretty[id]] > 1) ? std::string(chk.name) : pretty[id]; // collision -> keep RC_
+        }
+        return m;
+    }();
+    return map;
+}
+
+const std::string& GetCheckDisplayName(RandoCheckId id) {
+    static const std::string empty;
+    const auto& m = ComboCheckEmitNames();
+    auto it = m.find(id);
+    return it == m.end() ? empty : it->second;
+}
+
+RandoCheckId GetCheckIdFromDisplayName(const char* name) {
+    if (!name)
+        return RC_UNKNOWN;
+    static const std::unordered_map<std::string, RandoCheckId> inv = [] {
+        std::unordered_map<std::string, RandoCheckId> m;
+        for (auto& [id, emit] : ComboCheckEmitNames())
+            if (!emit.empty())
+                m.emplace(emit, id); // emit names are unique by construction
+        return m;
+    }();
+    auto it = inv.find(name);
+    return it == inv.end() ? RC_UNKNOWN : it->second;
+}
+#endif
 
 void PopulateCheckNames() {
     for (auto& [randoCheckId, randoStaticCheck] : Rando::StaticData::Checks) {

--- a/mm/2s2h/Rando/StaticData/Items.cpp
+++ b/mm/2s2h/Rando/StaticData/Items.cpp
@@ -1,4 +1,5 @@
 #include "StaticData.h"
+#include <unordered_map>
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/ShipUtils.h"
 #include "2s2h/Rando/Rando.h"
@@ -322,6 +323,55 @@ RandoItemId GetItemIdFromName(const char* name) {
     }
     return RI_UNKNOWN;
 }
+
+#ifdef COMBO_BUILD
+// ComboShip: friendly item name <-> id for the normalized combo spoiler. Emits `name` (human) instead
+// of the RI_ spoilerName. Names shared by 2+ items fall back to the RI_ spoilerName so lookup stays 1:1.
+// RI_TRIFORCE_PIECE_PREVIOUS is draw-only (never placed) and shares "Piece of the Triforce" with the
+// real RI_TRIFORCE_PIECE — excluded from the collision count so the friendly resolves to the real one.
+static const std::unordered_map<RandoItemId, std::string>& ComboItemEmitNames() {
+    static const std::unordered_map<RandoItemId, std::string> map = [] {
+        std::unordered_map<std::string, int> nameCount;
+        for (auto& [id, it] : Items) {
+            if (id == RI_TRIFORCE_PIECE_PREVIOUS)
+                continue;
+            if (it.name && it.name[0] != '\0')
+                nameCount[it.name]++;
+        }
+        std::unordered_map<RandoItemId, std::string> m;
+        for (auto& [id, it] : Items) {
+            const char* sp = (it.spoilerName && it.spoilerName[0] != '\0') ? it.spoilerName : "";
+            if (id == RI_TRIFORCE_PIECE_PREVIOUS || !it.name || it.name[0] == '\0' || nameCount[it.name] > 1)
+                m[id] = sp; // ambiguous or draw-only -> keep enum spoilerName
+            else
+                m[id] = it.name;
+        }
+        return m;
+    }();
+    return map;
+}
+
+const std::string& GetItemDisplayName(RandoItemId id) {
+    static const std::string empty;
+    const auto& m = ComboItemEmitNames();
+    auto it = m.find(id);
+    return it == m.end() ? empty : it->second;
+}
+
+RandoItemId GetItemIdFromDisplayName(const char* name) {
+    if (!name)
+        return RI_UNKNOWN;
+    static const std::unordered_map<std::string, RandoItemId> inv = [] {
+        std::unordered_map<std::string, RandoItemId> m;
+        for (auto& [id, emit] : ComboItemEmitNames())
+            if (!emit.empty())
+                m.emplace(emit, id); // emit names are unique by construction
+        return m;
+    }();
+    auto it = inv.find(name);
+    return it == inv.end() ? RI_UNKNOWN : it->second;
+}
+#endif
 
 RandoItemId GetItemIdFromVanillaItemId(u32 itemId) {
     for (auto& [randoItemId, randoStaticItem] : Items) {

--- a/mm/2s2h/Rando/StaticData/StaticData.h
+++ b/mm/2s2h/Rando/StaticData/StaticData.h
@@ -32,6 +32,11 @@ extern std::array<std::string, RC_MAX> CheckNames;
 
 RandoStaticCheck GetCheckFromFlag(FlagType flagType, s32 flag, s16 sceneId = SCENE_MAX);
 RandoCheckId GetCheckIdFromName(const char* name);
+#ifdef COMBO_BUILD
+// ComboShip: friendly check name <-> id for the normalized combo spoiler (see Checks.cpp).
+const std::string& GetCheckDisplayName(RandoCheckId id);
+RandoCheckId GetCheckIdFromDisplayName(const char* name);
+#endif
 void PopulateCheckNames();
 std::string GetLocationNameForHint(RandoCheckId randoCheckId, bool exact);
 
@@ -51,6 +56,11 @@ extern std::map<StartingItemCategory, std::vector<RandoItemId>> StartingItemsMap
 extern std::map<RandoItemId, u8> MaxStartingItemsMap;
 
 RandoItemId GetItemIdFromName(const char* name);
+#ifdef COMBO_BUILD
+// ComboShip: friendly item name <-> id for the normalized combo spoiler (see Items.cpp).
+const std::string& GetItemDisplayName(RandoItemId id);
+RandoItemId GetItemIdFromDisplayName(const char* name);
+#endif
 RandoItemId GetItemIdFromVanillaItemId(u32 itemId);
 u8 GetIconForZMessage(RandoItemId itemId);
 const char* GetIconTexturePath(RandoItemId itemId);

--- a/mm/src/code/z_pause.c
+++ b/mm/src/code/z_pause.c
@@ -25,6 +25,13 @@
 #include "padutils.h"
 #include <libultraship/bridge/consolevariablebridge.h>
 
+#ifdef COMBO_BUILD
+// ComboShip: MM's own debug CVar so MM debug can't leak into OOT (shared CVar store, issue #67)
+#define CVAR_MM_DEBUG_MODE_NAME "gDeveloperTools.DebugEnabledMM"
+#else
+#define CVAR_MM_DEBUG_MODE_NAME "gDeveloperTools.DebugEnabled"
+#endif
+
 void FrameAdvance_Init(FrameAdvanceContext* frameAdvCtx) {
     frameAdvCtx->timer = 0;
     frameAdvCtx->enabled = false;
@@ -34,7 +41,7 @@ void FrameAdvance_Init(FrameAdvanceContext* frameAdvCtx) {
  * Returns true when frame advance is not active (game will run normally)
  */
 s32 FrameAdvance_Update(FrameAdvanceContext* frameAdvCtx, Input* input) {
-    if (CVarGetInteger("gDeveloperTools.DebugEnabled", 0)) {
+    if (CVarGetInteger(CVAR_MM_DEBUG_MODE_NAME, 0)) {
         if (CHECK_BTN_ALL(input->cur.button, BTN_R) && CHECK_BTN_ALL(input->press.button, BTN_DDOWN)) {
             frameAdvCtx->enabled = !frameAdvCtx->enabled;
         }

--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -13026,10 +13026,17 @@ Vec3f D_8085D41C = { 0.0f, 0.0f, -30.0f };
 
 static bool sNoclipEnabled;
 
+#ifdef COMBO_BUILD
+// ComboShip: MM's own debug CVar so MM debug can't leak into OOT (shared CVar store, issue #67)
+#define CVAR_MM_DEBUG_MODE_NAME "gDeveloperTools.DebugEnabledMM"
+#else
+#define CVAR_MM_DEBUG_MODE_NAME "gDeveloperTools.DebugEnabled"
+#endif
+
 s32 Player_UpdateNoclip(Player* this, PlayState* play) {
     sPlayerControlInput = &play->state.input[0];
 
-    if (!CVarGetInteger("gDeveloperTools.DebugEnabled", 0)) {
+    if (!CVarGetInteger(CVAR_MM_DEBUG_MODE_NAME, 0)) {
         sNoclipEnabled = false;
         return true;
     }

--- a/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope_NES.c
+++ b/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope_NES.c
@@ -531,7 +531,13 @@ void KaleidoScope_HandlePageToggles(PlayState* play, Input* input) {
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
 
     // 2S2H [Debug] Restoring input check for debug inventory editor based on OOT debug
-    if (CVarGetInteger("gDeveloperTools.DebugEnabled", 0) && (pauseCtx->debugEditor == DEBUG_EDITOR_NONE) &&
+    // ComboShip: MM's own debug CVar so MM debug can't leak into OOT (shared CVar store, issue #67)
+#ifdef COMBO_BUILD
+#define CVAR_MM_DEBUG_MODE_NAME "gDeveloperTools.DebugEnabledMM"
+#else
+#define CVAR_MM_DEBUG_MODE_NAME "gDeveloperTools.DebugEnabled"
+#endif
+    if (CVarGetInteger(CVAR_MM_DEBUG_MODE_NAME, 0) && (pauseCtx->debugEditor == DEBUG_EDITOR_NONE) &&
         CHECK_BTN_ALL(input->press.button, BTN_L)) {
         pauseCtx->debugEditor = DEBUG_EDITOR_INVENTORY_INIT;
         return;

--- a/soh/soh/Network/Anchor/Menu.cpp
+++ b/soh/soh/Network/Anchor/Menu.cpp
@@ -128,6 +128,9 @@ void AnchorMainMenu(WidgetInfo& info) {
     ImGui::SeparatorText("Current Room");
     ImGui::Text("%s Connected", ICON_FA_CHECK);
 
+#ifndef COMBO_BUILD
+    // ComboShip: replaced in combo builds by the shared "Resync team state" control in the combo
+    // menu's Anchor panel, which syncs BOTH games. Kept here for standalone SoH.
     UIWidgets::PushStyleButton(THEME_COLOR);
     if (ImGui::Button("Request Team State")) {
         anchor->SendPacket_RequestTeamState();
@@ -136,6 +139,7 @@ void AnchorMainMenu(WidgetInfo& info) {
     UIWidgets::PopStyleButton();
 
     ImGui::SameLine();
+#endif
 
     UIWidgets::WindowButton("Toggle Anchor Room Window", CVAR_WINDOW("AnchorRoom"), SohGui::mAnchorRoomWindow);
 

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -4162,12 +4162,21 @@ extern "C" __declspec(dllexport) void SOH_ApplyRandoPlacements(const char* json)
 
         nlohmann::json placements = nlohmann::json::parse(json);
         int placed = 0, skipped = 0;
-        for (auto& [name, itemVal] : placements.items()) {
+        // ComboShip: cross-game name collisions are suffixed "(OOT)" in the consolidated spoiler; strip
+        // our own suffix before resolving native OOT location/item names.
+        auto stripOOT = [](std::string s) {
+            static const std::string suf = " (OOT)";
+            if (s.size() >= suf.size() && s.compare(s.size() - suf.size(), suf.size(), suf) == 0)
+                s.resize(s.size() - suf.size());
+            return s;
+        };
+        for (auto& [rawName, itemVal] : placements.items()) {
             if (!itemVal.is_string()) {
                 ++skipped;
                 continue;
             }
-            const std::string itemName = itemVal.get<std::string>();
+            const std::string name = stripOOT(rawName);
+            const std::string itemName = stripOOT(itemVal.get<std::string>());
 
             auto rcIt = Rando::StaticData::locationNameToEnum.find(name);
             if (rcIt == Rando::StaticData::locationNameToEnum.end()) {

--- a/soh/soh/SohGui/SohMenuRandomizer.cpp
+++ b/soh/soh/SohGui/SohMenuRandomizer.cpp
@@ -832,7 +832,9 @@ void SohMenu::AddMenuRandomizer() {
     AddSidebarEntry("Randomizer", path.sidebarName, 1);
     AddWidget(path, "Tricks/Glitches", WIDGET_CUSTOM).CustomFunction(DrawTricksMenu);
 
-    // Plandomizer
+#ifndef COMBO_BUILD
+    // Plandomizer. ComboShip: the OOT-only plando can't parse combo consolidated spoilers; the
+    // combo-aware plandomizer lives in the Combo menu instead, so hide this one in combo builds.
     path.sidebarName = "Plandomizer";
     AddSidebarEntry("Randomizer", path.sidebarName, 1);
     AddWidget(path, "Popout Plandomizer Window", WIDGET_WINDOW_BUTTON)
@@ -841,23 +843,6 @@ void SohMenu::AddMenuRandomizer() {
         .WindowName("Plandomizer Editor")
         .HideInSearch(true)
         .Options(WindowButtonOptions().Tooltip("Enables the separate Randomizer Settings Window."));
-#ifdef COMBO_BUILD
-    // ComboShip: draw the Plandomizer inline (SoH embeds it via the window button's EmbedWindow;
-    // comboui's flat model doesn't carry that flag). Mirrors "Controller Bindings Inline"; skipped
-    // while popped out so the Gui loop's floating copy isn't double-drawn.
-    AddWidget(path, "Plandomizer Inline", WIDGET_CUSTOM)
-        .RaceDisable(false)
-        .HideInSearch(true)
-        .CustomFunction([](WidgetInfo&) {
-            auto ctx = Ship::Context::GetInstance();
-            if (!ctx || !ctx->GetWindow() || !ctx->GetWindow()->GetGui())
-                return;
-            auto win = ctx->GetWindow()->GetGui()->GetGuiWindow("Plandomizer Editor");
-            if (!win || win->IsVisible())
-                return;
-            win->Update();
-            win->DrawElement();
-        });
 #endif
 
     // Item Tracker

--- a/soh/src/code/z_draw.c
+++ b/soh/src/code/z_draw.c
@@ -407,14 +407,24 @@ void GetItem_Draw(PlayState* play, s16 drawId) {
 // GetItem_GetDrawTableEntry. The other game (MM) asks soh.dll which display lists draw a foreign OOT
 // item and submits them through "__OTR__@oot:"-routed paths resolved against OOT's ResourceManager.
 //
-// Only "self-contained" draw funcs are exposed — those that merely submit dlists under plain
-// Gfx_SetupDL_25/26 Opa/Xlu state (plus an optional uniform scale). Funcs needing extra OOT runtime
-// state (texture scrolls, billboard rotation, grayscale, per-instance prim/env globals, special
-// matrices) are NOT portable to the other game's frame and return 0; the foreign game then falls
-// back to its sentinel. The 26Opa funcs are exposed as 25Opa — a close approximation. outDlists is
-// filled in SUBMISSION order; *outXluStart is the index of the first XLU-layer entry (-1 = all OPA).
+// Two tiers are exposed. SIMPLE funcs (drawKind 0) merely submit dlists under plain Gfx_SetupDL_25/26
+// Opa/Xlu state (plus an optional uniform scale); outDlists is filled in SUBMISSION order and
+// *outXluStart is the index of the first XLU-layer entry (-1 = all OPA). The remaining funcs need
+// extra OOT runtime state (segment-8/9 texture scrolls, billboard rotation, per-instance prim/env
+// color, grayscale) that can't be baked into a DL list: they set *outDrawKind to a CwDrawKind value
+// (see combo/menu/ComboItemDrawABI.h) and fill outColors for JEWEL/MUSIC_NOTE, and the foreign game's
+// per-kind handler re-binds the segment(s) + replays the matrices in its own frame. For those,
+// outDlists carries the raw table row (identity order). The 26Opa funcs are exposed as 25Opa (close
+// approximation). outColors is 16 bytes: primXlu[4], envXlu[4], primOpa[4], envOpa[4] (RGBA).
 // Returns the dlist count, or 0 if the row is unsupported/undrawable.
-s32 GetItem_GetDrawTableEntry(s32 drawId, void** outDlists, s32 maxDlists, s32* outXluStart, f32* outScale) {
+s32 GetItem_GetDrawTableEntry(s32 drawId, void** outDlists, s32 maxDlists, s32* outXluStart, f32* outScale,
+                              s32* outDrawKind, u8* outColors) {
+    // Mirror of CwDrawKind (ABI header is C++/POD; z_draw.c is C so keep local names in sync).
+    enum {
+        KIND_SIMPLE = 0, KIND_GORON_SWORD, KIND_DEKU_NUTS, KIND_RECOVERY_HEART, KIND_FISH, KIND_POTION,
+        KIND_MIRROR_SHIELD, KIND_BLUE_FIRE, KIND_POES, KIND_FAIRY, KIND_JEWEL, KIND_MAGIC_SPELL, KIND_SCALE,
+        KIND_SKULL_TOKEN, KIND_MUSIC_NOTE
+    };
     static const s8 sOrder0[] = { 0 };
     static const s8 sOrder01[] = { 0, 1 };
     static const s8 sOrder012[] = { 0, 1, 2 };
@@ -423,22 +433,109 @@ s32 GetItem_GetDrawTableEntry(s32 drawId, void** outDlists, s32 maxDlists, s32* 
     static const s8 sOrder1032[] = { 1, 0, 3, 2 };
     static const s8 sOrder10234[] = { 1, 0, 2, 3, 4 };
     static const s8 sOrderWallet[] = { 1, 0, 2, 3, 4, 5, 6, 7 };
+    static const s8 sIdent2[] = { 0, 1 };
+    static const s8 sIdent3[] = { 0, 1, 2 };
+    static const s8 sIdent4[] = { 0, 1, 2, 3 };
+    static const s8 sIdent6[] = { 0, 1, 2, 3, 4, 5 };
     void (*drawFunc)(PlayState*, s16);
     Gfx** res;
     const s8* order;
     s32 count;
     s32 xluStart;
+    s32 kind = KIND_SIMPLE;
     s32 i;
 
     if ((drawId < 0) || (drawId >= (s32)(sizeof(sDrawItemTable) / sizeof(sDrawItemTable[0]))) || (outDlists == NULL) ||
-        (outXluStart == NULL) || (outScale == NULL)) {
+        (outXluStart == NULL) || (outScale == NULL) || (outDrawKind == NULL)) {
         return 0;
     }
     *outScale = 0.0f; // 0 = no extra scale
+    *outDrawKind = KIND_SIMPLE;
     drawFunc = sDrawItemTable[drawId].drawFunc;
     res = sDrawItemTable[drawId].dlists;
 
-    if (drawFunc == GetItem_DrawOpa0) {
+    // -- Non-portable funcs: kind-tagged, carried in identity order for the consumer's 1:1 handler.
+    if (drawFunc == GetItem_DrawGoronSword) {
+        order = sOrder0; count = 1; xluStart = -1; kind = KIND_GORON_SWORD;
+    } else if (drawFunc == GetItem_DrawDekuNuts) {
+        order = sOrder0; count = 1; xluStart = -1; kind = KIND_DEKU_NUTS;
+    } else if (drawFunc == GetItem_DrawRecoveryHeart) {
+        order = sOrder0; count = 1; xluStart = 0; kind = KIND_RECOVERY_HEART;
+    } else if (drawFunc == GetItem_DrawFish) {
+        order = sOrder0; count = 1; xluStart = 0; kind = KIND_FISH;
+    } else if (drawFunc == GetItem_DrawPotion) {
+        order = sIdent6; count = 6; xluStart = 4; kind = KIND_POTION;
+    } else if (drawFunc == GetItem_DrawMirrorShield) {
+        order = sIdent2; count = 2; xluStart = 1; kind = KIND_MIRROR_SHIELD;
+    } else if (drawFunc == GetItem_DrawBlueFire) {
+        order = sIdent2; count = 2; xluStart = 1; kind = KIND_BLUE_FIRE;
+    } else if (drawFunc == GetItem_DrawPoes) {
+        order = sIdent4; count = 4; xluStart = 1; kind = KIND_POES;
+    } else if (drawFunc == GetItem_DrawFairy) {
+        order = sIdent3; count = 3; xluStart = 1; kind = KIND_FAIRY;
+    } else if ((drawFunc == GetItem_DrawJewelKokiri) || (drawFunc == GetItem_DrawJewelGoron) ||
+               (drawFunc == GetItem_DrawJewelZora)) {
+        order = sIdent2; count = 2; xluStart = 0; kind = KIND_JEWEL;
+        if (outColors != NULL) {
+            // Per-layer colors the jewel wrapper funcs set before GetItem_DrawJewel (primXlu, envXlu,
+            // primOpa, envOpa; alpha 255). The OPA setting layer is identical across all three stones.
+            static const u8 kOpaPrim[3] = { 255, 255, 170 };
+            static const u8 kOpaEnv[3] = { 150, 120, 0 };
+            const u8* xp;
+            const u8* xe;
+            static const u8 kKokiriXluPrim[3] = { 255, 255, 160 };
+            static const u8 kKokiriXluEnv[3] = { 0, 255, 0 };
+            static const u8 kGoronXluPrim[3] = { 255, 170, 255 };
+            static const u8 kGoronXluEnv[3] = { 255, 0, 100 };
+            static const u8 kZoraXluPrim[3] = { 50, 255, 255 };
+            static const u8 kZoraXluEnv[3] = { 50, 0, 150 };
+            if (drawFunc == GetItem_DrawJewelKokiri) {
+                xp = kKokiriXluPrim; xe = kKokiriXluEnv;
+            } else if (drawFunc == GetItem_DrawJewelGoron) {
+                xp = kGoronXluPrim; xe = kGoronXluEnv;
+            } else {
+                xp = kZoraXluPrim; xe = kZoraXluEnv;
+            }
+            for (i = 0; i < 3; i++) {
+                outColors[i] = xp[i];       // primXlu
+                outColors[4 + i] = xe[i];   // envXlu
+                outColors[8 + i] = kOpaPrim[i];
+                outColors[12 + i] = kOpaEnv[i];
+            }
+            outColors[3] = outColors[7] = outColors[11] = outColors[15] = 255; // alpha
+        }
+    } else if (drawFunc == GetItem_DrawMagicSpell) {
+        order = sIdent3; count = 3; xluStart = 0; kind = KIND_MAGIC_SPELL;
+    } else if (drawFunc == GetItem_DrawScale) {
+        order = sIdent4; count = 4; xluStart = 0; kind = KIND_SCALE;
+    } else if (drawFunc == GetItem_DrawGenericMusicNote) {
+        order = sOrder0; count = 1; xluStart = 0; kind = KIND_MUSIC_NOTE;
+        if (outColors != NULL) {
+            // Grayscale tint by note slot (drawId - 120), mirroring DrawGenericMusicNote's table.
+            static const u8 kNoteColors[7][3] = {
+                { 255, 255, 255 }, { 109, 73, 143 }, { 217, 110, 48 }, { 62, 109, 23 },
+                { 237, 231, 62 },  { 98, 177, 211 }, { 146, 146, 146 }
+            };
+            s32 slot = drawId - 120;
+            if (slot < 0 || slot > 6) {
+                slot = 0;
+            }
+            outColors[0] = kNoteColors[slot][0];
+            outColors[1] = kNoteColors[slot][1];
+            outColors[2] = kNoteColors[slot][2];
+            outColors[3] = 255;
+        }
+    } else if (drawFunc == GetItem_DrawTriforcePiece) {
+        // Plain scaled OPA — no segment/matrix state, so the simple consumer path draws it (index 0
+        // approximates the animating triforcePiece0/1/2 selection).
+        order = sOrder0; count = 1; xluStart = -1;
+        *outScale = 0.035f;
+    } else if (drawFunc == GetItem_DrawFishingPole) {
+        // Best-effort: rod only (dlists[0]) via the simple path; the lure/hook DLs aren't in the table
+        // row to carry across.
+        order = sOrder0; count = 1; xluStart = -1;
+        *outScale = 0.2f;
+    } else if (drawFunc == GetItem_DrawOpa0) {
         order = sOrder0;
         count = 1;
         xluStart = -1;
@@ -493,11 +590,12 @@ s32 GetItem_GetDrawTableEntry(s32 drawId, void** outDlists, s32 maxDlists, s32* 
         count = 8;
         xluStart = -1;
     } else if (drawFunc == GetItem_DrawSkullToken) {
-        // Static body only (OPA dlists[0]); the XLU flame needs an animated segment-8 texture scroll
-        // that isn't portable to the other game's frame, so it is dropped.
-        order = sOrder0;
-        count = 1;
-        xluStart = -1;
+        // Body (OPA dlists[0]) + flame (XLU dlists[1]); the flame's animated segment-8 texture scroll
+        // is replicated by the consumer's SKULL_TOKEN handler.
+        order = sIdent2;
+        count = 2;
+        xluStart = 1;
+        kind = KIND_SKULL_TOKEN;
     } else {
         return 0;
     }
@@ -512,6 +610,7 @@ s32 GetItem_GetDrawTableEntry(s32 drawId, void** outDlists, s32 maxDlists, s32* 
         outDlists[i] = (void*)res[order[i]];
     }
     *outXluStart = (xluStart > count) ? count : xluStart;
+    *outDrawKind = kind;
     return count;
 }
 #endif

--- a/soh/src/code/z_draw.c
+++ b/soh/src/code/z_draw.c
@@ -421,9 +421,21 @@ s32 GetItem_GetDrawTableEntry(s32 drawId, void** outDlists, s32 maxDlists, s32* 
                               s32* outDrawKind, u8* outColors) {
     // Mirror of CwDrawKind (ABI header is C++/POD; z_draw.c is C so keep local names in sync).
     enum {
-        KIND_SIMPLE = 0, KIND_GORON_SWORD, KIND_DEKU_NUTS, KIND_RECOVERY_HEART, KIND_FISH, KIND_POTION,
-        KIND_MIRROR_SHIELD, KIND_BLUE_FIRE, KIND_POES, KIND_FAIRY, KIND_JEWEL, KIND_MAGIC_SPELL, KIND_SCALE,
-        KIND_SKULL_TOKEN, KIND_MUSIC_NOTE
+        KIND_SIMPLE = 0,
+        KIND_GORON_SWORD,
+        KIND_DEKU_NUTS,
+        KIND_RECOVERY_HEART,
+        KIND_FISH,
+        KIND_POTION,
+        KIND_MIRROR_SHIELD,
+        KIND_BLUE_FIRE,
+        KIND_POES,
+        KIND_FAIRY,
+        KIND_JEWEL,
+        KIND_MAGIC_SPELL,
+        KIND_SCALE,
+        KIND_SKULL_TOKEN,
+        KIND_MUSIC_NOTE
     };
     static const s8 sOrder0[] = { 0 };
     static const s8 sOrder01[] = { 0, 1 };
@@ -456,26 +468,56 @@ s32 GetItem_GetDrawTableEntry(s32 drawId, void** outDlists, s32 maxDlists, s32* 
 
     // -- Non-portable funcs: kind-tagged, carried in identity order for the consumer's 1:1 handler.
     if (drawFunc == GetItem_DrawGoronSword) {
-        order = sOrder0; count = 1; xluStart = -1; kind = KIND_GORON_SWORD;
+        order = sOrder0;
+        count = 1;
+        xluStart = -1;
+        kind = KIND_GORON_SWORD;
     } else if (drawFunc == GetItem_DrawDekuNuts) {
-        order = sOrder0; count = 1; xluStart = -1; kind = KIND_DEKU_NUTS;
+        order = sOrder0;
+        count = 1;
+        xluStart = -1;
+        kind = KIND_DEKU_NUTS;
     } else if (drawFunc == GetItem_DrawRecoveryHeart) {
-        order = sOrder0; count = 1; xluStart = 0; kind = KIND_RECOVERY_HEART;
+        order = sOrder0;
+        count = 1;
+        xluStart = 0;
+        kind = KIND_RECOVERY_HEART;
     } else if (drawFunc == GetItem_DrawFish) {
-        order = sOrder0; count = 1; xluStart = 0; kind = KIND_FISH;
+        order = sOrder0;
+        count = 1;
+        xluStart = 0;
+        kind = KIND_FISH;
     } else if (drawFunc == GetItem_DrawPotion) {
-        order = sIdent6; count = 6; xluStart = 4; kind = KIND_POTION;
+        order = sIdent6;
+        count = 6;
+        xluStart = 4;
+        kind = KIND_POTION;
     } else if (drawFunc == GetItem_DrawMirrorShield) {
-        order = sIdent2; count = 2; xluStart = 1; kind = KIND_MIRROR_SHIELD;
+        order = sIdent2;
+        count = 2;
+        xluStart = 1;
+        kind = KIND_MIRROR_SHIELD;
     } else if (drawFunc == GetItem_DrawBlueFire) {
-        order = sIdent2; count = 2; xluStart = 1; kind = KIND_BLUE_FIRE;
+        order = sIdent2;
+        count = 2;
+        xluStart = 1;
+        kind = KIND_BLUE_FIRE;
     } else if (drawFunc == GetItem_DrawPoes) {
-        order = sIdent4; count = 4; xluStart = 1; kind = KIND_POES;
+        order = sIdent4;
+        count = 4;
+        xluStart = 1;
+        kind = KIND_POES;
     } else if (drawFunc == GetItem_DrawFairy) {
-        order = sIdent3; count = 3; xluStart = 1; kind = KIND_FAIRY;
+        order = sIdent3;
+        count = 3;
+        xluStart = 1;
+        kind = KIND_FAIRY;
     } else if ((drawFunc == GetItem_DrawJewelKokiri) || (drawFunc == GetItem_DrawJewelGoron) ||
                (drawFunc == GetItem_DrawJewelZora)) {
-        order = sIdent2; count = 2; xluStart = 0; kind = KIND_JEWEL;
+        order = sIdent2;
+        count = 2;
+        xluStart = 0;
+        kind = KIND_JEWEL;
         if (outColors != NULL) {
             // Per-layer colors the jewel wrapper funcs set before GetItem_DrawJewel (primXlu, envXlu,
             // primOpa, envOpa; alpha 255). The OPA setting layer is identical across all three stones.
@@ -490,32 +532,43 @@ s32 GetItem_GetDrawTableEntry(s32 drawId, void** outDlists, s32 maxDlists, s32* 
             static const u8 kZoraXluPrim[3] = { 50, 255, 255 };
             static const u8 kZoraXluEnv[3] = { 50, 0, 150 };
             if (drawFunc == GetItem_DrawJewelKokiri) {
-                xp = kKokiriXluPrim; xe = kKokiriXluEnv;
+                xp = kKokiriXluPrim;
+                xe = kKokiriXluEnv;
             } else if (drawFunc == GetItem_DrawJewelGoron) {
-                xp = kGoronXluPrim; xe = kGoronXluEnv;
+                xp = kGoronXluPrim;
+                xe = kGoronXluEnv;
             } else {
-                xp = kZoraXluPrim; xe = kZoraXluEnv;
+                xp = kZoraXluPrim;
+                xe = kZoraXluEnv;
             }
             for (i = 0; i < 3; i++) {
-                outColors[i] = xp[i];       // primXlu
-                outColors[4 + i] = xe[i];   // envXlu
+                outColors[i] = xp[i];     // primXlu
+                outColors[4 + i] = xe[i]; // envXlu
                 outColors[8 + i] = kOpaPrim[i];
                 outColors[12 + i] = kOpaEnv[i];
             }
             outColors[3] = outColors[7] = outColors[11] = outColors[15] = 255; // alpha
         }
     } else if (drawFunc == GetItem_DrawMagicSpell) {
-        order = sIdent3; count = 3; xluStart = 0; kind = KIND_MAGIC_SPELL;
+        order = sIdent3;
+        count = 3;
+        xluStart = 0;
+        kind = KIND_MAGIC_SPELL;
     } else if (drawFunc == GetItem_DrawScale) {
-        order = sIdent4; count = 4; xluStart = 0; kind = KIND_SCALE;
+        order = sIdent4;
+        count = 4;
+        xluStart = 0;
+        kind = KIND_SCALE;
     } else if (drawFunc == GetItem_DrawGenericMusicNote) {
-        order = sOrder0; count = 1; xluStart = 0; kind = KIND_MUSIC_NOTE;
+        order = sOrder0;
+        count = 1;
+        xluStart = 0;
+        kind = KIND_MUSIC_NOTE;
         if (outColors != NULL) {
             // Grayscale tint by note slot (drawId - 120), mirroring DrawGenericMusicNote's table.
-            static const u8 kNoteColors[7][3] = {
-                { 255, 255, 255 }, { 109, 73, 143 }, { 217, 110, 48 }, { 62, 109, 23 },
-                { 237, 231, 62 },  { 98, 177, 211 }, { 146, 146, 146 }
-            };
+            static const u8 kNoteColors[7][3] = { { 255, 255, 255 }, { 109, 73, 143 }, { 217, 110, 48 },
+                                                  { 62, 109, 23 },   { 237, 231, 62 }, { 98, 177, 211 },
+                                                  { 146, 146, 146 } };
             s32 slot = drawId - 120;
             if (slot < 0 || slot > 6) {
                 slot = 0;
@@ -528,12 +581,16 @@ s32 GetItem_GetDrawTableEntry(s32 drawId, void** outDlists, s32 maxDlists, s32* 
     } else if (drawFunc == GetItem_DrawTriforcePiece) {
         // Plain scaled OPA — no segment/matrix state, so the simple consumer path draws it (index 0
         // approximates the animating triforcePiece0/1/2 selection).
-        order = sOrder0; count = 1; xluStart = -1;
+        order = sOrder0;
+        count = 1;
+        xluStart = -1;
         *outScale = 0.035f;
     } else if (drawFunc == GetItem_DrawFishingPole) {
         // Best-effort: rod only (dlists[0]) via the simple path; the lure/hook DLs aren't in the table
         // row to carry across.
-        order = sOrder0; count = 1; xluStart = -1;
+        order = sOrder0;
+        count = 1;
+        xluStart = -1;
         *outScale = 0.2f;
     } else if (drawFunc == GetItem_DrawOpa0) {
         order = sOrder0;


### PR DESCRIPTION
Addresses issues #61, #66, #67, #73 (and closes out the #65 investigation).

## #73 — Cross-game plandomizer + friendly-name spoiler schema
- New **Combo > Plandomizer** panel: load a generated combo seed, edit any placement in either game (including assigning an OOT item to an MM check and vice-versa), then Save. Plays back verbatim through the existing reload path. The OOT-only plandomizer is hidden in combo builds.
- Normalized the consolidated spoiler to **friendly names** for both games' checks and items; cross-game name collisions (e.g. Mirror Shield) are disambiguated `(OOT)`/`(MM)`. Old mixed-schema seeds must be regenerated.

## #66 — OOT items display correctly in MM
- Preserve the foreign check id through the held-over-head phase so collected OOT items resolve their real model.
- **Foreign-draw portability:** 14 previously-unsupported OOT get-item draw funcs (swords, spiritual stones, potions, magic spells, mirror shield, deku nuts, recovery heart, fish, blue fire, poes, fairy, scales, skulltula tokens with flame, song notes) now render their real animated models in MM instead of the blue-rupee sentinel. Each handler re-binds the needed segment(s) before sampling and restores them, so no unbound-segment submits.

## #61 — MM trade items delivered from OOT
- Cross-granted trade items (Moon's Tear, deeds, Room Key, letters, pendant) now populate the main trade slot, so they show in the inventory and item tracker instead of only the rotatable offset.

## #67 — OOT no longer enters Debug Mode after returning from MM
- MM's debug CVar is namespaced (`gDeveloperTools.DebugEnabledMM`) in combo builds so it can't leak into OOT through the shared CVar store. Standalone 2ship is unchanged.

## #65 — Sanity-check MM item shuffle (no change)
- Investigated: the sword/shield counts are standard 2ship shopsanity behavior (shop slots' vanilla contents enter the pool) plus the starting-kit removal; abundance is the honored `RO_PLENTIFUL_ITEMS` toggle. Not combo-specific, so no change.

Combo-owned where possible; vendored changes are `COMBO_BUILD`-guarded.

<!--- section:artifacts:start -->
### Build Artifacts
  - [comborando-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8419145799.zip)
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8419144646.zip)
<!--- section:artifacts:end -->