### PR TITLE
Combo-owned Anchor: connection/admin/room-window UI + always-live roster

### DIFF
--- a/combo/CMakeLists.txt
+++ b/combo/CMakeLists.txt
@@ -36,6 +36,7 @@ set(COMBOUI_SOURCES
     gui/ComboTrackerBridge.cpp
     gui/ComboTrackerSwap.cpp
     gui/ComboAudioBridge.cpp
+    gui/ComboAnchorRoomWindow.cpp
 )
 add_library(comboui SHARED ${COMBOUI_SOURCES})
 set_target_properties(comboui PROPERTIES PREFIX "")

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -695,6 +695,9 @@ static void Disconnect() {
 static void Send(const char* json) {
     if (!json)
         return;
+    // Our own scene/room-state is broadcast OUTBOUND (never echoed inbound), so parse it here too or the
+    // self roster row would freeze at its join value.
+    UpdateRosterFromPacket(json);
     std::lock_guard<std::mutex> lk(sOutMutex);
     sOutQueue.push(json);
 }

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -22,9 +22,11 @@
 #include <atomic>
 #include <chrono>
 #include <unordered_map>
+#include <map>
 #include <thread>
 #include <mutex>
 #include <queue>
+#include <nlohmann/json.hpp>
 
 // SDL_net.h pulls in SDL.h -> SDL_main.h, which #defines main -> SDL_main unless we opt out.
 // ComboShip provides its own main(), so suppress SDL's entry-point hijack.
@@ -243,6 +245,10 @@ typedef void (*FnComboUIForeground)(int);
 static FnComboUIForeground ComboUI_OnForegroundGame = nullptr;
 static FnComboUIRegister ComboUI_RestoreTrackerIntent = nullptr;
 
+// ComboShip: hand comboui the launcher-owned Anchor roster getter (the room window reads it).
+typedef void (*FnComboUISetRosterProvider)(const char* (*)());
+static FnComboUISetRosterProvider ComboUI_SetAnchorRosterProvider = nullptr;
+
 // ComboShip-owned unified ROM extraction (see ComboExtract.h). The split init lets us create the
 // shared window from soh.o2r before any ROM exists, run the extraction screen, then finish.
 static FnVoid SOH_InitWindowOnly = nullptr;
@@ -420,6 +426,142 @@ static std::atomic<int> sActiveGame{ 0 };
 // gPlayState/isDormantApply, which PumpDormant also mutates there). Set here, drained by PumpDormant.
 static std::atomic<bool> sResyncPending{ false };
 
+// Combo-owned Anchor roster/presence. A game's Anchor only drains packets while it's the foreground
+// game, so its per-game roster goes stale when dormant. The launcher sees every packet on this
+// never-dormant thread, so it keeps ONE always-live roster the room window reads (display-only; games
+// keep their own roster for puppets/save-apply).
+struct ClientInfo {
+    uint32_t clientId = 0;
+    std::string name = "???";
+    uint8_t r = 255, g = 255, b = 255;
+    std::string teamId = "default";
+    bool online = false;
+    uint32_t seed = 0;
+    std::string clientVersion;
+    bool isSaveLoaded = false;
+    bool isGameComplete = false;
+    int16_t rawScene = 0;
+    int game = 0; // 0 = OOT, 1 = MM
+};
+struct RoomState {
+    uint32_t ownerClientId = 0;
+    int pvpMode = 1;
+    int showLocationsMode = 1;
+    int teleportMode = 1;
+    int syncItemsAndFlags = 1;
+};
+static std::mutex sRosterMutex;
+static std::map<uint32_t, ClientInfo> sRoster;
+static RoomState sRoomState;
+static uint32_t sOwnClientId = 0;
+
+// Fill a ClientInfo from a client JSON object (schema mirrors soh PrepClientState / JsonConversions).
+// MM namespaces its sceneNum (>= 1000) and tags packets originGame=="mm"; either flags the MM side.
+static void ParseClient(const nlohmann::json& c, const std::string& originGame, ClientInfo& info) {
+    info.clientId = c.value("clientId", (uint32_t)0);
+    info.name = c.value("name", std::string("???"));
+    if (c.contains("color") && c["color"].is_object()) {
+        info.r = c["color"].value("r", 255);
+        info.g = c["color"].value("g", 255);
+        info.b = c["color"].value("b", 255);
+    }
+    info.clientVersion = c.value("clientVersion", std::string());
+    info.teamId = c.value("teamId", std::string("default"));
+    info.online = c.value("online", false);
+    info.seed = c.value("seed", (uint32_t)0);
+    info.isSaveLoaded = c.value("isSaveLoaded", false);
+    info.isGameComplete = c.value("isGameComplete", false);
+    int32_t sceneNum = c.value("sceneNum", 0);
+    bool mm = originGame == "mm" || sceneNum >= 1000;
+    info.game = mm ? 1 : 0;
+    info.rawScene = (int16_t)(mm ? sceneNum - 1000 : sceneNum);
+}
+
+// Parse the presence/room packets into the roster (called on the receive thread, before forwarding).
+static void UpdateRosterFromPacket(const std::string& packet) {
+    try {
+        auto pj = nlohmann::json::parse(packet);
+        std::string type = pj.value("type", std::string());
+        std::string origin = pj.value("originGame", std::string());
+        if (type == "ALL_CLIENT_STATE") {
+            std::lock_guard<std::mutex> lk(sRosterMutex);
+            sRoster.clear();
+            for (auto& c : pj.value("state", nlohmann::json::array())) {
+                ClientInfo info;
+                ParseClient(c, "", info); // array entries carry no originGame; sceneNum tags MM
+                if (c.value("self", false))
+                    sOwnClientId = info.clientId;
+                sRoster[info.clientId] = info;
+            }
+        } else if (type == "UPDATE_CLIENT_STATE") {
+            uint32_t cid = pj.value("clientId", (uint32_t)0);
+            if (cid != 0 && pj.contains("state")) {
+                std::lock_guard<std::mutex> lk(sRosterMutex);
+                ClientInfo info;
+                ParseClient(pj["state"], origin, info);
+                info.clientId = cid;
+                sRoster[cid] = info;
+            }
+        } else if (type == "UPDATE_ROOM_STATE" && pj.contains("state")) {
+            auto s = pj["state"];
+            std::lock_guard<std::mutex> lk(sRosterMutex);
+            sRoomState.ownerClientId = s.value("ownerClientId", (uint32_t)0);
+            sRoomState.pvpMode = s.value("pvpMode", 1);
+            sRoomState.showLocationsMode = s.value("showLocationsMode", 1);
+            sRoomState.teleportMode = s.value("teleportMode", 1);
+            sRoomState.syncItemsAndFlags = s.value("syncItemsAndFlags", 1);
+        }
+        // UPDATE_TEAM_STATE (save blob) + PLAYER_UPDATE (high-rate puppet coords) are display-irrelevant.
+    } catch (...) {}
+}
+
+// Roster snapshot for comboui's room window: { ownClientId, room{...}, clients[...] }. areaVisible +
+// isOwner + self are resolved here (the launcher owns room-state); comboui resolves scene NAMES and
+// version/seed mismatch itself. ownTeam comes from the self entry's teamId (== gRemote.Anchor.TeamId).
+static const char* Combo_Anchor_GetRoster() {
+    static std::string cached;
+    try {
+        std::lock_guard<std::mutex> lk(sRosterMutex);
+        std::string ownTeam = "default";
+        auto selfIt = sRoster.find(sOwnClientId);
+        if (selfIt != sRoster.end())
+            ownTeam = selfIt->second.teamId;
+        int showLoc = sRoomState.showLocationsMode;
+
+        nlohmann::json clients = nlohmann::json::array();
+        for (auto& [cid, c] : sRoster) {
+            bool isOwnTeam = c.teamId == ownTeam;
+            bool areaVisible = c.isSaveLoaded && (showLoc == 2 || (showLoc == 1 && isOwnTeam));
+            nlohmann::json e;
+            e["clientId"] = cid;
+            e["name"] = c.name;
+            e["color"] = { { "r", c.r }, { "g", c.g }, { "b", c.b } };
+            e["teamId"] = c.teamId;
+            e["online"] = c.online;
+            e["self"] = (cid == sOwnClientId);
+            e["game"] = c.game == 1 ? "mm" : "oot";
+            e["rawScene"] = c.rawScene;
+            e["isOwner"] = (cid == sRoomState.ownerClientId);
+            e["isSaveLoaded"] = c.isSaveLoaded;
+            e["isGameComplete"] = c.isGameComplete;
+            e["areaVisible"] = areaVisible;
+            e["clientVersion"] = c.clientVersion;
+            e["seed"] = c.seed;
+            clients.push_back(e);
+        }
+        nlohmann::json out;
+        out["ownClientId"] = sOwnClientId;
+        out["room"] = { { "ownerClientId", sRoomState.ownerClientId },
+                        { "pvpMode", sRoomState.pvpMode },
+                        { "showLocationsMode", showLoc },
+                        { "teleportMode", sRoomState.teleportMode },
+                        { "syncItemsAndFlags", sRoomState.syncItemsAndFlags } };
+        out["clients"] = clients;
+        cached = out.dump();
+    } catch (...) { cached = "{}"; }
+    return cached.c_str();
+}
+
 // Background loop: connect, then relay outbound packets and feed inbound packets to the active
 // game. Mirrors soh's original Network::ReceiveFromServer framing (NUL-delimited JSON), only the
 // socket now lives in the launcher so it persists across transitions.
@@ -497,6 +639,8 @@ static void ReceiveLoop() {
             while (pos != std::string::npos) {
                 std::string packet = received.substr(0, pos);
                 received.erase(0, pos + 1);
+                // Keep the always-live combo roster in sync before forwarding (fixes dormant staleness).
+                UpdateRosterFromPacket(packet);
                 // A6: feed every packet to BOTH games. Each RecvJson only enqueues (thread-safe). The
                 // active game drains+handles it on its tick; the dormant game applies its save-affecting
                 // subset via PumpDormant (driven by the active game's per-frame pump call), so a
@@ -1932,6 +2076,10 @@ int main(int argc, char** argv) {
         ComboUI_Register = (FnComboUIRegister)GetSym(comboUIModule, "ComboUI_Register");
         ComboUI_OnForegroundGame = (FnComboUIForeground)GetSym(comboUIModule, "ComboUI_OnForegroundGame");
         ComboUI_RestoreTrackerIntent = (FnComboUIRegister)GetSym(comboUIModule, "ComboUI_RestoreTrackerIntent");
+        ComboUI_SetAnchorRosterProvider =
+            (FnComboUISetRosterProvider)GetSym(comboUIModule, "ComboUI_SetAnchorRosterProvider");
+        if (ComboUI_SetAnchorRosterProvider)
+            ComboUI_SetAnchorRosterProvider(&ComboAnchor::Combo_Anchor_GetRoster);
         if (ComboUI_Register) {
             ComboUI_Register();
             std::cout << "[ComboShip] comboui registered (unified menu installed)." << std::endl;

--- a/combo/gui/ComboAnchorRoomWindow.cpp
+++ b/combo/gui/ComboAnchorRoomWindow.cpp
@@ -1,0 +1,234 @@
+// combo/gui/ComboAnchorRoomWindow.cpp — see ComboAnchorRoomWindow.h
+#include "ComboAnchorRoomWindow.h"
+#include "ComboForeground.h" // ComboUI::GetForegroundGame() -> same-game teleport gating
+#include <imgui.h>
+#include <libultraship/libultraship.h> // CVar bridge
+#include <ship/window/gui/IconsFontAwesome4.h>
+#include <ship/Context.h>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <set>
+#include <map>
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+namespace ComboRando {
+
+namespace {
+// Shared Anchor CVar keys (process-global store; the combo panel writes them). comboui has no access to
+// soh's CVAR_REMOTE_ANCHOR macro, so the literals are re-declared here (as in ComboMenu.cpp).
+constexpr const char* kCvarTeamId = "gRemote.Anchor.TeamId";
+constexpr const char* kCvarRoomId = "gRemote.Anchor.RoomId";
+constexpr const char* kCvarTeleportMode = "gRemote.Anchor.RoomSettings.TeleportMode";
+constexpr const char* kVisibilityCvar = "gCombo.Anchor.RoomWindow";
+
+// Roster + teleport exports, resolved from the already-loaded game DLLs (same idiom as ComboMenu).
+typedef const char* (*FnGetRoster)(void);
+typedef void (*FnRequestTeleport)(uint32_t);
+typedef int (*FnGetConnState)(void);
+FnGetRoster sSohGetRoster = nullptr;
+FnGetRoster sMmGetRoster = nullptr;
+FnRequestTeleport sSohRequestTeleport = nullptr;
+FnRequestTeleport sMmRequestTeleport = nullptr;
+FnGetConnState sSohGetConnState = nullptr;
+
+void ResolveSyms() {
+#ifdef _WIN32
+    if (HMODULE h = GetModuleHandleA("soh.dll")) {
+        if (!sSohGetRoster)
+            sSohGetRoster = (FnGetRoster)GetProcAddress(h, "SOH_Anchor_GetRoster");
+        if (!sSohRequestTeleport)
+            sSohRequestTeleport = (FnRequestTeleport)GetProcAddress(h, "SOH_Anchor_RequestTeleport");
+        if (!sSohGetConnState)
+            sSohGetConnState = (FnGetConnState)GetProcAddress(h, "SOH_Anchor_GetConnectionState");
+    }
+    if (HMODULE h = GetModuleHandleA("2ship.dll")) {
+        if (!sMmGetRoster)
+            sMmGetRoster = (FnGetRoster)GetProcAddress(h, "MM_Anchor_GetRoster");
+        if (!sMmRequestTeleport)
+            sMmRequestTeleport = (FnRequestTeleport)GetProcAddress(h, "MM_Anchor_RequestTeleport");
+    }
+#endif
+}
+
+// Low-frequency roster cache: area names only change on a scene transition, so polling the exports a
+// couple of times a second is plenty (no per-frame FFI/JSON cost).
+double sLastPoll = -1.0;
+nlohmann::json sRoster = nlohmann::json::array(); // soh authoritative full roster
+std::map<uint32_t, std::string> sMmAreaNames;     // clientId -> MM-resolved area name
+
+void PollRoster() {
+    double now = ImGui::GetTime();
+    if (sLastPoll >= 0.0 && (now - sLastPoll) < 0.5) {
+        return;
+    }
+    sLastPoll = now;
+    try {
+        sRoster = sSohGetRoster ? nlohmann::json::parse(sSohGetRoster()) : nlohmann::json::array();
+    } catch (...) { sRoster = nlohmann::json::array(); }
+    sMmAreaNames.clear();
+    try {
+        if (sMmGetRoster) {
+            for (auto& e : nlohmann::json::parse(sMmGetRoster())) {
+                sMmAreaNames[e.value("clientId", (uint32_t)0)] = e.value("areaName", std::string());
+            }
+        }
+    } catch (...) {}
+}
+
+std::shared_ptr<ComboAnchorRoomWindow> sWindow;
+} // namespace
+
+void ComboAnchorRoomWindow::Draw() {
+    if (!IsVisible()) {
+        return;
+    }
+    auto ctx = Ship::Context::GetInstance();
+    if (!ctx || !ctx->GetWindow() || !ctx->GetWindow()->GetGui()) {
+        return;
+    }
+    // comboui's per-module GImGui must point at the shared context (same pattern as ComboMenu/SwapWindow).
+    ImGui::SetCurrentContext(ctx->GetWindow()->GetGui()->GetImGuiContext());
+
+    ImGui::SetNextWindowSize(ImVec2(320.0f, 380.0f), ImGuiCond_FirstUseEver);
+    if (ImGui::Begin("Anchor Room", &mIsVisible, ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav)) {
+        DrawElement();
+    }
+    ImGui::End();
+    SyncVisibilityConsoleVariable();
+}
+
+void ComboAnchorRoomWindow::DrawElement() {
+    ResolveSyms();
+
+    int connState = sSohGetConnState ? sSohGetConnState() : 0;
+    bool connected = (connState & 2) != 0;
+    if (!connected) {
+        ImGui::TextDisabled("Not connected.");
+        return;
+    }
+
+    PollRoster();
+
+    // Global room: only a player count is meaningful (mirrors soh's AnchorRoomWindow).
+    if (std::string("soh-global") == CVarGetString(kCvarRoomId, "")) {
+        int online = 0;
+        for (auto& c : sRoster) {
+            if (c.value("online", false)) {
+                online++;
+            }
+        }
+        ImGui::Text("Players Online: %d", online);
+        return;
+    }
+
+    const int activeGame = ComboUI::GetForegroundGame(); // 0 = OOT, 1 = MM
+    const std::string ownTeam = CVarGetString(kCvarTeamId, "default");
+    const int teleportMode = CVarGetInteger(kCvarTeleportMode, 1);
+
+    // Group by team, each player shown once.
+    std::set<std::string> teams;
+    for (auto& c : sRoster) {
+        teams.insert(c.value("teamId", std::string("default")));
+    }
+
+    for (auto& team : teams) {
+        if (teams.size() > 1) {
+            ImGui::SeparatorText(team.c_str());
+        }
+        bool isOwnTeam = team == ownTeam;
+        for (auto& c : sRoster) {
+            if (c.value("teamId", std::string("default")) != team) {
+                continue;
+            }
+            uint32_t clientId = c.value("clientId", (uint32_t)0);
+            bool self = c.value("self", false);
+            bool online = c.value("online", false);
+            std::string name = c.value("name", std::string("???"));
+            std::string game = c.value("game", std::string("oot"));
+
+            ImGui::PushID((int)clientId);
+
+            if (c.value("isOwner", false)) {
+                ImGui::TextColored(ImVec4(1, 1, 0, 1), "%s", ICON_FA_GAVEL);
+                ImGui::SameLine();
+            }
+
+            if (self) {
+                ImGui::TextColored(ImVec4(0.8f, 1.0f, 0.8f, 1.0f), "%s", name.c_str());
+            } else if (!online) {
+                ImGui::TextColored(ImVec4(1, 1, 1, 0.3f), "%s - offline", name.c_str());
+                ImGui::PopID();
+                continue;
+            } else {
+                auto col = c.value("color", nlohmann::json::object());
+                ImVec4 nameColor(col.value("r", 255) / 255.0f, col.value("g", 255) / 255.0f,
+                                 col.value("b", 255) / 255.0f, 1.0f);
+                ImGui::TextColored(nameColor, "%s", name.c_str());
+            }
+
+            // Area name: soh gates visibility (ShowLocationsMode) and resolves OOT names; MM area names
+            // are supplied by clientId in MM_Anchor_GetRoster and overlaid here for mm-tagged players.
+            if (c.value("areaVisible", false)) {
+                std::string area = c.value("areaName", std::string());
+                if (game == "mm") {
+                    auto it = sMmAreaNames.find(clientId);
+                    if (it != sMmAreaNames.end() && !it->second.empty()) {
+                        area = it->second;
+                    }
+                }
+                if (!area.empty()) {
+                    ImGui::SameLine();
+                    ImGui::TextColored(ImVec4(1, 1, 1, 0.5f), "- %s", area.c_str());
+                }
+            }
+
+            // Teleport: same-game only. Never rendered for a player in the other game (cross-game
+            // teleport is impossible). The game's export re-validates and no-ops if disallowed.
+            bool sameGame = (game == "mm") == (activeGame == 1);
+            bool teleportGate = !self && online && c.value("isSaveLoaded", false) && teleportMode != 0 &&
+                                (teleportMode == 2 || isOwnTeam);
+            if (sameGame && teleportGate) {
+                ImGui::SameLine();
+                ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
+                if (ImGui::Button(ICON_FA_LOCATION_ARROW, ImVec2(20.0f, 20.0f))) {
+                    if (activeGame == 1) {
+                        if (sMmRequestTeleport)
+                            sMmRequestTeleport(clientId);
+                    } else {
+                        if (sSohRequestTeleport)
+                            sSohRequestTeleport(clientId);
+                    }
+                }
+                ImGui::PopStyleVar();
+            }
+
+            if (c.value("versionMismatch", false)) {
+                ImGui::SameLine();
+                ImGui::TextColored(ImVec4(1, 0, 0, 1), "%s", ICON_FA_EXCLAMATION_TRIANGLE);
+                ImGui::SetItemTooltip("Incompatible version! Will not work together!");
+            }
+            if (c.value("seedMismatch", false)) {
+                ImGui::SameLine();
+                ImGui::TextColored(ImVec4(1, 0, 0, 1), "%s", ICON_FA_EXCLAMATION_TRIANGLE);
+                ImGui::SetItemTooltip("Seed mismatch! Continuing will break things!");
+            }
+
+            ImGui::PopID();
+        }
+    }
+}
+
+void RegisterAnchorRoomWindow() {
+    auto ctx = Ship::Context::GetInstance();
+    if (!ctx || !ctx->GetWindow() || !ctx->GetWindow()->GetGui()) {
+        return;
+    }
+    if (!sWindow) {
+        sWindow = std::make_shared<ComboAnchorRoomWindow>(kVisibilityCvar, "Anchor Room");
+    }
+    ctx->GetWindow()->GetGui()->AddGuiWindow(sWindow);
+}
+
+} // namespace ComboRando

--- a/combo/gui/ComboAnchorRoomWindow.cpp
+++ b/combo/gui/ComboAnchorRoomWindow.cpp
@@ -84,6 +84,12 @@ void ComboAnchorRoomWindow::Draw() {
     // comboui's per-module GImGui must point at the shared context (same pattern as ComboMenu/SwapWindow).
     ImGui::SetCurrentContext(ctx->GetWindow()->GetGui()->GetImGuiContext());
 
+    // Hide the overlay entirely when not connected, rather than showing an empty "Not connected" box.
+    ResolveSyms();
+    if (!sSohGetConnState || (sSohGetConnState() & 2) == 0) {
+        return;
+    }
+
     // Floating overlay: chrome-less, auto-sized to content, translucent — not a resizable window.
     ImGui::SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond_FirstUseEver);
     ImGui::SetNextWindowBgAlpha(0.65f);
@@ -97,15 +103,7 @@ void ComboAnchorRoomWindow::Draw() {
 }
 
 void ComboAnchorRoomWindow::DrawElement() {
-    ResolveSyms();
-
-    int connState = sSohGetConnState ? sSohGetConnState() : 0;
-    bool connected = (connState & 2) != 0;
-    if (!connected) {
-        ImGui::TextDisabled("Not connected.");
-        return;
-    }
-
+    // Draw() already gated on connected (the overlay is hidden otherwise), so no not-connected branch here.
     PollSnapshot();
     static const nlohmann::json kEmptyArr = nlohmann::json::array();
     const nlohmann::json& clients = sSnapshot.contains("clients") ? sSnapshot["clients"] : kEmptyArr;

--- a/combo/gui/ComboAnchorRoomWindow.cpp
+++ b/combo/gui/ComboAnchorRoomWindow.cpp
@@ -8,7 +8,6 @@
 #include <nlohmann/json.hpp>
 #include <string>
 #include <set>
-#include <map>
 #ifdef _WIN32
 #include <windows.h>
 #endif
@@ -20,15 +19,18 @@ namespace {
 // soh's CVAR_REMOTE_ANCHOR macro, so the literals are re-declared here (as in ComboMenu.cpp).
 constexpr const char* kCvarTeamId = "gRemote.Anchor.TeamId";
 constexpr const char* kCvarRoomId = "gRemote.Anchor.RoomId";
-constexpr const char* kCvarTeleportMode = "gRemote.Anchor.RoomSettings.TeleportMode";
 constexpr const char* kVisibilityCvar = "gCombo.Anchor.RoomWindow";
 
-// Roster + teleport exports, resolved from the already-loaded game DLLs (same idiom as ComboMenu).
-typedef const char* (*FnGetRoster)(void);
+// Launcher-owned roster: the exe registers this getter via ComboUI_SetAnchorRosterProvider. It parses
+// every packet on a never-dormant thread, so the roster is always live (no per-game staleness).
+const char* (*sRosterProvider)() = nullptr;
+
+// Stateless scene-name resolvers + teleport exports, resolved from the game DLLs (dormant-safe).
+typedef const char* (*FnResolveScene)(int);
 typedef void (*FnRequestTeleport)(uint32_t);
 typedef int (*FnGetConnState)(void);
-FnGetRoster sSohGetRoster = nullptr;
-FnGetRoster sMmGetRoster = nullptr;
+FnResolveScene sSohResolveScene = nullptr;
+FnResolveScene sMmResolveScene = nullptr;
 FnRequestTeleport sSohRequestTeleport = nullptr;
 FnRequestTeleport sMmRequestTeleport = nullptr;
 FnGetConnState sSohGetConnState = nullptr;
@@ -36,45 +38,36 @@ FnGetConnState sSohGetConnState = nullptr;
 void ResolveSyms() {
 #ifdef _WIN32
     if (HMODULE h = GetModuleHandleA("soh.dll")) {
-        if (!sSohGetRoster)
-            sSohGetRoster = (FnGetRoster)GetProcAddress(h, "SOH_Anchor_GetRoster");
+        if (!sSohResolveScene)
+            sSohResolveScene = (FnResolveScene)GetProcAddress(h, "SOH_Anchor_ResolveScene");
         if (!sSohRequestTeleport)
             sSohRequestTeleport = (FnRequestTeleport)GetProcAddress(h, "SOH_Anchor_RequestTeleport");
         if (!sSohGetConnState)
             sSohGetConnState = (FnGetConnState)GetProcAddress(h, "SOH_Anchor_GetConnectionState");
     }
     if (HMODULE h = GetModuleHandleA("2ship.dll")) {
-        if (!sMmGetRoster)
-            sMmGetRoster = (FnGetRoster)GetProcAddress(h, "MM_Anchor_GetRoster");
+        if (!sMmResolveScene)
+            sMmResolveScene = (FnResolveScene)GetProcAddress(h, "MM_Anchor_ResolveScene");
         if (!sMmRequestTeleport)
             sMmRequestTeleport = (FnRequestTeleport)GetProcAddress(h, "MM_Anchor_RequestTeleport");
     }
 #endif
 }
 
-// Low-frequency roster cache: area names only change on a scene transition, so polling the exports a
+// Low-frequency snapshot: scene/roster state only changes on transitions, so polling the launcher a
 // couple of times a second is plenty (no per-frame FFI/JSON cost).
 double sLastPoll = -1.0;
-nlohmann::json sRoster = nlohmann::json::array(); // soh authoritative full roster
-std::map<uint32_t, std::string> sMmAreaNames;     // clientId -> MM-resolved area name
+nlohmann::json sSnapshot = nlohmann::json::object(); // { ownClientId, room{...}, clients[...] }
 
-void PollRoster() {
+void PollSnapshot() {
     double now = ImGui::GetTime();
     if (sLastPoll >= 0.0 && (now - sLastPoll) < 0.5) {
         return;
     }
     sLastPoll = now;
     try {
-        sRoster = sSohGetRoster ? nlohmann::json::parse(sSohGetRoster()) : nlohmann::json::array();
-    } catch (...) { sRoster = nlohmann::json::array(); }
-    sMmAreaNames.clear();
-    try {
-        if (sMmGetRoster) {
-            for (auto& e : nlohmann::json::parse(sMmGetRoster())) {
-                sMmAreaNames[e.value("clientId", (uint32_t)0)] = e.value("areaName", std::string());
-            }
-        }
-    } catch (...) {}
+        sSnapshot = sRosterProvider ? nlohmann::json::parse(sRosterProvider()) : nlohmann::json::object();
+    } catch (...) { sSnapshot = nlohmann::json::object(); }
 }
 
 std::shared_ptr<ComboAnchorRoomWindow> sWindow;
@@ -91,8 +84,12 @@ void ComboAnchorRoomWindow::Draw() {
     // comboui's per-module GImGui must point at the shared context (same pattern as ComboMenu/SwapWindow).
     ImGui::SetCurrentContext(ctx->GetWindow()->GetGui()->GetImGuiContext());
 
-    ImGui::SetNextWindowSize(ImVec2(320.0f, 380.0f), ImGuiCond_FirstUseEver);
-    if (ImGui::Begin("Anchor Room", &mIsVisible, ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav)) {
+    // Floating overlay: chrome-less, auto-sized to content, translucent — not a resizable window.
+    ImGui::SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowBgAlpha(0.65f);
+    ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_AlwaysAutoResize |
+                             ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav;
+    if (ImGui::Begin("Anchor Room", nullptr, flags)) {
         DrawElement();
     }
     ImGui::End();
@@ -109,12 +106,15 @@ void ComboAnchorRoomWindow::DrawElement() {
         return;
     }
 
-    PollRoster();
+    PollSnapshot();
+    static const nlohmann::json kEmptyArr = nlohmann::json::array();
+    const nlohmann::json& clients = sSnapshot.contains("clients") ? sSnapshot["clients"] : kEmptyArr;
+    const nlohmann::json room = sSnapshot.value("room", nlohmann::json::object());
 
     // Global room: only a player count is meaningful (mirrors soh's AnchorRoomWindow).
     if (std::string("soh-global") == CVarGetString(kCvarRoomId, "")) {
         int online = 0;
-        for (auto& c : sRoster) {
+        for (auto& c : clients) {
             if (c.value("online", false)) {
                 online++;
             }
@@ -123,13 +123,29 @@ void ComboAnchorRoomWindow::DrawElement() {
         return;
     }
 
-    const int activeGame = ComboUI::GetForegroundGame(); // 0 = OOT, 1 = MM
-    const std::string ownTeam = CVarGetString(kCvarTeamId, "default");
-    const int teleportMode = CVarGetInteger(kCvarTeleportMode, 1);
+    const int activeGame = ComboUI::GetForegroundGame();    // 0 = OOT, 1 = MM
+    const int teleportMode = room.value("teleportMode", 1); // launcher-owned room state (not the local CVar)
+
+    // Own team: prefer the self entry's teamId (== gRemote.Anchor.TeamId), fall back to the CVar.
+    std::string ownTeam = CVarGetString(kCvarTeamId, "default");
+    std::string selfVersion;
+    uint32_t selfSeed = 0;
+    int selfGame = 0;
+    bool haveSelf = false;
+    for (auto& c : clients) {
+        if (c.value("self", false)) {
+            ownTeam = c.value("teamId", ownTeam);
+            selfVersion = c.value("clientVersion", std::string());
+            selfSeed = c.value("seed", (uint32_t)0);
+            selfGame = (c.value("game", std::string("oot")) == "mm") ? 1 : 0;
+            haveSelf = true;
+            break;
+        }
+    }
 
     // Group by team, each player shown once.
     std::set<std::string> teams;
-    for (auto& c : sRoster) {
+    for (auto& c : clients) {
         teams.insert(c.value("teamId", std::string("default")));
     }
 
@@ -138,7 +154,7 @@ void ComboAnchorRoomWindow::DrawElement() {
             ImGui::SeparatorText(team.c_str());
         }
         bool isOwnTeam = team == ownTeam;
-        for (auto& c : sRoster) {
+        for (auto& c : clients) {
             if (c.value("teamId", std::string("default")) != team) {
                 continue;
             }
@@ -147,6 +163,7 @@ void ComboAnchorRoomWindow::DrawElement() {
             bool online = c.value("online", false);
             std::string name = c.value("name", std::string("???"));
             std::string game = c.value("game", std::string("oot"));
+            int peerGame = (game == "mm") ? 1 : 0;
 
             ImGui::PushID((int)clientId);
 
@@ -168,15 +185,17 @@ void ComboAnchorRoomWindow::DrawElement() {
                 ImGui::TextColored(nameColor, "%s", name.c_str());
             }
 
-            // Area name: soh gates visibility (ShowLocationsMode) and resolves OOT names; MM area names
-            // are supplied by clientId in MM_Anchor_GetRoster and overlaid here for mm-tagged players.
+            // Area name: the launcher gates visibility (areaVisible); comboui resolves the display name
+            // from the raw scene id via the owning game's stateless resolver (works even while dormant).
             if (c.value("areaVisible", false)) {
-                std::string area = c.value("areaName", std::string());
-                if (game == "mm") {
-                    auto it = sMmAreaNames.find(clientId);
-                    if (it != sMmAreaNames.end() && !it->second.empty()) {
-                        area = it->second;
-                    }
+                int rawScene = c.value("rawScene", 0);
+                std::string area;
+                if (peerGame == 1) {
+                    if (sMmResolveScene)
+                        area = sMmResolveScene(rawScene);
+                } else {
+                    if (sSohResolveScene)
+                        area = sSohResolveScene(rawScene);
                 }
                 if (!area.empty()) {
                     ImGui::SameLine();
@@ -186,7 +205,7 @@ void ComboAnchorRoomWindow::DrawElement() {
 
             // Teleport: same-game only. Never rendered for a player in the other game (cross-game
             // teleport is impossible). The game's export re-validates and no-ops if disallowed.
-            bool sameGame = (game == "mm") == (activeGame == 1);
+            bool sameGame = (peerGame == activeGame);
             bool teleportGate = !self && online && c.value("isSaveLoaded", false) && teleportMode != 0 &&
                                 (teleportMode == 2 || isOwnTeam);
             if (sameGame && teleportGate) {
@@ -204,12 +223,18 @@ void ComboAnchorRoomWindow::DrawElement() {
                 ImGui::PopStyleVar();
             }
 
-            if (c.value("versionMismatch", false)) {
+            // Version/seed mismatch vs the self entry. Seed compare only within the same game (cross-game
+            // seed verification is out of scope; MM/OOT report their own seeds).
+            bool versionMismatch =
+                haveSelf && !self && !selfVersion.empty() && c.value("clientVersion", std::string()) != selfVersion;
+            bool seedMismatch = haveSelf && !self && peerGame == selfGame && online && c.value("isSaveLoaded", false) &&
+                                c.value("seed", (uint32_t)0) != selfSeed;
+            if (versionMismatch) {
                 ImGui::SameLine();
                 ImGui::TextColored(ImVec4(1, 0, 0, 1), "%s", ICON_FA_EXCLAMATION_TRIANGLE);
                 ImGui::SetItemTooltip("Incompatible version! Will not work together!");
             }
-            if (c.value("seedMismatch", false)) {
+            if (seedMismatch) {
                 ImGui::SameLine();
                 ImGui::TextColored(ImVec4(1, 0, 0, 1), "%s", ICON_FA_EXCLAMATION_TRIANGLE);
                 ImGui::SetItemTooltip("Seed mismatch! Continuing will break things!");
@@ -232,3 +257,14 @@ void RegisterAnchorRoomWindow() {
 }
 
 } // namespace ComboRando
+
+// ComboShip: the launcher hands comboui its always-live Anchor roster getter here (called at startup,
+// right after ComboUI_Register). The room window reads it via sRosterProvider.
+#ifdef _WIN32
+extern "C" __declspec(dllexport) void ComboUI_SetAnchorRosterProvider(const char* (*getter)())
+#else
+extern "C" void ComboUI_SetAnchorRosterProvider(const char* (*getter)())
+#endif
+{
+    ComboRando::sRosterProvider = getter;
+}

--- a/combo/gui/ComboAnchorRoomWindow.h
+++ b/combo/gui/ComboAnchorRoomWindow.h
@@ -1,0 +1,30 @@
+// combo/gui/ComboAnchorRoomWindow.h
+//
+// ComboShip: combo-native floating Anchor room window. Replaces soh's AnchorRoomWindow (hidden
+// in combo builds). Unions both games' roster snapshots (SOH_Anchor_GetRoster is authoritative; MM
+// supplements its own players' area names via MM_Anchor_GetRoster) so a client shows EVERY player once
+// with its real scene/area name — including other-game peers, which the soh window could not name.
+// Teleport is same-game only (button rendered only for players in the locally-active game).
+#pragma once
+
+#include <ship/window/gui/GuiWindow.h>
+
+namespace ComboRando {
+
+// Registered in ComboUI_Register alongside the tracker windows; toggled from the combo Anchor panel.
+void RegisterAnchorRoomWindow();
+
+class ComboAnchorRoomWindow final : public Ship::GuiWindow {
+  public:
+    using GuiWindow::GuiWindow;
+    void Draw() override;
+
+  protected:
+    void InitElement() override {
+    }
+    void UpdateElement() override {
+    }
+    void DrawElement() override;
+};
+
+} // namespace ComboRando

--- a/combo/gui/ComboAnchorRoomWindow.h
+++ b/combo/gui/ComboAnchorRoomWindow.h
@@ -1,9 +1,9 @@
 // combo/gui/ComboAnchorRoomWindow.h
 //
-// ComboShip: combo-native floating Anchor room window. Replaces soh's AnchorRoomWindow (hidden
-// in combo builds). Unions both games' roster snapshots (SOH_Anchor_GetRoster is authoritative; MM
-// supplements its own players' area names via MM_Anchor_GetRoster) so a client shows EVERY player once
-// with its real scene/area name — including other-game peers, which the soh window could not name.
+// ComboShip: combo-native floating Anchor room window. Replaces soh's AnchorRoomWindow (hidden in
+// combo builds). Reads the launcher-owned always-live roster (set via ComboUI_SetAnchorRosterProvider)
+// so every player shows once with a correct area name in BOTH games — even when a game is dormant.
+// Area names resolved via the stateless SOH_/MM_Anchor_ResolveScene exports.
 // Teleport is same-game only (button rendered only for players in the locally-active game).
 #pragma once
 

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -669,6 +669,17 @@ void DrawNetworkSharedPanel() {
     bool enabled = (state & 1) != 0;
     bool connected = (state & 2) != 0;
 
+    ImGui::TextWrapped("Play OOT and MM online with teammates: items and flags are shared per team, with "
+                       "live presence and same-game teleport. Set a host, room, and name, then Enable.");
+
+    // Widgets in the first cell of a 2-col stretch table, so they're half-width like the other panels.
+    const ImGuiTableFlags anchorTableFlags = ImGuiTableFlags_SizingStretchSame | ImGuiTableFlags_NoSavedSettings;
+    if (!ImGui::BeginTable("##anchorcols", 2, anchorTableFlags)) {
+        return;
+    }
+    ImGui::TableNextRow();
+    ImGui::TableSetColumnIndex(0);
+
     // --- Connection settings (disabled while enabled, like soh) ---
     ImGui::SeparatorText("Connection Settings");
     ImGui::BeginDisabled(enabled);
@@ -871,6 +882,8 @@ void DrawNetworkSharedPanel() {
     }
     ComboRando::ComboMenu_PopButton();
     ImGui::TextDisabled("Shows every teammate's game and area, with same-game teleport.");
+
+    ImGui::EndTable();
 }
 
 // Build the combined item picker list from both games' static-data dumps (items[] = full item table

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -810,7 +810,30 @@ void DrawNetworkSharedPanel() {
         ComboRando::ComboMenu_PopCheckbox();
     }
 
-    // --- Room admin (owner-only, non-global) ---
+    // --- Room window: toggle the combo-native floating roster window (only once Anchor is enabled) ---
+    if (enabled) {
+        ImGui::SeparatorText("Room");
+        bool roomOpen = CVarGetInteger("gCombo.Anchor.RoomWindow", 0) != 0;
+        ComboRando::ComboMenu_PushButton(theme);
+        if (ImGui::Button(roomOpen ? "Hide Room Window" : "Show Room Window", ImVec2(-1.0f, 0.0f))) {
+            roomOpen = !roomOpen;
+            CVarSetInteger("gCombo.Anchor.RoomWindow", roomOpen ? 1 : 0);
+            AnchorSaveCVars();
+            if (auto ctx = Ship::Context::GetInstance(); ctx && ctx->GetWindow() && ctx->GetWindow()->GetGui()) {
+                if (auto win = ctx->GetWindow()->GetGui()->GetGuiWindow("Anchor Room")) {
+                    if (roomOpen)
+                        win->Show();
+                    else
+                        win->Hide();
+                }
+            }
+        }
+        ComboRando::ComboMenu_PopButton();
+        ImGui::TextDisabled("Shows every teammate's game and area, with same-game teleport.");
+    }
+
+    // --- Room settings (owner-only, non-global) — second column ---
+    ImGui::TableSetColumnIndex(1);
     // ownerInfo bit0=isOwner, bit1=isGlobalRoom; 0 unless connected. Mirrors soh's AnchorAdminMenu gate.
     int ownerInfo = sSohAnchorGetOwnerInfo ? sSohAnchorGetOwnerInfo() : 0;
     bool isOwner = (ownerInfo & 1) != 0;
@@ -863,28 +886,6 @@ void DrawNetworkSharedPanel() {
             sendRoomState();
         }
         ComboRando::ComboMenu_PopCheckbox();
-    }
-
-    // --- Room window: toggle the combo-native floating roster window (only once Anchor is enabled) ---
-    if (enabled) {
-        ImGui::SeparatorText("Room");
-        bool roomOpen = CVarGetInteger("gCombo.Anchor.RoomWindow", 0) != 0;
-        ComboRando::ComboMenu_PushButton(theme);
-        if (ImGui::Button(roomOpen ? "Hide Room Window" : "Show Room Window", ImVec2(-1.0f, 0.0f))) {
-            roomOpen = !roomOpen;
-            CVarSetInteger("gCombo.Anchor.RoomWindow", roomOpen ? 1 : 0);
-            AnchorSaveCVars();
-            if (auto ctx = Ship::Context::GetInstance(); ctx && ctx->GetWindow() && ctx->GetWindow()->GetGui()) {
-                if (auto win = ctx->GetWindow()->GetGui()->GetGuiWindow("Anchor Room")) {
-                    if (roomOpen)
-                        win->Show();
-                    else
-                        win->Hide();
-                }
-            }
-        }
-        ComboRando::ComboMenu_PopButton();
-        ImGui::TextDisabled("Shows every teammate's game and area, with same-game teleport.");
     }
 
     ImGui::EndTable();

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -9,6 +9,7 @@
 #include "ComboTrackerSwap.h"
 #include "rando/ComboPlaythrough.h" // plando: ParseSpoilerPlacements + Suffix/BuildForeignArray + slot paths
 #include <imgui.h>
+#include <libultraship/libultraship.h> // CVar bridge (CVarGet/Set* incl. color) + color.h (Color_RGBA8)
 #include <ship/window/gui/IconsFontAwesome4.h> // ICON_FA_* for the header action buttons
 #include <memory>
 #include <string>
@@ -49,11 +50,21 @@ void ResolveComboGenSyms() {
 typedef void (*FnRequestResync)(void);
 FnRequestResync sSohRequestResync = nullptr;
 FnRequestResync sMmRequestResync = nullptr;
+// Phase 1 Anchor connection panel: soh drives Enable/Disable + reports connection state (the socket
+// is launcher-owned, but enable/status stays in soh's Anchor object). Resolved from soh.dll.
+typedef void (*FnSetEnabled)(int);
+typedef int (*FnGetConnState)(void);
+FnSetEnabled sSohAnchorSetEnabled = nullptr;
+FnGetConnState sSohAnchorGetConnState = nullptr;
 void ResolveAnchorResyncSyms() {
 #ifdef _WIN32
-    if (!sSohRequestResync) {
-        if (HMODULE h = GetModuleHandleA("soh.dll"))
+    if (HMODULE h = GetModuleHandleA("soh.dll")) {
+        if (!sSohRequestResync)
             sSohRequestResync = (FnRequestResync)GetProcAddress(h, "SOH_Anchor_RequestResync");
+        if (!sSohAnchorSetEnabled)
+            sSohAnchorSetEnabled = (FnSetEnabled)GetProcAddress(h, "SOH_Anchor_SetEnabled");
+        if (!sSohAnchorGetConnState)
+            sSohAnchorGetConnState = (FnGetConnState)GetProcAddress(h, "SOH_Anchor_GetConnectionState");
     }
     if (!sMmRequestResync) {
         if (HMODULE h = GetModuleHandleA("2ship.dll"))
@@ -61,6 +72,18 @@ void ResolveAnchorResyncSyms() {
     }
 #endif
 }
+
+// Shared Anchor config CVar keys (process-global libultraship store; both game DLLs read these — see
+// MMAnchor.cpp). comboui has no access to soh's CVAR_REMOTE_ANCHOR macro, so the literals live here.
+namespace AnchorCVar {
+constexpr const char* Host = "gRemote.Anchor.Host";
+constexpr const char* Port = "gRemote.Anchor.Port";
+constexpr const char* Name = "gRemote.Anchor.Name";
+constexpr const char* RoomId = "gRemote.Anchor.RoomId";
+constexpr const char* TeamId = "gRemote.Anchor.TeamId";
+constexpr const char* ColorValue = "gRemote.Anchor.Color.Value";
+constexpr const char* ShowOnMinimap = "gRemote.Anchor.ShowOtherPlayersOnMinimap";
+} // namespace AnchorCVar
 
 // Combo plandomizer exports: each game's static-data dump (friendly item names) + the reload trigger
 // that plays an edited consolidated spoiler back verbatim. Resolved like the combo-gen syms above.
@@ -603,14 +626,140 @@ void DrawCheckTrackerSharedPanel() {
     }
 }
 
-// Shared > Network "Team Sync": launcher-orchestrated Anchor resync (bug 2). The Ship of Harkinian
-// Network settings (Sail, Crowd Control) sit beside this as their own entries in the Network group.
+// Helper: seed a fixed char buffer from a string CVar for ImGui::InputText.
+static void AnchorLoadStr(char* buf, size_t n, const char* cvar, const char* dflt) {
+    const char* cur = CVarGetString(cvar, dflt);
+    std::strncpy(buf, cur ? cur : "", n - 1);
+    buf[n - 1] = '\0';
+}
+
+// Persist CVar writes to disk next frame (mirrors soh's Anchor menu, which saves after every edit).
+static void AnchorSaveCVars() {
+    if (auto ctx = Ship::Context::GetInstance(); ctx && ctx->GetWindow() && ctx->GetWindow()->GetGui()) {
+        ctx->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+    }
+}
+
+// Shared > Network "Anchor": combo-native connection panel (Phase 1). Replaces the proxied soh
+// AnchorMainMenu (hidden in combo). Writes the shared gRemote.Anchor.* CVars both games read, and
+// drives Enable/Disable + status via the SOH_Anchor_* exports. Admin/Instructions (Phases 2/3) are
+// still surfaced from the soh Network>Anchor sidebar below.
 void DrawNetworkSharedPanel() {
     const ImVec4 theme = ComboRando::ComboMenu_ThemeColor();
     ResolveAnchorResyncSyms();
 
-    // Team sync is an Anchor feature (covers both games) — keep it at the top of the Anchor panel so
-    // it's immediately visible, above the Ship of Harkinian Anchor connection settings.
+    int state = sSohAnchorGetConnState ? sSohAnchorGetConnState() : 0;
+    bool enabled = (state & 1) != 0;
+    bool connected = (state & 2) != 0;
+
+    // --- Connection settings (disabled while enabled, like soh) ---
+    ImGui::SeparatorText("Connection Settings");
+    ImGui::BeginDisabled(enabled);
+
+    char host[256], name[128], roomId[128], teamId[128];
+    AnchorLoadStr(host, sizeof(host), AnchorCVar::Host, "anchor.hm64.org");
+    AnchorLoadStr(name, sizeof(name), AnchorCVar::Name, "");
+    AnchorLoadStr(roomId, sizeof(roomId), AnchorCVar::RoomId, "");
+    AnchorLoadStr(teamId, sizeof(teamId), AnchorCVar::TeamId, "default");
+    int port = CVarGetInteger(AnchorCVar::Port, 43383);
+
+    ImGui::Text("Host");
+    ComboRando::ComboMenu_PushInput(theme);
+    if (ImGui::InputText("##AnchorHost", host, sizeof(host))) {
+        CVarSetString(AnchorCVar::Host, host);
+        AnchorSaveCVars();
+    }
+    ImGui::Text("Port");
+    if (ImGui::InputInt("##AnchorPort", &port)) {
+        if (port < 1025)
+            port = 1025;
+        if (port > 65534)
+            port = 65534;
+        CVarSetInteger(AnchorCVar::Port, port);
+        AnchorSaveCVars();
+    }
+    ImGui::Text("Name");
+    if (ImGui::InputText("##AnchorName", name, sizeof(name))) {
+        CVarSetString(AnchorCVar::Name, name);
+        AnchorSaveCVars();
+    }
+    ComboRando::ComboMenu_PopInput();
+
+    // Color: shared gRemote.Anchor.Color.Value (Color type; MM reads it as Color24). RGB only, matching
+    // soh's picker default {100,255,100}.
+    Color_RGBA8 col = CVarGetColor(AnchorCVar::ColorValue, Color_RGBA8{ 100, 255, 100, 255 });
+    float rgb[3] = { col.r / 255.0f, col.g / 255.0f, col.b / 255.0f };
+    ImGui::Text("Color");
+    ImGui::SameLine();
+    if (ImGui::ColorEdit3("##AnchorColor", rgb, ImGuiColorEditFlags_NoInputs)) {
+        col.r = (uint8_t)(rgb[0] * 255.0f + 0.5f);
+        col.g = (uint8_t)(rgb[1] * 255.0f + 0.5f);
+        col.b = (uint8_t)(rgb[2] * 255.0f + 0.5f);
+        col.a = 255;
+        CVarSetColor(AnchorCVar::ColorValue, col);
+        AnchorSaveCVars();
+    }
+
+    ComboRando::ComboMenu_PushInput(theme);
+    ImGui::Text("Room ID");
+    if (ImGui::InputText("##AnchorRoomId", roomId, sizeof(roomId))) {
+        CVarSetString(AnchorCVar::RoomId, roomId);
+        AnchorSaveCVars();
+    }
+    ImGui::Text("Team ID (Items & Flags Shared)");
+    if (ImGui::InputText("##AnchorTeamId", teamId, sizeof(teamId))) {
+        CVarSetString(AnchorCVar::TeamId, teamId);
+        AnchorSaveCVars();
+    }
+    ComboRando::ComboMenu_PopInput();
+
+    ImGui::Spacing();
+    ComboRando::ComboMenu_PushButton(theme);
+    if (ImGui::Button("Restore Defaults", ImVec2(ImGui::GetContentRegionAvail().x / 2, 0))) {
+        CVarSetString(AnchorCVar::Host, "anchor.hm64.org");
+        CVarSetInteger(AnchorCVar::Port, 43383);
+        CVarSetString(AnchorCVar::TeamId, "default");
+        CVarSetString(AnchorCVar::RoomId, "");
+        CVarSetString(AnchorCVar::Name, "");
+        AnchorSaveCVars();
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Global Room", ImVec2(-1.0f, 0.0f))) {
+        CVarSetString(AnchorCVar::Host, "anchor.hm64.org");
+        CVarSetInteger(AnchorCVar::Port, 43383);
+        CVarSetString(AnchorCVar::TeamId, "default");
+        CVarSetString(AnchorCVar::RoomId, "soh-global");
+        AnchorSaveCVars();
+    }
+    ComboRando::ComboMenu_PopButton();
+    ImGui::SetItemTooltip("Always-online public room so you don't have to experience Hyrule alone. "
+                          "PVP and syncing are disabled.");
+    ImGui::EndDisabled();
+
+    // --- Enable/Disable (gated by form validity, mirroring soh's isFormValid) ---
+    ImGui::Spacing();
+    bool formValid = host[0] != '\0' && port > 1024 && port < 65535 && roomId[0] != '\0' && name[0] != '\0';
+    ImGui::BeginDisabled(!formValid || sSohAnchorSetEnabled == nullptr);
+    const ImVec4 red = { 0.66f, 0.13f, 0.13f, 1.0f };
+    const ImVec4 green = { 0.15f, 0.55f, 0.20f, 1.0f };
+    ComboRando::ComboMenu_PushButton(enabled ? red : green);
+    if (ImGui::Button(enabled ? "Disable" : "Enable", ImVec2(-1.0f, 0.0f))) {
+        if (sSohAnchorSetEnabled)
+            sSohAnchorSetEnabled(enabled ? 0 : 1);
+    }
+    ComboRando::ComboMenu_PopButton();
+    ImGui::EndDisabled();
+
+    // --- Status line ---
+    if (enabled) {
+        if (connected) {
+            ImGui::TextColored(ImVec4(0.4f, 0.9f, 0.4f, 1.0f), "Connected");
+        } else {
+            ImGui::TextDisabled("Connecting...");
+        }
+    }
+
+    // --- Team sync (both games) + minimap toggle ---
     ImGui::SeparatorText("Team Sync");
     ImGui::TextWrapped("Pull the latest team progress from your Anchor teammates for BOTH games.");
     ComboRando::ComboMenu_PushButton(theme);
@@ -623,8 +772,16 @@ void DrawNetworkSharedPanel() {
     ComboRando::ComboMenu_PopButton();
     ImGui::TextDisabled("Use this if you're missing items/flags a teammate has collected in either game.");
 
-    // Below it, the Ship of Harkinian "Network > Anchor" settings (host/port/connect) rendered from the
-    // game model, so the full Anchor config lives here too.
+    bool showMinimap = CVarGetInteger(AnchorCVar::ShowOnMinimap, 1) != 0;
+    ComboRando::ComboMenu_PushCheckbox(theme);
+    if (ImGui::Checkbox("Show Other Players on Minimap", &showMinimap)) {
+        CVarSetInteger(AnchorCVar::ShowOnMinimap, showMinimap ? 1 : 0);
+        AnchorSaveCVars();
+    }
+    ComboRando::ComboMenu_PopCheckbox();
+
+    // Admin / Instructions still come from the soh Network>Anchor sidebar (AnchorMainMenu is hidden in
+    // combo, so only those render). Phases 2/3 replace them with combo-native panels.
     auto& model = ComboMenuModel::Get();
     model.EnsureLoaded();
     const ComboRando::GameMenu& oot = model.Oot();
@@ -635,7 +792,6 @@ void DrawNetworkSharedPanel() {
                 continue;
             for (int sb = 0; sb < sec.sidebarCount; ++sb) {
                 if (sec.sidebars[sb].sidebarName && strcmp(sec.sidebars[sb].sidebarName, "Anchor") == 0) {
-                    ImGui::SeparatorText("Anchor Connection");
                     RenderSidebarWidgets(sec.sidebars[sb], oot);
                 }
             }

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -7,9 +7,10 @@
 #include "ComboTrackerBridge.h"
 #include "ComboTrackerCommon.h" // kKinds (HideBackground CVars for the tracker panels)
 #include "ComboTrackerSwap.h"
+#include "ComboAnchorRoomWindow.h"  // combo-native floating Anchor room window
 #include "rando/ComboPlaythrough.h" // plando: ParseSpoilerPlacements + Suffix/BuildForeignArray + slot paths
 #include <imgui.h>
-#include <libultraship/libultraship.h> // CVar bridge (CVarGet/Set* incl. color) + color.h (Color_RGBA8)
+#include <libultraship/libultraship.h>         // CVar bridge (CVarGet/Set* incl. color) + color.h (Color_RGBA8)
 #include <ship/window/gui/IconsFontAwesome4.h> // ICON_FA_* for the header action buttons
 #include <memory>
 #include <string>
@@ -50,13 +51,13 @@ void ResolveComboGenSyms() {
 typedef void (*FnRequestResync)(void);
 FnRequestResync sSohRequestResync = nullptr;
 FnRequestResync sMmRequestResync = nullptr;
-// Phase 1 Anchor connection panel: soh drives Enable/Disable + reports connection state (the socket
+// Anchor connection panel: soh drives Enable/Disable + reports connection state (the socket
 // is launcher-owned, but enable/status stays in soh's Anchor object). Resolved from soh.dll.
 typedef void (*FnSetEnabled)(int);
 typedef int (*FnGetConnState)(void);
 FnSetEnabled sSohAnchorSetEnabled = nullptr;
 FnGetConnState sSohAnchorGetConnState = nullptr;
-// Phase 2 room-admin: owner-gating + room-state broadcast + clear-team-state, all in soh's Anchor object.
+// Room-admin: owner-gating + room-state broadcast + clear-team-state, all in soh's Anchor object.
 typedef int (*FnGetOwnerInfo)(void);
 typedef void (*FnSendRoomState)(void);
 typedef void (*FnClearTeamState)(void);
@@ -96,7 +97,7 @@ constexpr const char* RoomId = "gRemote.Anchor.RoomId";
 constexpr const char* TeamId = "gRemote.Anchor.TeamId";
 constexpr const char* ColorValue = "gRemote.Anchor.Color.Value";
 constexpr const char* ShowOnMinimap = "gRemote.Anchor.ShowOtherPlayersOnMinimap";
-// Room-admin settings (Phase 2): shared store both games read; changes broadcast via SendRoomState.
+// Room-admin settings: shared store both games read; changes broadcast via SendRoomState.
 constexpr const char* PvpMode = "gRemote.Anchor.RoomSettings.PvpMode";
 constexpr const char* ShowLocationsMode = "gRemote.Anchor.RoomSettings.ShowLocationsMode";
 constexpr const char* TeleportMode = "gRemote.Anchor.RoomSettings.TeleportMode";
@@ -658,10 +659,8 @@ static void AnchorSaveCVars() {
     }
 }
 
-// Shared > Network "Anchor": combo-native connection panel (Phase 1). Replaces the proxied soh
-// AnchorMainMenu (hidden in combo). Writes the shared gRemote.Anchor.* CVars both games read, and
-// drives Enable/Disable + status via the SOH_Anchor_* exports. Admin/Instructions (Phases 2/3) are
-// still surfaced from the soh Network>Anchor sidebar below.
+// Combo Anchor panel: connection settings, owner-only room admin, and a toggle for the room window.
+// Writes the shared gRemote.Anchor.* CVars and drives the games via the SOH_/MM_Anchor_* exports.
 void DrawNetworkSharedPanel() {
     const ImVec4 theme = ComboRando::ComboMenu_ThemeColor();
     ResolveAnchorResyncSyms();
@@ -798,7 +797,7 @@ void DrawNetworkSharedPanel() {
     }
     ComboRando::ComboMenu_PopCheckbox();
 
-    // --- Room admin (Phase 2, owner-only, non-global) ---
+    // --- Room admin (owner-only, non-global) ---
     // ownerInfo bit0=isOwner, bit1=isGlobalRoom; 0 unless connected. Mirrors soh's AnchorAdminMenu gate.
     int ownerInfo = sSohAnchorGetOwnerInfo ? sSohAnchorGetOwnerInfo() : 0;
     bool isOwner = (ownerInfo & 1) != 0;
@@ -853,24 +852,25 @@ void DrawNetworkSharedPanel() {
         ComboRando::ComboMenu_PopCheckbox();
     }
 
-    // Instructions still come from the soh Network>Anchor sidebar (AnchorMainMenu/AnchorAdminMenu are
-    // hidden in combo, so only AnchorInstructions renders). Phase 3 replaces it with a combo-native panel.
-    auto& model = ComboMenuModel::Get();
-    model.EnsureLoaded();
-    const ComboRando::GameMenu& oot = model.Oot();
-    if (oot.loaded && oot.menu) {
-        for (int s = 0; s < oot.menu->sectionCount; ++s) {
-            const CwSection& sec = oot.menu->sections[s];
-            if (!sec.sectionLabel || strcmp(sec.sectionLabel, "Network") != 0)
-                continue;
-            for (int sb = 0; sb < sec.sidebarCount; ++sb) {
-                if (sec.sidebars[sb].sidebarName && strcmp(sec.sidebars[sb].sidebarName, "Anchor") == 0) {
-                    RenderSidebarWidgets(sec.sidebars[sb], oot);
-                }
+    // --- Room window: toggle the combo-native floating roster window ---
+    ImGui::SeparatorText("Room");
+    bool roomOpen = CVarGetInteger("gCombo.Anchor.RoomWindow", 0) != 0;
+    ComboRando::ComboMenu_PushButton(theme);
+    if (ImGui::Button(roomOpen ? "Hide Room Window" : "Show Room Window", ImVec2(-1.0f, 0.0f))) {
+        roomOpen = !roomOpen;
+        CVarSetInteger("gCombo.Anchor.RoomWindow", roomOpen ? 1 : 0);
+        AnchorSaveCVars();
+        if (auto ctx = Ship::Context::GetInstance(); ctx && ctx->GetWindow() && ctx->GetWindow()->GetGui()) {
+            if (auto win = ctx->GetWindow()->GetGui()->GetGuiWindow("Anchor Room")) {
+                if (roomOpen)
+                    win->Show();
+                else
+                    win->Hide();
             }
-            break;
         }
     }
+    ComboRando::ComboMenu_PopButton();
+    ImGui::TextDisabled("Shows every teammate's game and area, with same-game teleport.");
 }
 
 // Build the combined item picker list from both games' static-data dumps (items[] = full item table
@@ -1580,4 +1580,7 @@ extern "C" void ComboUI_Register(void)
     // Item Tracker: shared appearance + game-swap manager (see ComboTrackerSwap.h).
     ComboTracker::SyncAppearance();
     ComboTracker::RegisterSwap();
+
+    // Combo-native floating Anchor room window (toggled from the Anchor panel).
+    ComboRando::RegisterAnchorRoomWindow();
 }

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -56,6 +56,13 @@ typedef void (*FnSetEnabled)(int);
 typedef int (*FnGetConnState)(void);
 FnSetEnabled sSohAnchorSetEnabled = nullptr;
 FnGetConnState sSohAnchorGetConnState = nullptr;
+// Phase 2 room-admin: owner-gating + room-state broadcast + clear-team-state, all in soh's Anchor object.
+typedef int (*FnGetOwnerInfo)(void);
+typedef void (*FnSendRoomState)(void);
+typedef void (*FnClearTeamState)(void);
+FnGetOwnerInfo sSohAnchorGetOwnerInfo = nullptr;
+FnSendRoomState sSohAnchorSendRoomState = nullptr;
+FnClearTeamState sSohAnchorClearTeamState = nullptr;
 void ResolveAnchorResyncSyms() {
 #ifdef _WIN32
     if (HMODULE h = GetModuleHandleA("soh.dll")) {
@@ -65,6 +72,12 @@ void ResolveAnchorResyncSyms() {
             sSohAnchorSetEnabled = (FnSetEnabled)GetProcAddress(h, "SOH_Anchor_SetEnabled");
         if (!sSohAnchorGetConnState)
             sSohAnchorGetConnState = (FnGetConnState)GetProcAddress(h, "SOH_Anchor_GetConnectionState");
+        if (!sSohAnchorGetOwnerInfo)
+            sSohAnchorGetOwnerInfo = (FnGetOwnerInfo)GetProcAddress(h, "SOH_Anchor_GetOwnerInfo");
+        if (!sSohAnchorSendRoomState)
+            sSohAnchorSendRoomState = (FnSendRoomState)GetProcAddress(h, "SOH_Anchor_SendRoomState");
+        if (!sSohAnchorClearTeamState)
+            sSohAnchorClearTeamState = (FnClearTeamState)GetProcAddress(h, "SOH_Anchor_ClearTeamState");
     }
     if (!sMmRequestResync) {
         if (HMODULE h = GetModuleHandleA("2ship.dll"))
@@ -83,6 +96,11 @@ constexpr const char* RoomId = "gRemote.Anchor.RoomId";
 constexpr const char* TeamId = "gRemote.Anchor.TeamId";
 constexpr const char* ColorValue = "gRemote.Anchor.Color.Value";
 constexpr const char* ShowOnMinimap = "gRemote.Anchor.ShowOtherPlayersOnMinimap";
+// Room-admin settings (Phase 2): shared store both games read; changes broadcast via SendRoomState.
+constexpr const char* PvpMode = "gRemote.Anchor.RoomSettings.PvpMode";
+constexpr const char* ShowLocationsMode = "gRemote.Anchor.RoomSettings.ShowLocationsMode";
+constexpr const char* TeleportMode = "gRemote.Anchor.RoomSettings.TeleportMode";
+constexpr const char* SyncItemsAndFlags = "gRemote.Anchor.RoomSettings.SyncItemsAndFlags";
 } // namespace AnchorCVar
 
 // Combo plandomizer exports: each game's static-data dump (friendly item names) + the reload trigger
@@ -780,8 +798,63 @@ void DrawNetworkSharedPanel() {
     }
     ComboRando::ComboMenu_PopCheckbox();
 
-    // Admin / Instructions still come from the soh Network>Anchor sidebar (AnchorMainMenu is hidden in
-    // combo, so only those render). Phases 2/3 replace them with combo-native panels.
+    // --- Room admin (Phase 2, owner-only, non-global) ---
+    // ownerInfo bit0=isOwner, bit1=isGlobalRoom; 0 unless connected. Mirrors soh's AnchorAdminMenu gate.
+    int ownerInfo = sSohAnchorGetOwnerInfo ? sSohAnchorGetOwnerInfo() : 0;
+    bool isOwner = (ownerInfo & 1) != 0;
+    bool isGlobalRoom = (ownerInfo & 2) != 0;
+    if (connected && isOwner && !isGlobalRoom) {
+        ImGui::SeparatorText("Room Settings (Admin Only)");
+
+        ComboRando::ComboMenu_PushButton(theme);
+        if (ImGui::Button("Clear All Team State", ImVec2(-1.0f, 0.0f))) {
+            if (sSohAnchorClearTeamState)
+                sSohAnchorClearTeamState();
+        }
+        ComboRando::ComboMenu_PopButton();
+
+        auto sendRoomState = [&]() {
+            if (sSohAnchorSendRoomState)
+                sSohAnchorSendRoomState();
+        };
+
+        const char* kPvpModes[] = { "Off", "On", "On + Friendly Fire" };
+        const char* kShowLocationsModes[] = { "None", "Team Only", "All" };
+        const char* kTeleportModes[] = { "None", "Team Only", "All" };
+
+        ComboRando::ComboMenu_PushCombobox(theme);
+        int pvp = CVarGetInteger(AnchorCVar::PvpMode, 1);
+        if (ImGui::Combo("PvP Mode", &pvp, kPvpModes, 3)) {
+            CVarSetInteger(AnchorCVar::PvpMode, pvp);
+            AnchorSaveCVars();
+            sendRoomState();
+        }
+        int showLoc = CVarGetInteger(AnchorCVar::ShowLocationsMode, 1);
+        if (ImGui::Combo("Show Locations For", &showLoc, kShowLocationsModes, 3)) {
+            CVarSetInteger(AnchorCVar::ShowLocationsMode, showLoc);
+            AnchorSaveCVars();
+            sendRoomState();
+        }
+        int teleport = CVarGetInteger(AnchorCVar::TeleportMode, 1);
+        if (ImGui::Combo("Allow Teleporting To", &teleport, kTeleportModes, 3)) {
+            CVarSetInteger(AnchorCVar::TeleportMode, teleport);
+            AnchorSaveCVars();
+            sendRoomState();
+        }
+        ComboRando::ComboMenu_PopCombobox();
+
+        bool syncItems = CVarGetInteger(AnchorCVar::SyncItemsAndFlags, 1) != 0;
+        ComboRando::ComboMenu_PushCheckbox(theme);
+        if (ImGui::Checkbox("Sync Items & Flags", &syncItems)) {
+            CVarSetInteger(AnchorCVar::SyncItemsAndFlags, syncItems ? 1 : 0);
+            AnchorSaveCVars();
+            sendRoomState();
+        }
+        ComboRando::ComboMenu_PopCheckbox();
+    }
+
+    // Instructions still come from the soh Network>Anchor sidebar (AnchorMainMenu/AnchorAdminMenu are
+    // hidden in combo, so only AnchorInstructions renders). Phase 3 replaces it with a combo-native panel.
     auto& model = ComboMenuModel::Get();
     model.EnsureLoaded();
     const ComboRando::GameMenu& oot = model.Oot();

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -787,26 +787,28 @@ void DrawNetworkSharedPanel() {
         }
     }
 
-    // --- Team sync (both games) + minimap toggle ---
-    ImGui::SeparatorText("Team Sync");
-    ImGui::TextWrapped("Pull the latest team progress from your Anchor teammates for BOTH games.");
-    ComboRando::ComboMenu_PushButton(theme);
-    if (ImGui::Button("Resync team state", ImVec2(-1.0f, 0.0f))) {
-        if (sSohRequestResync)
-            sSohRequestResync();
-        if (sMmRequestResync)
-            sMmRequestResync();
-    }
-    ComboRando::ComboMenu_PopButton();
-    ImGui::TextDisabled("Use this if you're missing items/flags a teammate has collected in either game.");
+    // --- Team sync + minimap (only once Anchor is enabled) ---
+    if (enabled) {
+        ImGui::SeparatorText("Team Sync");
+        ImGui::TextWrapped("Pull the latest team progress from your Anchor teammates for BOTH games.");
+        ComboRando::ComboMenu_PushButton(theme);
+        if (ImGui::Button("Resync team state", ImVec2(-1.0f, 0.0f))) {
+            if (sSohRequestResync)
+                sSohRequestResync();
+            if (sMmRequestResync)
+                sMmRequestResync();
+        }
+        ComboRando::ComboMenu_PopButton();
+        ImGui::TextDisabled("Use this if you're missing items/flags a teammate has collected in either game.");
 
-    bool showMinimap = CVarGetInteger(AnchorCVar::ShowOnMinimap, 1) != 0;
-    ComboRando::ComboMenu_PushCheckbox(theme);
-    if (ImGui::Checkbox("Show Other Players on Minimap", &showMinimap)) {
-        CVarSetInteger(AnchorCVar::ShowOnMinimap, showMinimap ? 1 : 0);
-        AnchorSaveCVars();
+        bool showMinimap = CVarGetInteger(AnchorCVar::ShowOnMinimap, 1) != 0;
+        ComboRando::ComboMenu_PushCheckbox(theme);
+        if (ImGui::Checkbox("Show Other Players on Minimap", &showMinimap)) {
+            CVarSetInteger(AnchorCVar::ShowOnMinimap, showMinimap ? 1 : 0);
+            AnchorSaveCVars();
+        }
+        ComboRando::ComboMenu_PopCheckbox();
     }
-    ComboRando::ComboMenu_PopCheckbox();
 
     // --- Room admin (owner-only, non-global) ---
     // ownerInfo bit0=isOwner, bit1=isGlobalRoom; 0 unless connected. Mirrors soh's AnchorAdminMenu gate.
@@ -863,25 +865,27 @@ void DrawNetworkSharedPanel() {
         ComboRando::ComboMenu_PopCheckbox();
     }
 
-    // --- Room window: toggle the combo-native floating roster window ---
-    ImGui::SeparatorText("Room");
-    bool roomOpen = CVarGetInteger("gCombo.Anchor.RoomWindow", 0) != 0;
-    ComboRando::ComboMenu_PushButton(theme);
-    if (ImGui::Button(roomOpen ? "Hide Room Window" : "Show Room Window", ImVec2(-1.0f, 0.0f))) {
-        roomOpen = !roomOpen;
-        CVarSetInteger("gCombo.Anchor.RoomWindow", roomOpen ? 1 : 0);
-        AnchorSaveCVars();
-        if (auto ctx = Ship::Context::GetInstance(); ctx && ctx->GetWindow() && ctx->GetWindow()->GetGui()) {
-            if (auto win = ctx->GetWindow()->GetGui()->GetGuiWindow("Anchor Room")) {
-                if (roomOpen)
-                    win->Show();
-                else
-                    win->Hide();
+    // --- Room window: toggle the combo-native floating roster window (only once Anchor is enabled) ---
+    if (enabled) {
+        ImGui::SeparatorText("Room");
+        bool roomOpen = CVarGetInteger("gCombo.Anchor.RoomWindow", 0) != 0;
+        ComboRando::ComboMenu_PushButton(theme);
+        if (ImGui::Button(roomOpen ? "Hide Room Window" : "Show Room Window", ImVec2(-1.0f, 0.0f))) {
+            roomOpen = !roomOpen;
+            CVarSetInteger("gCombo.Anchor.RoomWindow", roomOpen ? 1 : 0);
+            AnchorSaveCVars();
+            if (auto ctx = Ship::Context::GetInstance(); ctx && ctx->GetWindow() && ctx->GetWindow()->GetGui()) {
+                if (auto win = ctx->GetWindow()->GetGui()->GetGuiWindow("Anchor Room")) {
+                    if (roomOpen)
+                        win->Show();
+                    else
+                        win->Hide();
+                }
             }
         }
+        ComboRando::ComboMenu_PopButton();
+        ImGui::TextDisabled("Shows every teammate's game and area, with same-game teleport.");
     }
-    ComboRando::ComboMenu_PopButton();
-    ImGui::TextDisabled("Shows every teammate's game and area, with same-game teleport.");
 
     ImGui::EndTable();
 }

--- a/combo/rando/ComboAnchorToast.h
+++ b/combo/rando/ComboAnchorToast.h
@@ -1,0 +1,28 @@
+// combo/rando/ComboAnchorToast.h — ComboShip: shared "Save updated from team" toast debounce.
+// OOT and MM each request a team resync (on connect and on the manual Resync button), and the server
+// answers each request, so a single resync produces a burst of UPDATE_TEAM_STATE replies across BOTH
+// game DLLs. A per-DLL static can't dedup a cross-game OOT+MM pair, so gate the toast on a shared,
+// process-global CVar timestamp: the first reply in a 2s window toasts, the rest are silent.
+// Included by soh (Packets/UpdateTeamState.cpp) and MM (MMAnchor.cpp).
+#pragma once
+
+#include <chrono>
+#include <string>
+#include <libultraship/bridge/consolevariablebridge.h>
+
+// Wall clock (not steady_clock): the timestamp CVar may be persisted, and a steady_clock epoch resets
+// per process, which would wedge the debounce across restarts.
+inline bool ComboAnchor_ShouldToastResync() {
+    long long nowMs =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
+            .count();
+    long long lastMs = 0;
+    try {
+        lastMs = std::stoll(CVarGetString("gCombo.Anchor.LastResyncToastMs", "0"));
+    } catch (...) {}
+    if (nowMs - lastMs > 2000 || nowMs < lastMs) { // second guard: clock moved backwards
+        CVarSetString("gCombo.Anchor.LastResyncToastMs", std::to_string(nowMs).c_str());
+        return true;
+    }
+    return false;
+}

--- a/docs/UPSTREAM_MERGES.md
+++ b/docs/UPSTREAM_MERGES.md
@@ -1842,6 +1842,28 @@ Fixes, all `COMBO_BUILD`:
   as a false duplicate. `ResetCrossItemDedupForSeed` runs on the generation worker thread while
   `DeliverCrossItem` runs on the game thread, so both now take `sAppliedCrossChecksMutex`.
 
+## Anchor co-op sync: toast-burst + name-tag color (2026-07-17)
+
+**Why:** the "Save updated from team" toast fired 2-3x on every connect and on every manual resync
+button press, even solo. Root cause: `Anchor::OnConnected` (soh) sent its own
+`REQUEST_TEAM_STATE` in addition to the launcher's on-connect resync (`SOH_Anchor_RequestResync` +
+`MM_Anchor_RequestResync`), so a solo/no-teammate reply (server answers directly when no teammates
+are online) lands once per send, and `ReceiveLoop` forwards every reply to BOTH game DLLs
+unconditionally — the foreground game applies+toasts on each one it receives (the dormant game's
+`PumpDormant` already silently drops `UPDATE_TEAM_STATE`, so it never double-toasts).
+
+Fixes, all `COMBO_BUILD`:
+- `soh/soh/Network/Anchor/Anchor.cpp` (`OnConnected`): removed the redundant direct
+  `SendPacket_RequestTeamState()` call — the launcher's resync is the sole on-connect source now.
+- `soh/soh/Network/Anchor/Packets/UpdateTeamState.cpp` + `mm/2s2h/Network/Anchor/MMAnchor.cpp`
+  (`HandlePacket_UpdateTeamState`): debounce the toast (2s, `steady_clock`) — the state merge still
+  runs every time (idempotent), only the notification is deduped. Sender-count-agnostic, so it also
+  covers the manual "Resync team state" button (which legitimately sends both an OOT and an MM
+  request) and any other multi-reply burst.
+- `soh/soh/Network/Anchor/DummyPlayer.cpp` + `mm/2s2h/Network/Anchor/DummyPlayer.cpp`: remote puppet
+  name tags now use the client's Anchor color (`client.color`) instead of the dark default
+  (`NameTagOptions.textColor` alpha 0).
+
 ## Cross-hint playtest fixes: color, dump size, altar (2026-07-16)
 
 **Why:** playtest of the cross-hints feature found 3 issues: hint text displayed with no color,

--- a/mm/2s2h/Network/Anchor/DummyPlayer.cpp
+++ b/mm/2s2h/Network/Anchor/DummyPlayer.cpp
@@ -100,7 +100,10 @@ void DummyPlayer_Init(Actor* actor, PlayState* play) {
 
     bool isGlobalRoom = (std::string("soh-global") == CVarGetString("gRemote.Anchor.RoomId", ""));
     if (!isGlobalRoom) {
-        NameTag_RegisterForActorWithOptions(actor, client.name.c_str(), { .yOffset = 30 });
+        // ComboShip: use the client's Anchor color instead of the dark default (mirrors soh's puppet).
+        NameTag_RegisterForActorWithOptions(
+            actor, client.name.c_str(),
+            { .yOffset = 30, .textColor = { client.color.r, client.color.g, client.color.b, 255 } });
     }
 }
 

--- a/mm/2s2h/Network/Anchor/MMAnchor.cpp
+++ b/mm/2s2h/Network/Anchor/MMAnchor.cpp
@@ -8,6 +8,7 @@
 #include "2s2h/Rando/CheckTracker/CheckTracker.h" // Phase 2d: re-derive after team-state apply
 #include "2s2h/Rando/ActorBehavior/ActorBehavior.h"
 #include "2s2h/ShipInit.hpp"
+#include "2s2h/ShipUtils.h" // ComboShip: Ship_GetSceneName for the roster area-name supplement
 #include "2s2h/BenGui/Notification.h"
 #include "BenJsonConversions.hpp" // to_json/from_json for Vec3f/Vec3s/PosRot AND Save (Phase 2d)
 
@@ -26,6 +27,7 @@ static constexpr const char* kCvarName = "gRemote.Anchor.Name";
 static constexpr const char* kCvarColor = "gRemote.Anchor.Color.Value";
 static constexpr const char* kCvarTeamId = "gRemote.Anchor.TeamId";
 static constexpr const char* kCvarLastClientId = "gRemote.Anchor.LastClientId";
+static constexpr const char* kCvarTeleportMode = "gRemote.Anchor.RoomSettings.TeleportMode"; // teleport gate
 
 // Packet type strings — must match SoH's Anchor exactly for cross-client interop.
 static const std::string PKT_ALL_CLIENT_STATE = "ALL_CLIENT_STATE";
@@ -38,6 +40,9 @@ static const std::string PKT_REQUEST_TEAM_STATE = "REQUEST_TEAM_STATE";
 // Issue #3: cross-game item delivery. ComboShip-private packet type (the public server relays unknown
 // types peer-to-peer, so no server change is needed).
 static const std::string PKT_CROSS_ITEM = "COMBO_CROSS_ITEM";
+// Same-game teleport. Same wire strings as soh's Anchor; MM-origin so soh clients drop them.
+static const std::string PKT_REQUEST_TELEPORT = "REQUEST_TELEPORT";
+static const std::string PKT_TELEPORT_TO = "TELEPORT_TO";
 
 // Launcher-registered outbound transport (set via MM_SetAnchorSend). Null until the exe wires it.
 extern "C" {
@@ -218,6 +223,10 @@ void MMAnchor::ProcessIncomingPacketQueue() {
                 HandlePacket_UpdateTeamState(payload);
             } else if (type == PKT_REQUEST_TEAM_STATE) {
                 HandlePacket_RequestTeamState(payload);
+            } else if (type == PKT_REQUEST_TELEPORT) {
+                HandlePacket_RequestTeleport(payload);
+            } else if (type == PKT_TELEPORT_TO) {
+                HandlePacket_TeleportTo(payload);
             }
             // Flag sync intentionally deferred (mirrors canonical, which stubs it).
         } catch (const std::exception& e) {
@@ -880,6 +889,88 @@ void MMAnchor::HandlePacket_UpdateTeamState(nlohmann::json& payload) {
     }
 }
 
+// MARK: - Same-game teleport (mirrors soh's REQUEST_TELEPORT -> TELEPORT_TO handshake)
+
+// Gate mirrors soh's CanTeleportTo minus OOT's problematic-scene list (MM has none). TeleportMode is
+// read from the shared CVar (owner-authored, process-global store both games read).
+bool MMAnchor::CanTeleportTo(uint32_t clientId) {
+    int teleportMode = CVarGetInteger(kCvarTeleportMode, 1);
+    if (teleportMode == 0 || !IsSaveLoaded()) {
+        return false;
+    }
+    auto it = clients.find(clientId);
+    if (it == clients.end()) {
+        return false;
+    }
+    MMAnchorClient& client = it->second;
+    if (client.self || !client.online || !client.isSaveLoaded) {
+        return false;
+    }
+    if (teleportMode == 1 && client.teamId != CVarGetString(kCvarTeamId, "default")) {
+        return false;
+    }
+    return true;
+}
+
+void MMAnchor::SendPacket_RequestTeleport(uint32_t clientId) {
+    if (!CanTeleportTo(clientId)) {
+        return;
+    }
+    nlohmann::json payload;
+    payload["type"] = PKT_REQUEST_TELEPORT;
+    payload["targetClientId"] = clientId;
+    SendJson(payload);
+}
+
+void MMAnchor::HandlePacket_RequestTeleport(const nlohmann::json& payload) {
+    if (!IsSaveLoaded() || payload.value("targetClientId", (uint32_t)0) != ownClientId) {
+        return; // only the requested target answers (server directs, but double-check)
+    }
+    uint32_t requester = payload.value("clientId", (uint32_t)0);
+    if (requester != 0) {
+        SendPacket_TeleportTo(requester);
+    }
+}
+
+void MMAnchor::SendPacket_TeleportTo(uint32_t clientId) {
+    if (!IsSaveLoaded()) {
+        return;
+    }
+    Player* player = GET_PLAYER(gPlayState);
+    nlohmann::json payload;
+    payload["type"] = PKT_TELEPORT_TO;
+    payload["targetClientId"] = clientId;
+    payload["entranceId"] = gSaveContext.save.entrance;
+    payload["roomNum"] = (int32_t)gPlayState->roomCtx.curRoom.num;
+    payload["pos"] = player->actor.world.pos; // Vec3f via BenJsonConversions
+    payload["rotY"] = (int32_t)player->actor.shape.rot.y;
+    SendJson(payload);
+}
+
+void MMAnchor::HandlePacket_TeleportTo(const nlohmann::json& payload) {
+    if (!IsSaveLoaded() || payload.value("targetClientId", (uint32_t)0) != ownClientId) {
+        return;
+    }
+    s32 entranceId = payload.value("entranceId", (s32)-1);
+    s8 roomNum = (s8)payload.value("roomNum", (int32_t)-1);
+    if (entranceId < 0 || roomNum < 0) {
+        return;
+    }
+    Vec3f pos = payload.contains("pos") ? payload["pos"].get<Vec3f>() : Vec3f{ 0, 0, 0 };
+    s16 rotY = (s16)payload.value("rotY", (int32_t)0);
+    // Warp mirrors DeveloperTools/WarpPoint.cpp Warp() (gPlayState != NULL branch).
+    gPlayState->nextEntrance = Entrance_Create(entranceId >> 9, 0, entranceId & 0xF);
+    gPlayState->transitionTrigger = TRANS_TRIGGER_START;
+    gPlayState->transitionType = TRANS_TYPE_INSTANT;
+    gSaveContext.respawn[RESPAWN_MODE_DOWN].entrance = Entrance_Create(entranceId >> 9, 0, entranceId & 0xF);
+    gSaveContext.respawn[RESPAWN_MODE_DOWN].roomIndex = roomNum;
+    gSaveContext.respawn[RESPAWN_MODE_DOWN].pos = pos;
+    gSaveContext.respawn[RESPAWN_MODE_DOWN].yaw = rotY;
+    gSaveContext.respawn[RESPAWN_MODE_DOWN].playerParams = PLAYER_PARAMS(0xFF, PLAYER_START_MODE_D);
+    gSaveContext.nextTransitionType = TRANS_TYPE_FADE_BLACK_FAST;
+    gSaveContext.respawnFlag = -8;
+}
+
 // MARK: - Launcher-facing C ABI (mirrors soh's SOH_Anchor_* exports)
 
 extern "C" __declspec(dllexport) void MM_SetAnchorSend(void (*cb)(const char*)) {
@@ -932,6 +1023,43 @@ extern "C" __declspec(dllexport) void MM_Anchor_Activate(void) {
 extern "C" __declspec(dllexport) void MM_Anchor_Deactivate(void) {
     if (MMAnchor::Instance) {
         MMAnchor::Instance->Deactivate();
+    }
+}
+
+// Supplemental roster for the combo room window. soh owns the authoritative full roster; MM
+// only fills in its OWN players' area names (keyed by clientId), resolved locally from the raw scene id.
+// comboui overlays these onto soh's mm-tagged entries. OOT clients also appear here but comboui ignores
+// them (it applies MM area names only to game=="mm" rows).
+extern "C" __declspec(dllexport) const char* MM_Anchor_GetRoster(void) {
+    static std::string cached;
+    try {
+        nlohmann::json arr = nlohmann::json::array();
+        if (MMAnchor::Instance) {
+            for (auto& [clientId, client] : MMAnchor::Instance->clients) {
+                s16 sceneId = (client.self && gPlayState != nullptr) ? gPlayState->sceneId : client.sceneId;
+                nlohmann::json e;
+                e["clientId"] = clientId;
+                e["areaName"] = Ship_GetSceneName(sceneId);
+                arr.push_back(e);
+            }
+        }
+        cached = arr.dump();
+    } catch (const std::exception& e) {
+        SPDLOG_ERROR("[MM_Anchor_GetRoster] {}", e.what());
+        cached = "[]";
+    } catch (...) { cached = "[]"; }
+    return cached.c_str();
+}
+
+// Same-game teleport trigger for the combo room window (MM active + MM peer). Wraps
+// SendPacket_RequestTeleport, which re-validates via CanTeleportTo and no-ops if disallowed.
+extern "C" __declspec(dllexport) void MM_Anchor_RequestTeleport(uint32_t clientId) {
+    try {
+        if (MMAnchor::Instance) {
+            MMAnchor::Instance->SendPacket_RequestTeleport(clientId);
+        }
+    } catch (const std::exception& e) { SPDLOG_ERROR("[MM_Anchor_RequestTeleport] {}", e.what()); } catch (...) {
+        SPDLOG_ERROR("[MM_Anchor_RequestTeleport] unknown exception");
     }
 }
 

--- a/mm/2s2h/Network/Anchor/MMAnchor.cpp
+++ b/mm/2s2h/Network/Anchor/MMAnchor.cpp
@@ -1026,28 +1026,11 @@ extern "C" __declspec(dllexport) void MM_Anchor_Deactivate(void) {
     }
 }
 
-// Supplemental roster for the combo room window. soh owns the authoritative full roster; MM
-// only fills in its OWN players' area names (keyed by clientId), resolved locally from the raw scene id.
-// comboui overlays these onto soh's mm-tagged entries. OOT clients also appear here but comboui ignores
-// them (it applies MM area names only to game=="mm" rows).
-extern "C" __declspec(dllexport) const char* MM_Anchor_GetRoster(void) {
+// ComboShip: stateless MM scene-name lookup for the combo room window. The launcher owns the roster
+// now; comboui resolves each MM peer's area name from its raw scene id via this (works while dormant).
+extern "C" __declspec(dllexport) const char* MM_Anchor_ResolveScene(int rawScene) {
     static std::string cached;
-    try {
-        nlohmann::json arr = nlohmann::json::array();
-        if (MMAnchor::Instance) {
-            for (auto& [clientId, client] : MMAnchor::Instance->clients) {
-                s16 sceneId = (client.self && gPlayState != nullptr) ? gPlayState->sceneId : client.sceneId;
-                nlohmann::json e;
-                e["clientId"] = clientId;
-                e["areaName"] = Ship_GetSceneName(sceneId);
-                arr.push_back(e);
-            }
-        }
-        cached = arr.dump();
-    } catch (const std::exception& e) {
-        SPDLOG_ERROR("[MM_Anchor_GetRoster] {}", e.what());
-        cached = "[]";
-    } catch (...) { cached = "[]"; }
+    cached = Ship_GetSceneName((s16)rawScene);
     return cached.c_str();
 }
 

--- a/mm/2s2h/Network/Anchor/MMAnchor.cpp
+++ b/mm/2s2h/Network/Anchor/MMAnchor.cpp
@@ -11,7 +11,8 @@
 #include "2s2h/ShipInit.hpp"
 #include "2s2h/ShipUtils.h" // ComboShip: Ship_GetSceneName for the roster area-name supplement
 #include "2s2h/BenGui/Notification.h"
-#include "BenJsonConversions.hpp" // to_json/from_json for Vec3f/Vec3s/PosRot AND Save (Phase 2d)
+#include "2s2h/SaveManager/SaveManager.h" // dormant team-state persist (SaveManager_SaveCurrentForCombo)
+#include "BenJsonConversions.hpp"         // to_json/from_json for Vec3f/Vec3s/PosRot AND Save (Phase 2d)
 
 extern "C" {
 #include "macros.h"
@@ -237,9 +238,8 @@ void MMAnchor::ProcessIncomingPacketQueue() {
 }
 
 // A6: called on the ACTIVE sibling's game thread while MM is dormant. Drain the queue and apply only
-// save-data-only, dormant-safe packets (co-op GIVE_ITEM). Presence/puppet/team-state are dropped —
-// team-state re-runs OnFileLoad/ShipInit, which isn't safe while dormant, and is re-requested on MM
-// activation anyway. gSaveContext here is MM's frozen save; MM isn't ticking, so no concurrent writer.
+// save-data-only, dormant-safe packets (co-op GIVE_ITEM, team-state resync). Presence/puppet packets
+// are dropped. gSaveContext here is MM's frozen save; MM isn't ticking, so no concurrent writer.
 void MMAnchor::PumpDormant() {
     std::queue<nlohmann::json> toProcess;
     {
@@ -259,6 +259,20 @@ void MMAnchor::PumpDormant() {
                 // nothing whenever this client is in the other game.
                 SPDLOG_INFO("[MMAnchor] dormant REQUEST_TEAM_STATE: answering from frozen save");
                 SendTeamStateFromSave(payload.value("targetTeamId", std::string("default")));
+            } else if (payload.value("type", std::string()) == PKT_UPDATE_TEAM_STATE) {
+                // Bug: previously dropped entirely while dormant. The merge itself only touches
+                // gSaveContext.save, so it's dormant-safe once the scene-bound post-steps are skipped
+                // (guarded by isDormantApply inside the handler).
+                bool willApply = roomState.syncItemsAndFlags && payload.contains("state") &&
+                                 payload["state"].contains("shipSaveInfo");
+                SPDLOG_INFO("[MMAnchor] dormant UPDATE_TEAM_STATE applying={}", willApply);
+                isDormantApply = true;
+                HandlePacket_UpdateTeamState(payload);
+                isDormantApply = false;
+                if (willApply && gSaveContext.fileNum != 0xFF) {
+                    SaveManager_SaveCurrentForCombo();
+                    SPDLOG_INFO("[MMAnchor] dormant MM save persisted after team-state apply");
+                }
             }
         } catch (const std::exception& e) { SPDLOG_ERROR("[MMAnchor] dormant apply exception: {}", e.what()); }
     }
@@ -870,15 +884,19 @@ void MMAnchor::HandlePacket_UpdateTeamState(nlohmann::json& payload) {
         gSaveContext.save.saveInfo.playerData.healthCapacity = localHealthCapacity;
     }
 
-    // ComboShip: collapse the OOT+MM resync burst to one toast across BOTH games (shared-CVar debounce).
-    if (ComboAnchor_ShouldToastResync()) {
-        Notification::Emit({
-            .message = "Save updated from team",
-        });
+    // ComboShip: dormant apply has no gPlayState/scene — CheckTracker/ActorBehavior/ShipInit re-derive
+    // scene-bound state and aren't dormant-safe, and a backgrounded apply shouldn't toast. MM's own
+    // OnSaveLoad re-requests a resync on activation, which re-runs this block in the foreground.
+    if (!isDormantApply) {
+        if (ComboAnchor_ShouldToastResync()) {
+            Notification::Emit({
+                .message = "Save updated from team",
+            });
+        }
+        Rando::CheckTracker::OnFileLoad();
+        Rando::ActorBehavior::OnFileLoad();
+        ShipInit::Init("IS_RANDO");
     }
-    Rando::CheckTracker::OnFileLoad();
-    Rando::ActorBehavior::OnFileLoad();
-    ShipInit::Init("IS_RANDO");
 
     // Replay any packets queued on the server while we were away, through the normal incoming path.
     if (payload.contains("queue") && payload["queue"].is_array()) {

--- a/mm/2s2h/Network/Anchor/MMAnchor.cpp
+++ b/mm/2s2h/Network/Anchor/MMAnchor.cpp
@@ -2,6 +2,7 @@
 #ifdef COMBO_BUILD
 
 #include <spdlog/spdlog.h>
+#include "rando/ComboAnchorToast.h" // shared cross-game resync-toast debounce
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/NameTag/NameTag.h"
 #include "2s2h/Rando/Rando.h" // Rando::GiveItem / ConvertItem / CurrentJunkItem / RANDO_SAVE_CHECKS / IS_RANDO
@@ -869,9 +870,12 @@ void MMAnchor::HandlePacket_UpdateTeamState(nlohmann::json& payload) {
         gSaveContext.save.saveInfo.playerData.healthCapacity = localHealthCapacity;
     }
 
-    Notification::Emit({
-        .message = "Save updated from team",
-    });
+    // ComboShip: collapse the OOT+MM resync burst to one toast across BOTH games (shared-CVar debounce).
+    if (ComboAnchor_ShouldToastResync()) {
+        Notification::Emit({
+            .message = "Save updated from team",
+        });
+    }
     Rando::CheckTracker::OnFileLoad();
     Rando::ActorBehavior::OnFileLoad();
     ShipInit::Init("IS_RANDO");

--- a/mm/2s2h/Network/Anchor/MMAnchor.h
+++ b/mm/2s2h/Network/Anchor/MMAnchor.h
@@ -120,6 +120,8 @@ class MMAnchor {
 
     bool IsSaveLoaded();
     void PumpDormant(); // A6: drain+apply save-affecting co-op packets while MM is the dormant game
+    // True while PumpDormant applies a packet (MM backgrounded, no gPlayState); mirrors soh's Anchor.
+    bool isDormantApply = false;
     // Bug 2: request a fresh team-state from teammates regardless of active/dormant (bypasses
     // SendPacket_RequestTeamState's isActive gate — a resync must go out from the dormant sibling too).
     void RequestResyncDormantSafe();

--- a/mm/2s2h/Network/Anchor/MMAnchor.h
+++ b/mm/2s2h/Network/Anchor/MMAnchor.h
@@ -105,6 +105,12 @@ class MMAnchor {
     void SendTeamStateFromSave(const std::string& targetTeamId); // no isActive gate: dormant answers too
     void SendPacket_RequestTeamState();
 
+    // ComboShip: same-game teleport (mirrors soh's two-step REQUEST_TELEPORT -> TELEPORT_TO).
+    // The launcher only routes this for an MM-active/MM-peer pair (teleport is same-game only).
+    void SendPacket_RequestTeleport(uint32_t clientId);
+    void SendPacket_TeleportTo(uint32_t clientId);
+    bool CanTeleportTo(uint32_t clientId);
+
     bool isActive = false;
     uint32_t ownClientId = 0;
     std::map<uint32_t, MMAnchorClient> clients;
@@ -133,6 +139,8 @@ class MMAnchor {
     void ApplyDormantGiveItem(const nlohmann::json& payload);   // A6: dormant-safe co-op item apply
     void HandlePacket_UpdateTeamState(nlohmann::json& payload); // mutates payload (rando check unpack)
     void HandlePacket_RequestTeamState(const nlohmann::json& payload);
+    void HandlePacket_RequestTeleport(const nlohmann::json& payload); // answer with our location
+    void HandlePacket_TeleportTo(const nlohmann::json& payload);      // warp to peer's location
 
     bool hooksRegistered = false;
     bool shouldRefreshActors = false;

--- a/soh/soh/Network/Anchor/Anchor.cpp
+++ b/soh/soh/Network/Anchor/Anchor.cpp
@@ -106,9 +106,13 @@ void Anchor::OnConnected() {
     SendPacket_Handshake();
     RegisterHooks();
 
+#ifndef COMBO_BUILD
     if (IsSaveLoaded()) {
         SendPacket_RequestTeamState();
     }
+#endif
+    // ComboShip: the launcher's on-connect resync (sResyncPending -> RequestResyncDormantSafe) is the
+    // sole on-connect resync source; this call would duplicate it (see docs/UPSTREAM_MERGES.md).
 }
 
 void Anchor::OnDisconnected() {

--- a/soh/soh/Network/Anchor/Anchor.cpp
+++ b/soh/soh/Network/Anchor/Anchor.cpp
@@ -311,8 +311,7 @@ void Anchor::PumpDormant() {
         }
         if (type == REQUEST_TEAM_STATE) {
             // Answering is read-only over the frozen save, so it's dormant-safe; without it a
-            // teammate's resync gets nothing whenever this client is in the other game. Applying a
-            // received UPDATE_TEAM_STATE stays foreground-only (dropped below).
+            // teammate's resync gets nothing whenever this client is in the other game.
             // Bug 2: this branch was missing the isDormantApply wrap the GIVE_ITEM branch below has,
             // so IsSaveLoaded() (gated on gPlayState) always failed here while dormant — dormant OOT
             // never actually answered.
@@ -323,8 +322,19 @@ void Anchor::PumpDormant() {
             isDormantApply = false;
             continue;
         }
+        if (type == UPDATE_TEAM_STATE) {
+            // Bug: previously dropped here entirely ("re-requested on activation"), but the launcher's
+            // on-connect resync targets exactly this dormant window. Apply straight to the resident
+            // save; HandlePacket_UpdateTeamState sets dormantDidApply under isDormantApply.
+            isDormantApply = true;
+            try {
+                HandlePacket_UpdateTeamState(payload);
+            } catch (const std::exception& e) { SPDLOG_ERROR("[Anchor] dormant team-state apply: {}", e.what()); }
+            isDormantApply = false;
+            continue;
+        }
         if (type != GIVE_ITEM) {
-            continue; // drop presence/puppet/team-state while dormant (re-requested on activation)
+            continue; // drop presence/puppet packets while dormant
         }
         if (!payload.contains("modId")) {
             continue; // MM-shaped GIVE_ITEM; the dormant MM pump handles it

--- a/soh/soh/Network/Anchor/DummyPlayer.cpp
+++ b/soh/soh/Network/Anchor/DummyPlayer.cpp
@@ -89,7 +89,14 @@ void DummyPlayer_Init(Actor* actor, PlayState* play) {
     bool isGlobalRoom = (std::string("soh-global") == CVarGetString(CVAR_REMOTE_ANCHOR("RoomId"), ""));
 
     if (!isGlobalRoom) {
+#ifdef COMBO_BUILD
+        // ComboShip: use the client's Anchor color instead of the dark default so remote name tags
+        // are readable and match the roster.
+        NameTag_RegisterForActorWithOptions(actor, client.name.c_str(),
+                                            { .textColor = { client.color.r, client.color.g, client.color.b, 255 } });
+#else
         NameTag_RegisterForActorWithOptions(actor, client.name.c_str(), {});
+#endif
     }
 }
 

--- a/soh/soh/Network/Anchor/Menu.cpp
+++ b/soh/soh/Network/Anchor/Menu.cpp
@@ -248,9 +248,13 @@ void AnchorInstructionsMenu(WidgetInfo& info) {
 
 void RegisterAnchorMenu() {
     WidgetPath path = { "Network", "Anchor", SECTION_COLUMN_1 };
+#ifndef COMBO_BUILD
+    // ComboShip: the connection UI is combo-native (comboui Anchor panel) in combo builds; hide soh's
+    // AnchorMainMenu so it's not duplicated. Admin/Instructions stay (Phases 2/3 replace them).
     SohGui::mSohMenu->AddWidget(path, "AnchorMainMenu", WIDGET_CUSTOM)
         .CustomFunction(AnchorMainMenu)
         .HideInSearch(true);
+#endif
     path.column = SECTION_COLUMN_2;
     SohGui::mSohMenu->AddWidget(path, "AnchorAdminMenu", WIDGET_CUSTOM)
         .CustomFunction(AnchorAdminMenu)

--- a/soh/soh/Network/Anchor/Menu.cpp
+++ b/soh/soh/Network/Anchor/Menu.cpp
@@ -256,9 +256,13 @@ void RegisterAnchorMenu() {
         .HideInSearch(true);
 #endif
     path.column = SECTION_COLUMN_2;
+#ifndef COMBO_BUILD
+    // ComboShip: room-admin UI is combo-native (comboui Anchor panel, Phase 2) in combo builds; hide
+    // soh's AnchorAdminMenu so it's not duplicated. Instructions stay (Phase 3 replaces them).
     SohGui::mSohMenu->AddWidget(path, "AnchorAdminMenu", WIDGET_CUSTOM)
         .CustomFunction(AnchorAdminMenu)
         .HideInSearch(true);
+#endif
     SohGui::mSohMenu->AddWidget(path, "AnchorInstructionsMenu", WIDGET_CUSTOM)
         .CustomFunction(AnchorInstructionsMenu)
         .HideInSearch(true);

--- a/soh/soh/Network/Anchor/Menu.cpp
+++ b/soh/soh/Network/Anchor/Menu.cpp
@@ -250,22 +250,26 @@ void RegisterAnchorMenu() {
     WidgetPath path = { "Network", "Anchor", SECTION_COLUMN_1 };
 #ifndef COMBO_BUILD
     // ComboShip: the connection UI is combo-native (comboui Anchor panel) in combo builds; hide soh's
-    // AnchorMainMenu so it's not duplicated. Admin/Instructions stay (Phases 2/3 replace them).
+    // AnchorMainMenu so it's not duplicated. Admin/Instructions stay (combo replaces them).
     SohGui::mSohMenu->AddWidget(path, "AnchorMainMenu", WIDGET_CUSTOM)
         .CustomFunction(AnchorMainMenu)
         .HideInSearch(true);
 #endif
     path.column = SECTION_COLUMN_2;
 #ifndef COMBO_BUILD
-    // ComboShip: room-admin UI is combo-native (comboui Anchor panel, Phase 2) in combo builds; hide
-    // soh's AnchorAdminMenu so it's not duplicated. Instructions stay (Phase 3 replaces them).
+    // ComboShip: room-admin UI is combo-native (comboui Anchor panel) in combo builds; hide
+    // soh's AnchorAdminMenu so it's not duplicated. Instructions stay (combo replaces them).
     SohGui::mSohMenu->AddWidget(path, "AnchorAdminMenu", WIDGET_CUSTOM)
         .CustomFunction(AnchorAdminMenu)
         .HideInSearch(true);
 #endif
+#ifndef COMBO_BUILD
+    // ComboShip: the entire Anchor UI is combo-native (comboui panel + room window) in combo builds;
+    // hide soh's Instructions too so the combo panels are the sole Anchor UI.
     SohGui::mSohMenu->AddWidget(path, "AnchorInstructionsMenu", WIDGET_CUSTOM)
         .CustomFunction(AnchorInstructionsMenu)
         .HideInSearch(true);
+#endif
 }
 
 static RegisterMenuInitFunc menuInitFunc(RegisterAnchorMenu);

--- a/soh/soh/Network/Anchor/Packets/UpdateTeamState.cpp
+++ b/soh/soh/Network/Anchor/Packets/UpdateTeamState.cpp
@@ -4,6 +4,9 @@
 #include "soh/OTRGlobals.h"
 #include "soh/Notification/Notification.h"
 #include "soh/Enhancements/randomizer/randomizer.h"
+#ifdef COMBO_BUILD
+#include "rando/ComboAnchorToast.h" // shared cross-game resync-toast debounce
+#endif
 
 extern "C" {
 #include "variables.h"
@@ -318,9 +321,17 @@ void Anchor::HandlePacket_UpdateTeamState(nlohmann::json payload) {
             // }
         }
 
+#ifdef COMBO_BUILD
+        // ComboShip: OOT and MM each request a resync (connect/manual), and the server answers each, so
+        // collapse the burst to ONE toast across BOTH games via a shared-CVar timestamp (per-DLL statics
+        // can't dedup a cross-game OOT+MM pair).
+        if (ComboAnchor_ShouldToastResync())
+            Notification::Emit({ .message = "Save updated from team" });
+#else
         Notification::Emit({
             .message = "Save updated from team",
         });
+#endif
     }
 
     if (payload.contains("queue")) {

--- a/soh/soh/Network/Anchor/Packets/UpdateTeamState.cpp
+++ b/soh/soh/Network/Anchor/Packets/UpdateTeamState.cpp
@@ -180,7 +180,8 @@ void Anchor::HandlePacket_UpdateTeamState(nlohmann::json payload) {
             }
 
             gSaveContext.sceneFlags[i] = loadedData.sceneFlags[i];
-            if (IsSaveLoaded() && gPlayState->sceneNum == i) {
+            // ComboShip: dormant apply's IsSaveLoaded() is true from fileNum alone; gPlayState is null.
+            if (IsSaveLoaded() && gPlayState != NULL && gPlayState->sceneNum == i) {
                 gPlayState->actorCtx.flags.chest = loadedData.sceneFlags[i].chest;
                 gPlayState->actorCtx.flags.swch = loadedData.sceneFlags[i].swch;
                 gPlayState->actorCtx.flags.clear = loadedData.sceneFlags[i].clear;
@@ -325,8 +326,11 @@ void Anchor::HandlePacket_UpdateTeamState(nlohmann::json payload) {
         // ComboShip: OOT and MM each request a resync (connect/manual), and the server answers each, so
         // collapse the burst to ONE toast across BOTH games via a shared-CVar timestamp (per-DLL statics
         // can't dedup a cross-game OOT+MM pair).
-        if (ComboAnchor_ShouldToastResync())
+        if (isDormantApply) {
+            dormantDidApply = true; // let PumpDormant persist; no toast for a backgrounded apply
+        } else if (ComboAnchor_ShouldToastResync()) {
             Notification::Emit({ .message = "Save updated from team" });
+        }
 #else
         Notification::Emit({
             .message = "Save updated from team",

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -104,6 +104,8 @@
 #include "soh/Network/CrowdControl/CrowdControl.h"
 #include "soh/Network/Sail/Sail.h"
 #include "soh/Network/Anchor/Anchor.h"
+#include "soh/util.h"                                // ComboShip: SohUtils::GetSceneName for the Anchor roster export
+#include "soh/Enhancements/randomizer/SeedContext.h" // ComboShip: Rando::Context::GetSeed for roster seed-mismatch
 #include "Enhancements/game-interactor/GameInteractor.h"
 #include "Enhancements/randomizer/draw.h"
 #include <libultraship/controller/controldeck/ControlDeck.h>
@@ -2844,7 +2846,7 @@ extern "C" __declspec(dllexport) int SOH_Anchor_GetConnectionState(void) {
     return (Anchor::Instance->isEnabled ? 1 : 0) | (Anchor::Instance->isConnected ? 2 : 0);
 }
 
-// ComboShip: owner-gating for the combo panel's room-admin section (Phase 2). bit0=isOwner,
+// ComboShip: owner-gating for the combo panel's room-admin section. bit0=isOwner,
 // bit1=isGlobalRoom. 0 if Anchor not connected. Mirrors AnchorAdminMenu's gate.
 extern "C" __declspec(dllexport) int SOH_Anchor_GetOwnerInfo(void) {
     try {
@@ -2890,6 +2892,80 @@ extern "C" __declspec(dllexport) void SOH_Anchor_ClearTeamState(void) {
         }
     } catch (const std::exception& e) { SPDLOG_ERROR("[SOH_Anchor_ClearTeamState] {}", e.what()); } catch (...) {
         SPDLOG_ERROR("[SOH_Anchor_ClearTeamState] unknown exception");
+    }
+}
+
+// ComboShip: authoritative roster snapshot for the combo-native room window. soh's Anchor
+// holds every client (both games) with rich fields; OOT resolves its OWN players' scene names here.
+// MM peers (namespaced sceneNum >= 1000) get game="mm" with an empty areaName that MM_Anchor_GetRoster
+// fills in by clientId. Cached std::string -> c_str() (single-call-safe, like the other dumps).
+extern "C" __declspec(dllexport) const char* SOH_Anchor_GetRoster(void) {
+    static std::string cached;
+    try {
+        nlohmann::json arr = nlohmann::json::array();
+        auto anchor = Anchor::Instance;
+        if (anchor) {
+            std::string ownTeamId = CVarGetString(CVAR_REMOTE_ANCHOR("TeamId"), "default");
+            uint32_t ownSeed = IS_RANDO ? Rando::Context::GetInstance()->GetSeed() : 0;
+            u8 showLoc = anchor->roomState.showLocationsMode;
+            bool ownSaveLoaded = anchor->IsSaveLoaded();
+            for (auto& [clientId, client] : anchor->clients) {
+                bool mm = client.sceneNum >= 1000; // MM namespaces its scene id so it can't collide with OOT
+                bool saveLoaded = client.self ? ownSaveLoaded : client.isSaveLoaded;
+                bool isOwnTeam = client.teamId == ownTeamId;
+                bool areaVisible = saveLoaded && (showLoc == 2 || (showLoc == 1 && isOwnTeam));
+
+                std::string areaName;
+                if (areaVisible && !mm) {
+                    s16 sceneNum = (client.self && gPlayState) ? gPlayState->sceneNum : client.sceneNum;
+                    if (sceneNum >= 0 && sceneNum < 1000) {
+                        areaName = SohUtils::GetSceneName(sceneNum);
+                    }
+                }
+
+                // Seed comparison is only meaningful within OOT; MM peers report an MM-side seed (cross-game
+                // seed verification is out of scope), so suppress it for them (mirrors AnchorRoomWindow).
+                bool seedMismatch = !mm && !client.self && client.online && client.isSaveLoaded && ownSaveLoaded &&
+                                    client.seed != ownSeed;
+
+                nlohmann::json e;
+                e["clientId"] = clientId;
+                e["name"] = client.self ? std::string(CVarGetString(CVAR_REMOTE_ANCHOR("Name"), "")) : client.name;
+                e["color"] = { { "r", client.color.r }, { "g", client.color.g }, { "b", client.color.b } };
+                e["teamId"] = client.teamId;
+                e["online"] = client.online;
+                e["self"] = client.self;
+                e["game"] = mm ? "mm" : "oot";
+                e["isOwner"] = client.clientId == anchor->roomState.ownerClientId;
+                e["isSaveLoaded"] = saveLoaded;
+                e["isGameComplete"] = client.isGameComplete;
+                e["areaVisible"] = areaVisible;
+                e["areaName"] = areaName;
+                e["versionMismatch"] = !client.self && client.clientVersion != Anchor::clientVersion;
+                e["seedMismatch"] = seedMismatch;
+                arr.push_back(e);
+            }
+        }
+        cached = arr.dump();
+    } catch (const std::exception& e) {
+        SPDLOG_ERROR("[SOH_Anchor_GetRoster] {}", e.what());
+        cached = "[]";
+    } catch (...) {
+        SPDLOG_ERROR("[SOH_Anchor_GetRoster] unknown exception");
+        cached = "[]";
+    }
+    return cached.c_str();
+}
+
+// ComboShip: same-game teleport trigger for the combo room window (OOT active + OOT peer).
+// Wraps SendPacket_RequestTeleport, which re-validates via CanTeleportTo and no-ops if disallowed.
+extern "C" __declspec(dllexport) void SOH_Anchor_RequestTeleport(uint32_t clientId) {
+    try {
+        if (Anchor::Instance) {
+            Anchor::Instance->SendPacket_RequestTeleport(clientId);
+        }
+    } catch (const std::exception& e) { SPDLOG_ERROR("[SOH_Anchor_RequestTeleport] {}", e.what()); } catch (...) {
+        SPDLOG_ERROR("[SOH_Anchor_RequestTeleport] unknown exception");
     }
 }
 

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -2844,6 +2844,55 @@ extern "C" __declspec(dllexport) int SOH_Anchor_GetConnectionState(void) {
     return (Anchor::Instance->isEnabled ? 1 : 0) | (Anchor::Instance->isConnected ? 2 : 0);
 }
 
+// ComboShip: owner-gating for the combo panel's room-admin section (Phase 2). bit0=isOwner,
+// bit1=isGlobalRoom. 0 if Anchor not connected. Mirrors AnchorAdminMenu's gate.
+extern "C" __declspec(dllexport) int SOH_Anchor_GetOwnerInfo(void) {
+    try {
+        auto anchor = Anchor::Instance;
+        if (!anchor || !anchor->isEnabled || !anchor->isConnected) {
+            return 0;
+        }
+        bool isOwner = anchor->roomState.ownerClientId == anchor->ownClientId;
+        bool isGlobalRoom = std::string("soh-global") == CVarGetString(CVAR_REMOTE_ANCHOR("RoomId"), "");
+        return (isOwner ? 1 : 0) | (isGlobalRoom ? 2 : 0);
+    } catch (const std::exception& e) {
+        SPDLOG_ERROR("[SOH_Anchor_GetOwnerInfo] {}", e.what());
+        return 0;
+    } catch (...) {
+        SPDLOG_ERROR("[SOH_Anchor_GetOwnerInfo] unknown exception");
+        return 0;
+    }
+}
+
+// ComboShip: broadcast the RoomSettings.* CVar changes made in the combo admin panel to the room.
+extern "C" __declspec(dllexport) void SOH_Anchor_SendRoomState(void) {
+    try {
+        if (Anchor::Instance) {
+            Anchor::Instance->SendPacket_UpdateRoomState();
+        }
+    } catch (const std::exception& e) { SPDLOG_ERROR("[SOH_Anchor_SendRoomState] {}", e.what()); } catch (...) {
+        SPDLOG_ERROR("[SOH_Anchor_SendRoomState] unknown exception");
+    }
+}
+
+// ComboShip: clear team state for every team present in the room (mirrors AnchorAdminMenu's button).
+extern "C" __declspec(dllexport) void SOH_Anchor_ClearTeamState(void) {
+    try {
+        if (!Anchor::Instance) {
+            return;
+        }
+        std::set<std::string> teams;
+        for (auto& [clientId, client] : Anchor::Instance->clients) {
+            teams.insert(client.teamId);
+        }
+        for (auto& team : teams) {
+            Anchor::Instance->SendPacket_ClearTeamState(team);
+        }
+    } catch (const std::exception& e) { SPDLOG_ERROR("[SOH_Anchor_ClearTeamState] {}", e.what()); } catch (...) {
+        SPDLOG_ERROR("[SOH_Anchor_ClearTeamState] unknown exception");
+    }
+}
+
 // ComboShip: cross-game item delivery seam (issue #3). When the other game collects a check whose
 // item belongs to OOT, the launcher calls SOH_GrantCrossItem to grant it straight into OOT's
 // resident save — even when OOT is the dormant (frozen) game. We use Randomizer_Item_Give, which

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -2895,64 +2895,14 @@ extern "C" __declspec(dllexport) void SOH_Anchor_ClearTeamState(void) {
     }
 }
 
-// ComboShip: authoritative roster snapshot for the combo-native room window. soh's Anchor
-// holds every client (both games) with rich fields; OOT resolves its OWN players' scene names here.
-// MM peers (namespaced sceneNum >= 1000) get game="mm" with an empty areaName that MM_Anchor_GetRoster
-// fills in by clientId. Cached std::string -> c_str() (single-call-safe, like the other dumps).
-extern "C" __declspec(dllexport) const char* SOH_Anchor_GetRoster(void) {
+// ComboShip: stateless OOT scene-name lookup for the combo room window. The launcher owns the roster
+// now; comboui resolves each OOT peer's area name from its raw scene id via this (works while dormant).
+extern "C" __declspec(dllexport) const char* SOH_Anchor_ResolveScene(int sceneId) {
     static std::string cached;
-    try {
-        nlohmann::json arr = nlohmann::json::array();
-        auto anchor = Anchor::Instance;
-        if (anchor) {
-            std::string ownTeamId = CVarGetString(CVAR_REMOTE_ANCHOR("TeamId"), "default");
-            uint32_t ownSeed = IS_RANDO ? Rando::Context::GetInstance()->GetSeed() : 0;
-            u8 showLoc = anchor->roomState.showLocationsMode;
-            bool ownSaveLoaded = anchor->IsSaveLoaded();
-            for (auto& [clientId, client] : anchor->clients) {
-                bool mm = client.sceneNum >= 1000; // MM namespaces its scene id so it can't collide with OOT
-                bool saveLoaded = client.self ? ownSaveLoaded : client.isSaveLoaded;
-                bool isOwnTeam = client.teamId == ownTeamId;
-                bool areaVisible = saveLoaded && (showLoc == 2 || (showLoc == 1 && isOwnTeam));
-
-                std::string areaName;
-                if (areaVisible && !mm) {
-                    s16 sceneNum = (client.self && gPlayState) ? gPlayState->sceneNum : client.sceneNum;
-                    if (sceneNum >= 0 && sceneNum < 1000) {
-                        areaName = SohUtils::GetSceneName(sceneNum);
-                    }
-                }
-
-                // Seed comparison is only meaningful within OOT; MM peers report an MM-side seed (cross-game
-                // seed verification is out of scope), so suppress it for them (mirrors AnchorRoomWindow).
-                bool seedMismatch = !mm && !client.self && client.online && client.isSaveLoaded && ownSaveLoaded &&
-                                    client.seed != ownSeed;
-
-                nlohmann::json e;
-                e["clientId"] = clientId;
-                e["name"] = client.self ? std::string(CVarGetString(CVAR_REMOTE_ANCHOR("Name"), "")) : client.name;
-                e["color"] = { { "r", client.color.r }, { "g", client.color.g }, { "b", client.color.b } };
-                e["teamId"] = client.teamId;
-                e["online"] = client.online;
-                e["self"] = client.self;
-                e["game"] = mm ? "mm" : "oot";
-                e["isOwner"] = client.clientId == anchor->roomState.ownerClientId;
-                e["isSaveLoaded"] = saveLoaded;
-                e["isGameComplete"] = client.isGameComplete;
-                e["areaVisible"] = areaVisible;
-                e["areaName"] = areaName;
-                e["versionMismatch"] = !client.self && client.clientVersion != Anchor::clientVersion;
-                e["seedMismatch"] = seedMismatch;
-                arr.push_back(e);
-            }
-        }
-        cached = arr.dump();
-    } catch (const std::exception& e) {
-        SPDLOG_ERROR("[SOH_Anchor_GetRoster] {}", e.what());
-        cached = "[]";
-    } catch (...) {
-        SPDLOG_ERROR("[SOH_Anchor_GetRoster] unknown exception");
-        cached = "[]";
+    if (sceneId >= 0 && sceneId < 1000) {
+        cached = SohUtils::GetSceneName(sceneId);
+    } else {
+        cached = "";
     }
     return cached.c_str();
 }

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -2815,6 +2815,35 @@ extern "C" __declspec(dllexport) void SOH_Anchor_RequestResync(void) {
     }
 }
 
+// ComboShip: combo-native Anchor connection panel drives Enable/Disable (soh's own menu is hidden in
+// combo). Mirrors Menu.cpp's Enable/Disable path incl. the Enabled CVar write.
+extern "C" __declspec(dllexport) void SOH_Anchor_SetEnabled(int enabled) {
+    try {
+        if (!Anchor::Instance) {
+            return;
+        }
+        if (enabled) {
+            CVarSetInteger(CVAR_REMOTE_ANCHOR("Enabled"), 1);
+            Ship::Context::GetRawInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+            Anchor::Instance->Enable();
+        } else {
+            CVarClear(CVAR_REMOTE_ANCHOR("Enabled"));
+            Ship::Context::GetRawInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+            Anchor::Instance->Disable();
+        }
+    } catch (const std::exception& e) { SPDLOG_ERROR("[SOH_Anchor_SetEnabled] {}", e.what()); } catch (...) {
+        SPDLOG_ERROR("[SOH_Anchor_SetEnabled] unknown exception");
+    }
+}
+
+// ComboShip: connection state for the combo panel status line/gating. bit0=isEnabled, bit1=isConnected.
+extern "C" __declspec(dllexport) int SOH_Anchor_GetConnectionState(void) {
+    if (!Anchor::Instance) {
+        return 0;
+    }
+    return (Anchor::Instance->isEnabled ? 1 : 0) | (Anchor::Instance->isConnected ? 2 : 0);
+}
+
 // ComboShip: cross-game item delivery seam (issue #3). When the other game collects a check whose
 // item belongs to OOT, the launcher calls SOH_GrantCrossItem to grant it straight into OOT's
 // resident save — even when OOT is the dormant (frozen) game. We use Randomizer_Item_Give, which

--- a/soh/soh/SohGui/SohGui.cpp
+++ b/soh/soh/SohGui/SohGui.cpp
@@ -202,8 +202,11 @@ void SetupGuiElements() {
     mNotificationWindow->Show();
     mTimeDisplayWindow = std::make_shared<TimeDisplayWindow>(CVAR_WINDOW("TimeDisplayEnabled"), "Additional Timers");
     gui->AddGuiWindow(mTimeDisplayWindow);
+#ifndef COMBO_BUILD
+    // ComboShip: the Anchor room window is combo-native (comboui) in combo builds; don't register soh's.
     mAnchorRoomWindow = std::make_shared<AnchorRoomWindow>(CVAR_WINDOW("AnchorRoom"), "Anchor Room");
     gui->AddGuiWindow(mAnchorRoomWindow);
+#endif
 }
 
 void Destroy() {


### PR DESCRIPTION
Re-target of #75 to develop. #75 was merged into the plandomizer branch (its stacked base) rather than develop, so the Anchor work never reached develop. The plando work is already in develop via #74; this PR adds only the Anchor commits on top.

## UI (combo-native, in the Combo > Network group)
- Anchor panel: connection settings, Enable/Disable, live status, Restore Defaults / Global Room, both-games Resync — driving the shared `gRemote.Anchor.*` CVars. Owner-only Room Settings in a second column. Team Sync + Room Window shown only when enabled.
- Floating room window: every teammate once, grouped by team, each with their real area name (resolved by their own game — fixes the cross-game "Majora's Mask" placeholder), owner/offline/version-mismatch indicators, same-game-only teleport. Hidden when disconnected.
- Remote players' name tags use each player's Anchor color. soh's Anchor menus/room window hidden in combo builds; standalone SoH unchanged.

## Roster / networking
- The launcher parses presence/room packets on its never-dormant thread into one always-live roster (exposed to comboui via a register-time getter), fixing dormant-staleness (peers showing offline / blank areas by foreground game). Per-game GetRoster exports removed; area names via stateless `SOH_/MM_Anchor_ResolveScene`.
- Team-state resync now applies + persists to the dormant game's save on reconnect (both directions).
- Resync toasts collapse to one via a shared cross-game debounce; the self roster row tracks the local player's live scene.

Vendored soh/mm changes are COMBO_BUILD-guarded (network adapters). Playtested end-to-end with two clients.

<!--- section:artifacts:start -->
### Build Artifacts
  - [comborando-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8424178434.zip)
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8424177904.zip)
<!--- section:artifacts:end -->