### PR TITLE
Combo rando: fix BEATABLE_ONLY seeds never generating

### DIFF
--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -723,7 +723,7 @@ static void SetActiveGame(int game /* 0 = OOT, 1 = MM */) {
 // Grants into the TARGET game's resident save via its save-only export (target is usually the
 // dormant game, so its save isn't mutating underneath us). See docs/deviations/rando.md.
 static std::set<std::string> sAppliedCrossChecks; // dedup: the same wire packet can reach both DLLs
-static uint32_t sCrossItemDedupSeed = 0;           // scoped per-seed (ResetCrossItemDedupForSeed)
+static uint32_t sCrossItemDedupSeed = 0;          // scoped per-seed (ResetCrossItemDedupForSeed)
 // Reset runs on the generation worker; deliver runs on the game thread — both mutate the set.
 static std::mutex sAppliedCrossChecksMutex;
 

--- a/combo/rando/ComboPlaythrough.h
+++ b/combo/rando/ComboPlaythrough.h
@@ -335,7 +335,7 @@ inline PlaythroughResult RunPlaythrough(const std::string& spoilerJson, const Or
                                         const OracleFns& mmOracle, const std::string& seedLabel, void (*mmRestore)(),
                                         nlohmann::json* playthroughOut = nullptr, const std::string& sohDumpJson = "",
                                         const std::string& mmDumpJson = "") {
-    static const char* kOotGanon = "Ganon"; // RC_GANON reachable = OOT beatable (see CrossWorldRando.h)
+    static const char* kOotGanon = "Ganon";           // RC_GANON reachable = OOT beatable (see CrossWorldRando.h)
     static const char* kMmWin = "Moon Majora Pot 01"; // ComboShip: friendly form of RC_MOON_MAJORA_POT_01
 
     PlaythroughResult result;

--- a/combo/rando/ComboPlaythrough.h
+++ b/combo/rando/ComboPlaythrough.h
@@ -157,7 +157,7 @@ inline ReachSet QueryReachableMemo(const OracleFns& o, const std::vector<std::st
     return reach;
 }
 
-// Default win condition: OOT tower-top + Boss Key owned (Ganon) AND MM's in-lair check (Majora).
+// Default win condition: RC_GANON reachable (OOT) AND MM's in-lair check (Majora).
 // A pluggable goal so a future goal (e.g. Triforce hunt) can be swapped in without touching the
 // traversal machinery below.
 using GoalPredicate =
@@ -165,14 +165,11 @@ using GoalPredicate =
                        const std::vector<std::string>& ownedOot)>;
 inline bool DefaultGanonMajoraGoal(const std::unordered_set<std::string>& ootReach,
                                    const std::unordered_set<std::string>& mmReach,
-                                   const std::vector<std::string>& ownedOot) {
-    static const char* kOotTowerTop = "Ganon's Castle Tower Boss Key Chest";
-    static const char* kOotBossKey = "Ganon's Castle Boss Key";
+                                   const std::vector<std::string>& /*ownedOot*/) {
+    // RC_GANON reachable = OOT beatable (bridge + boss key, placed or force-granted); see CrossWorldRando.h.
+    static const char* kOotGanon = "Ganon";
     static const char* kMmWin = "Moon Majora Pot 01"; // ComboShip: friendly form of RC_MOON_MAJORA_POT_01
-    bool canGanon =
-        ootReach.count(kOotTowerTop) > 0 && std::find(ownedOot.begin(), ownedOot.end(), kOotBossKey) != ownedOot.end();
-    bool canMajora = mmReach.count(kMmWin) > 0;
-    return canGanon && canMajora;
+    return ootReach.count(kOotGanon) > 0 && mmReach.count(kMmWin) > 0;
 }
 
 // NO_LOGIC goal: OOT may be structurally unbeatable from empty (the combined goal would degenerate and
@@ -181,7 +178,7 @@ inline bool DefaultGanonMajoraGoal(const std::unordered_set<std::string>& ootRea
 inline bool MmOnlyMajoraGoal(const std::unordered_set<std::string>& /*ootReach*/,
                              const std::unordered_set<std::string>& mmReach,
                              const std::vector<std::string>& /*ownedOot*/) {
-    static const char* kMmWin = "RC_MOON_MAJORA_POT_01";
+    static const char* kMmWin = "Moon Majora Pot 01"; // friendly name the MM oracle returns (not raw RC_)
     return mmReach.count(kMmWin) > 0;
 }
 
@@ -338,8 +335,7 @@ inline PlaythroughResult RunPlaythrough(const std::string& spoilerJson, const Or
                                         const OracleFns& mmOracle, const std::string& seedLabel, void (*mmRestore)(),
                                         nlohmann::json* playthroughOut = nullptr, const std::string& sohDumpJson = "",
                                         const std::string& mmDumpJson = "") {
-    static const char* kOotTowerTop = "Ganon's Castle Tower Boss Key Chest";
-    static const char* kOotBossKey = "Ganon's Castle Boss Key";
+    static const char* kOotGanon = "Ganon"; // RC_GANON reachable = OOT beatable (see CrossWorldRando.h)
     static const char* kMmWin = "Moon Majora Pot 01"; // ComboShip: friendly form of RC_MOON_MAJORA_POT_01
 
     PlaythroughResult result;
@@ -353,7 +349,7 @@ inline PlaythroughResult RunPlaythrough(const std::string& spoilerJson, const Or
     std::unordered_set<std::string> collected; // "<cg>:<cn>"
     std::ostringstream log;
     log << "Cross-world playthrough - seed '" << seedLabel << "'\n"
-        << "Beatable when: Ganondorf reachable (OOT: tower top reachable + Boss Key owned)"
+        << "Beatable when: Ganon reachable (OOT: RC_GANON, i.e. bridge + boss key)"
         << " AND Majora's Lair reachable (MM).\n\n";
 
     int beatableSphere = -1;
@@ -361,8 +357,7 @@ inline PlaythroughResult RunPlaythrough(const std::string& spoilerJson, const Or
     for (int sphere = 0; sphere < kMaxSpheres; ++sphere) {
         auto ootReach = queryReachable(ootOracle, ownedOot);
         auto mmReach = queryReachable(mmOracle, ownedMm);
-        bool canGanon = ootReach.count(kOotTowerTop) > 0 &&
-                        std::find(ownedOot.begin(), ownedOot.end(), kOotBossKey) != ownedOot.end();
+        bool canGanon = ootReach.count(kOotGanon) > 0;
         bool canMajora = mmReach.count(kMmWin) > 0;
         if (canGanon && canMajora) {
             beatableSphere = sphere;
@@ -414,8 +409,7 @@ inline PlaythroughResult RunPlaythrough(const std::string& spoilerJson, const Or
         (p.itemGame == GAME_OOT ? allOot : allMm).push_back(p.item);
     auto everReachOot = queryReachable(ootOracle, allOot);
     auto everReachMm = queryReachable(mmOracle, allMm);
-    result.ganonReachable =
-        everReachOot.count(kOotTowerTop) > 0 && std::find(allOot.begin(), allOot.end(), kOotBossKey) != allOot.end();
+    result.ganonReachable = everReachOot.count(kOotGanon) > 0;
     result.majoraReachable = everReachMm.count(kMmWin) > 0;
 
     if (mmRestore)

--- a/combo/rando/CrossWorldRando.h
+++ b/combo/rando/CrossWorldRando.h
@@ -536,7 +536,7 @@ inline CombinedFillResult CrossWorldCombinedFill(const std::string& sohDumpJson,
             // On UNBEATABLE, name which side blocked (ganon/majora) so a future win-marker rename or
             // logic regression is self-diagnosing instead of a silent all-passes-fail.
             std::string goalStr = ootAccess != OotAccess::BEATABLE_ONLY ? ""
-                                  : goalOk ? " goal=ok"
+                                  : goalOk                              ? " goal=ok"
                                            : " goal=UNBEATABLE(ganon=" + std::to_string(ootWin) +
                                                  " majora=" + std::to_string(mmWin) + ")";
             std::cerr << "[ComboShip] CrossWorldCombinedFill: validation failed — mmAdvUnreachable=" << mmAdvUnreachable

--- a/combo/rando/CrossWorldRando.h
+++ b/combo/rando/CrossWorldRando.h
@@ -536,9 +536,9 @@ inline CombinedFillResult CrossWorldCombinedFill(const std::string& sohDumpJson,
             // On UNBEATABLE, name which side blocked (ganon/majora) so a future win-marker rename or
             // logic regression is self-diagnosing instead of a silent all-passes-fail.
             std::string goalStr = ootAccess != OotAccess::BEATABLE_ONLY ? ""
-                                  : goalOk                              ? " goal=ok"
-                                         : " goal=UNBEATABLE(ganon=" + std::to_string(ootWin) + " majora=" +
-                                               std::to_string(mmWin) + ")";
+                                  : goalOk ? " goal=ok"
+                                           : " goal=UNBEATABLE(ganon=" + std::to_string(ootWin) +
+                                                 " majora=" + std::to_string(mmWin) + ")";
             std::cerr << "[ComboShip] CrossWorldCombinedFill: validation failed — mmAdvUnreachable=" << mmAdvUnreachable
                       << " ootAdvUnreachable=" << ootAdvUnreachable << goalStr << " (pass " << pass << ", " << passMs()
                       << " ms) — retrying\n";

--- a/combo/rando/CrossWorldRando.h
+++ b/combo/rando/CrossWorldRando.h
@@ -524,22 +524,24 @@ inline CombinedFillResult CrossWorldCombinedFill(const std::string& sohDumpJson,
         // BEATABLE_ONLY additionally requires the win still holds (mirrors DefaultGanonMajoraGoal;
         // duplicated here to keep this header free of ComboPlaythrough.h). NO_LOGIC accepts an
         // OOT-unbeatable seed; MM stays reachable+beatable regardless.
-        auto beatableGoal = [&]() {
-            static const char* kOotTowerTop = "Ganon's Castle Tower Boss Key Chest";
-            static const char* kOotBossKey = "Ganon's Castle Boss Key";
-            static const char* kMmWin = "RC_MOON_MAJORA_POT_01";
-            return ootFinal.count(kOotTowerTop) > 0 &&
-                   std::find(vf.ootOwned.begin(), vf.ootOwned.end(), kOotBossKey) != vf.ootOwned.end() &&
-                   mmFinal.count(kMmWin) > 0;
-        };
-        bool goalOk = (ootAccess != OotAccess::BEATABLE_ONLY) || beatableGoal();
+        // RC_GANON reachable = OOT beatable: its region logic gates on bridge + boss key (placed OR
+        // force-granted), correct for every GBK/bridge mode — unlike the old tower-chest proxy (held a
+        // random item, could be unreachable). Names are the friendly forms the OOT/MM oracles return.
+        const bool ootWin = ootFinal.count("Ganon") > 0;
+        const bool mmWin = mmFinal.count("Moon Majora Pot 01") > 0;
+        bool goalOk = (ootAccess != OotAccess::BEATABLE_ONLY) || (ootWin && mmWin);
         bool needRetry = mmAdvUnreachable > 0 || (ootAccess == OotAccess::ALL_REACHABLE && ootAdvUnreachable > 0) ||
                          (ootAccess == OotAccess::BEATABLE_ONLY && !goalOk);
         if (needRetry) {
+            // On UNBEATABLE, name which side blocked (ganon/majora) so a future win-marker rename or
+            // logic regression is self-diagnosing instead of a silent all-passes-fail.
+            std::string goalStr = ootAccess != OotAccess::BEATABLE_ONLY ? ""
+                                  : goalOk                              ? " goal=ok"
+                                         : " goal=UNBEATABLE(ganon=" + std::to_string(ootWin) + " majora=" +
+                                               std::to_string(mmWin) + ")";
             std::cerr << "[ComboShip] CrossWorldCombinedFill: validation failed — mmAdvUnreachable=" << mmAdvUnreachable
-                      << " ootAdvUnreachable=" << ootAdvUnreachable
-                      << (ootAccess == OotAccess::BEATABLE_ONLY ? (goalOk ? " goal=ok" : " goal=UNBEATABLE") : "")
-                      << " (pass " << pass << ", " << passMs() << " ms) — retrying\n";
+                      << " ootAdvUnreachable=" << ootAdvUnreachable << goalStr << " (pass " << pass << ", " << passMs()
+                      << " ms) — retrying\n";
             continue;
         }
         if (ootAdvUnreachable > 0)


### PR DESCRIPTION
## Problem
Cross-world seeds with beatable-only accessibility (`AllLocationsReachable=0` → `BEATABLE_ONLY` mode) never generated — the fill retried every pass and gave up with `goal=UNBEATABLE`. Affected every such config since PR #72.

## Cause
The win check was wrong on both sides:
- **OOT:** required `Ganon's Castle Tower Boss Key Chest` reachable + boss key owned. That chest holds a *random shuffled item* (often junk, which the fill tolerates as unreachable) and doesn't exist in LACS boss-key modes (Rewards/Medallions/Stones/Tokens/Dungeons/Triforce).
- **MM:** matched the raw enum `RC_MOON_MAJORA_POT_01`, but the MM oracle returns the friendly name `Moon Majora Pot 01` — so the MM clause was always false on its own.

## Fix
Use `RC_GANON` reachability (`"Ganon"`) as the OOT beatability signal — OOT's region logic already gates the Ganon arena on the boss key (placed or force-granted), correct for every boss-key/bridge mode — plus the friendly MM check name. Applied to the fill goal (`CrossWorldRando.h`), the playthrough validator, and the pare-down (`ComboPlaythrough.h`). The `UNBEATABLE` retry log now names which side blocked (`ganon=x majora=y`).

## Verification
`comborando` (rebuilt to match the fill) generates the previously-failing config on pass 1, plus additional seeds; `--playthrough` independently confirms the result is beatable.

## Follow-ups (not in this PR)
- `RC_GANON` is necessary-but-not-sufficient for triforce-hunt win conditions (pre-existing limitation).
- No BEATABLE_ONLY smoke test in CI.

<!--- section:artifacts:start -->
### Build Artifacts
<!--- section:artifacts:end -->