### PR TITLE
Split mods folder into per-game mods/soh and mods/2ship

### DIFF
--- a/CMake/CPackProjectConfig.cmake
+++ b/CMake/CPackProjectConfig.cmake
@@ -12,7 +12,7 @@ endif()
 
 # ComboShip: the upstream default packs only the "2s2h" component (just 2ship.dll) — a leftover
 # from the vendored 2Ship project. The Windows ZIP must bundle the FULL combo runtime:
-#   combo = ComboShip.exe + libultraship.dll + comboui.dll + assets/ + readme.txt + mods/
+#   combo = ComboShip.exe + libultraship.dll + comboui.dll + assets/ + readme.txt + mods/soh + mods/2ship
 #   ship  = soh.dll  + soh.o2r  + gamecontrollerdb.txt
 #   2s2h  = 2ship.dll + 2ship.o2r
 # (oot.o2r / mm.o2r are ROM-derived and intentionally NOT packaged — testers extract their own.)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,8 +347,10 @@ endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows|NintendoSwitch|CafeOS")
     # ComboShip: the README is not shipped in the package (it's repo docs, not a runtime file).
-    install(CODE "file(MAKE_DIRECTORY \"\${CMAKE_INSTALL_PREFIX}/mods\")" COMPONENT combo)
-    install(CODE "file(TOUCH \"\${CMAKE_INSTALL_PREFIX}/mods/custom_mod_files_go_here.txt\")" COMPONENT combo)
+    install(CODE "file(MAKE_DIRECTORY \"\${CMAKE_INSTALL_PREFIX}/mods/soh\")" COMPONENT combo)
+    install(CODE "file(TOUCH \"\${CMAKE_INSTALL_PREFIX}/mods/soh/custom_mod_files_go_here.txt\")" COMPONENT combo)
+    install(CODE "file(MAKE_DIRECTORY \"\${CMAKE_INSTALL_PREFIX}/mods/2ship\")" COMPONENT combo)
+    install(CODE "file(TOUCH \"\${CMAKE_INSTALL_PREFIX}/mods/2ship/custom_mod_files_go_here.txt\")" COMPONENT combo)
 endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ ComboShip currently builds on **Windows** only. macOS and Linux support will ret
 
 ### Configure and build
 
-From the `Combo/` directory, configure once to generate the Visual Studio solution:
+From the repository root (the clone folder, which contains this README), configure once to generate the Visual Studio solution:
 
 ```powershell
 cmake -B build/x64 -A x64

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -339,10 +339,10 @@ bool PathTestCleanup(FILE* tfile) {
 
 void CheckAndCreateModFolder() {
     try {
-        std::string modsPath = Ship::Context::LocateFileAcrossAppDirs("mods", appShortName);
+        std::string modsPath = Ship::Context::LocateFileAcrossAppDirs("mods/" + appShortName, appShortName);
         if (!std::filesystem::exists(modsPath)) {
             // Create mods folder relative to app dir
-            modsPath = Ship::Context::GetPathRelativeToAppDirectory("mods", appShortName);
+            modsPath = Ship::Context::GetPathRelativeToAppDirectory("mods/" + appShortName, appShortName);
             std::string filePath = modsPath + "/custom_mod_files_go_here.txt";
             if (std::filesystem::create_directories(modsPath)) {
                 std::ofstream(filePath).close();

--- a/mm/2s2h/Enhancements/ModMenu/ModMenu.cpp
+++ b/mm/2s2h/Enhancements/ModMenu/ModMenu.cpp
@@ -131,7 +131,7 @@ void UpdateModFiles(bool init = false, bool reset = false) {
     unsupportedFiles.clear();
     filePaths.clear();
     bool changed = false;
-    std::string modsPath = Ship::Context::LocateFileAcrossAppDirs("mods", appShortName);
+    std::string modsPath = Ship::Context::LocateFileAcrossAppDirs("mods/" + appShortName, appShortName);
     std::map<std::string, std::string> tempMods;
     if (modsPath.length() > 0 && std::filesystem::exists(modsPath)) {
         std::vector<std::filesystem::path> enabledFiles;

--- a/soh/soh/Enhancements/mod_menu.cpp
+++ b/soh/soh/Enhancements/mod_menu.cpp
@@ -209,7 +209,7 @@ void UpdateModFiles(bool init = false, bool reset = false) {
     unsupportedFiles.clear();
     filePaths.clear();
     bool changed = false;
-    std::string modsPath = Ship::Context::LocateFileAcrossAppDirs("mods", appShortName);
+    std::string modsPath = Ship::Context::LocateFileAcrossAppDirs("mods/" + appShortName, appShortName);
     std::map<std::string, std::string> tempMods;
     if (modsPath.length() > 0 && std::filesystem::exists(modsPath)) {
         std::vector<std::filesystem::path> enabledFiles;

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -462,10 +462,10 @@ bool PathTestCleanup(FILE* tfile) {
 
 void CheckAndCreateModFolder() {
     try {
-        std::string modsPath = Ship::Context::LocateFileAcrossAppDirs("mods", appShortName);
+        std::string modsPath = Ship::Context::LocateFileAcrossAppDirs("mods/" + appShortName, appShortName);
         if (!std::filesystem::exists(modsPath)) {
             // Create mods folder relative to app dir
-            modsPath = Ship::Context::GetPathRelativeToAppDirectory("mods", appShortName);
+            modsPath = Ship::Context::GetPathRelativeToAppDirectory("mods/" + appShortName, appShortName);
             std::string filePath = modsPath + "/custom_mod_files_go_here.txt";
             if (std::filesystem::create_directories(modsPath)) {
                 std::ofstream(filePath).close();


### PR DESCRIPTION
Each game now scans its own mods subfolder (`"mods/" + appShortName`) instead of a shared `mods/`, so OOT and MM no longer load each other's mods and same-named mods don't conflict. Packaging creates both subfolders. No migration of a flat `mods/` (old mods are re-placed into the per-game subfolder).

Unplaytested — verify each game only lists/loads its own mods.

<!--- section:artifacts:start -->
### Build Artifacts
  - [comborando-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8617081505.zip)
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8617080975.zip)
<!--- section:artifacts:end -->