### PR TITLE
Gate combosave compatibility on a manual COMBO_RELEASE_VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,28 +7,12 @@ set(CMAKE_C_STANDARD 23 CACHE STRING "The C standard to use")
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version")
 
 # ── ComboShip version ─────────────────────────────────────────────────────────
-# Derived so that every upstream merge automatically yields a new build version,
-# which trips SoH's stale-rando-save gate (SaveManager::StartupCheckAndInitMeta
-# compares the full major.minor.patch triple) and renames format-incompatible
-# pre-merge rando saves to .bak instead of crashing on a shifted save enum.
-#
-#   MAJOR = COMBO_EPOCH   manual. Bump by hand for ComboShip-owned breaks (save
-#                         fields we add, Anchor protocol) AND for releases that must
-#                         force o2r/asset re-extraction — the o2r gate is MAJOR-only
-#                         (OTRGlobals::VerifyArchiveVersion, mm BenPort.cpp).
-#   MINOR = f(soh pin)    first 4 hex of upstream-pins.json soh.mergedSha (0..0xFFFF).
-#   PATCH = f(mm pin)     first 4 hex of upstream-pins.json mm.mergedSha  (0..0xFFFF).
-#
-# So a soh merge changes MINOR, an mm merge changes PATCH, and either invalidates
-# pre-merge rando saves with no manual step. The numeric triple is intentionally
-# opaque; the human-readable label lives in PROJECT_BUILD_NAME (below, shown in-game
-# via gBuildVersion) and the package filename. See docs/UPSTREAM_MERGES.md.
-set(COMBO_EPOCH 1)  # ← bump by hand for ComboShip-owned breaks / o2r-forcing releases
+# Pin-derived major.minor.patch: diagnostics/banner only (the o2r gate is MAJOR-only).
+# See docs/UPSTREAM_MERGES.md.
+set(COMBO_EPOCH 1)  # ← bump for ComboShip-owned breaks / o2r-forcing releases
 
-# COMBO_RELEASE_VERSION: manual release identity; SOLE authority for combosave compatibility (gated
-# at the launcher container level, see combo/ComboShip.cpp). The pin-derived triple below is
-# diagnostics/banner only. Bump rule: patch = combo-side changes; minor = one game's upstream release
-# (counter); major = both games synced to upstream (resets minor).
+# Manual release identity; SOLE authority for combosave compat (gated in combo/ComboShip.cpp).
+# See docs/UPSTREAM_MERGES.md for the bump rule.
 set(COMBO_RELEASE_VERSION "0.1.1" CACHE STRING "ComboShip release version (manual; gates combosave compat)" FORCE)
 
 set(COMBO_PINS "${CMAKE_CURRENT_SOURCE_DIR}/upstream-pins.json")
@@ -38,8 +22,7 @@ file(READ "${COMBO_PINS}" COMBO_PINS_JSON)
 string(JSON COMBO_SOH_SHA GET "${COMBO_PINS_JSON}" upstreams soh mergedSha)
 string(JSON COMBO_MM_SHA  GET "${COMBO_PINS_JSON}" upstreams mm  mergedSha)
 
-# first 4 hex of each pin, masked to 15 bits -> 0..0x7FFF: fits the SIGNED s16 save-version fields
-# (unmasked 0..0xFFFF wrapped negative and .bak'd every save); still changes per merge for the gate.
+# first 4 hex of each pin, masked to 15 bits so it fits the SIGNED s16 save-version fields.
 string(SUBSTRING "${COMBO_SOH_SHA}" 0 4 COMBO_SOH_HEX)
 string(SUBSTRING "${COMBO_MM_SHA}"  0 4 COMBO_MM_HEX)
 math(EXPR COMBO_MINOR "0x${COMBO_SOH_HEX} & 0x7FFF")
@@ -58,9 +41,7 @@ include(CMake/soh-cvars.cmake)
 include(CMake/2ship-cvars.cmake)
 include(CMake/lus-cvars.cmake)
 
-# gBuildVersion (shown in-game) = "<PROJECT_BUILD_NAME> (<major>.<minor>.<patch>)".
-# Embed the readable upstream identity so the otherwise-opaque numeric triple is
-# legible, e.g. "Combo Build e1 soh-74e1d4c mm-3545e62 (1.29921.13637)".
+# In-game banner (gBuildVersion): release version + readable upstream identity.
 set(PROJECT_BUILD_NAME "ComboShip v${COMBO_RELEASE_VERSION} | Combo Build e${COMBO_EPOCH} soh-${COMBO_SOH_SHORT} mm-${COMBO_MM_SHORT}" CACHE STRING "" FORCE)
 set(PROJECT_TEAM "github.com/harbourmasters" CACHE STRING "" FORCE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,12 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment ve
 # via gBuildVersion) and the package filename. See docs/UPSTREAM_MERGES.md.
 set(COMBO_EPOCH 1)  # ← bump by hand for ComboShip-owned breaks / o2r-forcing releases
 
+# COMBO_RELEASE_VERSION: manual release identity; SOLE authority for combosave compatibility (gated
+# at the launcher container level, see combo/ComboShip.cpp). The pin-derived triple below is
+# diagnostics/banner only. Bump rule: patch = combo-side changes; minor = one game's upstream release
+# (counter); major = both games synced to upstream (resets minor).
+set(COMBO_RELEASE_VERSION "0.1.1" CACHE STRING "ComboShip release version (manual; gates combosave compat)" FORCE)
+
 set(COMBO_PINS "${CMAKE_CURRENT_SOURCE_DIR}/upstream-pins.json")
 # Reconfigure whenever the pins change so the derived version stays in sync.
 set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${COMBO_PINS}")
@@ -55,7 +61,7 @@ include(CMake/lus-cvars.cmake)
 # gBuildVersion (shown in-game) = "<PROJECT_BUILD_NAME> (<major>.<minor>.<patch>)".
 # Embed the readable upstream identity so the otherwise-opaque numeric triple is
 # legible, e.g. "Combo Build e1 soh-74e1d4c mm-3545e62 (1.29921.13637)".
-set(PROJECT_BUILD_NAME "Combo Build e${COMBO_EPOCH} soh-${COMBO_SOH_SHORT} mm-${COMBO_MM_SHORT}" CACHE STRING "" FORCE)
+set(PROJECT_BUILD_NAME "ComboShip v${COMBO_RELEASE_VERSION} | Combo Build e${COMBO_EPOCH} soh-${COMBO_SOH_SHORT} mm-${COMBO_MM_SHORT}" CACHE STRING "" FORCE)
 set(PROJECT_TEAM "github.com/harbourmasters" CACHE STRING "" FORCE)
 
 # Git information

--- a/combo/CMakeLists.txt
+++ b/combo/CMakeLists.txt
@@ -76,6 +76,9 @@ target_include_directories(ComboShip PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 find_package(nlohmann_json REQUIRED)
 target_link_libraries(ComboShip PRIVATE nlohmann_json::nlohmann_json)
 
+# COMBO_RELEASE_VERSION: launcher-only gate for combosave compat (the games don't gate, so no macro there).
+target_compile_definitions(ComboShip PRIVATE COMBO_RELEASE_VERSION="${COMBO_RELEASE_VERSION}")
+
 # ComboShip owns the persistent Anchor network connection (Phase 1), so it links SDL_net directly.
 # Mirrors soh's linkage (SDL2_net::SDL2_net-static on the static-md triplet, plain otherwise). We do
 # NOT link SDL2main here — ComboShip provides its own main().

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -233,6 +233,9 @@ static FnTakeStr MM_LoadComboRando = nullptr;
 // OOT file-select "copy file": whole-container copy (both games + rando) through the launcher.
 typedef void (*FnSetCopyContainer)(void (*)(int, int));
 static FnSetCopyContainer SOH_SetCopyContainer = nullptr;
+// OOT polls this each frame (main thread) for slots whose container was backed up for a release mismatch.
+typedef void (*FnSetOutdatedSaveNotice)(int (*)());
+static FnSetOutdatedSaveNotice SOH_SetOutdatedSaveNotice = nullptr;
 
 // ComboShip: OOT forced placements (Link's Pocket etc.) the static dump can't carry — see
 // SOH_GetForcedPlacements. Seed-parameterized so the pick is deterministic per generated seed.
@@ -298,9 +301,14 @@ static FnOracleVoid Combo_MM_Rando_Restore = nullptr;
 // The launcher mediates every per-slot read/write through Combo_ReadGameSave/Combo_WriteGameSave
 // (pushed into each DLL at boot), so the in-process cache stays authoritative. Single mutex serializes
 // OOT's thread-pool writes, MM's synchronous writes, and Anchor cross-writes. Write = temp+rename,
-// never torn on crash. See docs/deviations/boot-shutdown.md.
+// never torn on crash. Each container carries "comboRelease" (COMBO_RELEASE_VERSION); a container from a
+// different release is backed up to .bak and recreated — the launcher is the sole save-compat gate.
+// See docs/deviations/boot-shutdown.md.
 static std::mutex g_containerMutex;
 static std::map<int, nlohmann::json> g_containerCache;
+// Slots whose container was backed up for a COMBO_RELEASE_VERSION mismatch; guarded by g_containerMutex.
+// OOT drains it on the main thread (Combo_TakeEvictionNotice) to surface a popup.
+static std::vector<int> g_evictedSlots;
 
 static std::filesystem::path ComboContainerPath(int fileNum) {
     return std::filesystem::path("Save") / ("file" + std::to_string(fileNum + 1) + ".combosav");
@@ -329,8 +337,19 @@ static nlohmann::json& LoadOrCreateContainer(int fileNum) {
     if (existed && !parsed) {
         std::filesystem::rename(path, path.string() + ".corrupt-" + std::to_string(std::time(nullptr)), ec);
     }
+    // COMBO_RELEASE_VERSION gate: a container from a different ComboShip release is outdated. Back it
+    // up aside and start fresh; record the slot so OOT can surface a popup on its main thread.
+    if (parsed) {
+        auto rel = j.find("comboRelease");
+        if (rel == j.end() || !rel->is_string() || rel->get<std::string>() != COMBO_RELEASE_VERSION) {
+            std::filesystem::rename(path, path.string() + "-" + std::to_string(std::time(nullptr)) + ".bak", ec);
+            g_evictedSlots.push_back(fileNum); // caller holds g_containerMutex
+            parsed = false;
+        }
+    }
     if (!parsed)
         j = nlohmann::json{ { "comboVersion", 1 },
+                            { "comboRelease", COMBO_RELEASE_VERSION },
                             { "slot", fileNum },
                             { "oot", nullptr },
                             { "mm", nullptr },
@@ -352,6 +371,7 @@ static void FlushContainer(int fileNum) {
         std::ofstream out(tmp, std::ios::trunc | std::ios::binary);
         if (!out.is_open())
             return;
+        it->second["comboRelease"] = COMBO_RELEASE_VERSION; // every write carries the current release
         out << it->second.dump();
     }
     std::filesystem::rename(tmp, path, ec);
@@ -359,6 +379,17 @@ static void FlushContainer(int fileNum) {
         std::filesystem::remove(path, ec);
         std::filesystem::rename(tmp, path, ec);
     }
+}
+
+// OOT (main thread) polls this each frame via SOH_SetOutdatedSaveNotice: pops the next slot whose
+// container was backed up for a release mismatch, or -1 if none. Mirrors the SOH_SetCopyContainer wiring.
+static int Combo_TakeEvictionNotice() {
+    std::lock_guard<std::mutex> lk(g_containerMutex);
+    if (g_evictedSlots.empty())
+        return -1;
+    int slot = g_evictedSlots.front();
+    g_evictedSlots.erase(g_evictedSlots.begin());
+    return slot;
 }
 
 static void EraseComboContainer(int slot) {
@@ -1975,6 +2006,7 @@ int main(int argc, char** argv) {
     SOH_LoadComboRando = (FnTakeStr)GetSym(sohModule, "SOH_LoadComboRando");
     MM_LoadComboRando = (FnTakeStr)GetSym(mmModule, "MM_LoadComboRando");
     SOH_SetCopyContainer = (FnSetCopyContainer)GetSym(sohModule, "SOH_SetCopyContainer");
+    SOH_SetOutdatedSaveNotice = (FnSetOutdatedSaveNotice)GetSym(sohModule, "SOH_SetOutdatedSaveNotice");
     SOH_SetDeleteForeignSave = (FnSetDeleteForeignSave)GetSym(sohModule, "SOH_SetDeleteForeignSave");
     MM_SetDeleteForeignSave = (FnSetDeleteForeignSave)GetSym(mmModule, "MM_SetDeleteForeignSave");
     SOH_DeleteSaveFile = (FnDeleteSaveFile)GetSym(sohModule, "SOH_DeleteSaveFile");
@@ -2290,6 +2322,9 @@ int main(int argc, char** argv) {
         MM_SetComboSaveIO(&Combo_ReadGameSave, &Combo_WriteGameSave);
     if (SOH_SetCopyContainer)
         SOH_SetCopyContainer(&Combo_CopyContainer);
+    // OOT owns the shared file-select; it polls for release-evicted slots and shows the outdated-save popup.
+    if (SOH_SetOutdatedSaveNotice)
+        SOH_SetOutdatedSaveNotice(&Combo_TakeEvictionNotice);
 
     // Cross-game erase seam (issue #1): erasing a save slot in either game wipes both saves.
     if (SOH_SetDeleteForeignSave)

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -348,12 +348,9 @@ static nlohmann::json& LoadOrCreateContainer(int fileNum) {
         }
     }
     if (!parsed)
-        j = nlohmann::json{ { "comboVersion", 1 },
-                            { "comboRelease", COMBO_RELEASE_VERSION },
-                            { "slot", fileNum },
-                            { "oot", nullptr },
-                            { "mm", nullptr },
-                            { "combo", nlohmann::json::object() } };
+        j = nlohmann::json{ { "comboVersion", 1 }, { "comboRelease", COMBO_RELEASE_VERSION },
+                            { "slot", fileNum },   { "oot", nullptr },
+                            { "mm", nullptr },     { "combo", nlohmann::json::object() } };
     return g_containerCache.emplace(fileNum, std::move(j)).first->second;
 }
 

--- a/docs/UPSTREAM_MERGES.md
+++ b/docs/UPSTREAM_MERGES.md
@@ -129,6 +129,12 @@ top-level project) changes on every merge, and the rando-save gate fires on its 
 `PROJECT_BUILD_NAME` label (shown in-game) and the package filename
 (`ComboShip-e<epoch>-soh<sha>-mm<sha>`).
 
+**`COMBO_RELEASE_VERSION` (manual, e.g. `0.1.1`)** is separate from the pin-derived triple and is the
+**sole authority for combosave compatibility** (gated at the launcher container level — see
+`docs/deviations/boot-shutdown.md`). Bump rule: `patch` = combo-side changes; `minor` = a counter of the
+currently-ahead game's upstream releases; `major` = ticks when the trailing game catches up (both synced),
+resetting `minor`. Any bump retires existing combosaves once; not bumping it keeps saves across rebuilds.
+
 **The two o2r version checks are NOT the same granularity** (this bit me once — get it right):
 
 | Archive | Check | Granularity | Effect of a routine merge (minor/patch change) |

--- a/docs/deviations/boot-shutdown.md
+++ b/docs/deviations/boot-shutdown.md
@@ -194,6 +194,18 @@ section (so an Anchor MM-item write during OOT play can't clobber the OOT sectio
 overwritten. `Combo_CopyContainer` / `SOH_SetCopyContainer` back OOT file-select "copy file" (whole
 container, since there's no per-game `.sav` to copy).
 
+**Release-version save gate:** `COMBO_RELEASE_VERSION` (root `CMakeLists.txt`, manual — e.g. `0.1.1`)
+is the sole authority for combosave compatibility, enforced at the launcher container level, not in
+either game. It is compiled into the `ComboShip` target only. Every container write stamps
+`comboRelease`; on load, a container missing it or carrying a different string is renamed aside to a
+timestamped `.bak`, its slot recorded, and a fresh container created. OOT drains the recorded slots on
+its main thread (`SOH_SetOutdatedSaveNotice` → `Combo_TakeEvictionNotice`) and shows an "Outdated
+ComboShip Save" popup — the launcher never touches ImGui (`Combo_ReadGameSave` may run off-thread). The
+old pin-derived `major.minor.patch` triple + MM git commit hash remain for the in-game banner/diagnostics
+only (the MM rando `commitHash` strcmp throw is now `#ifndef COMBO_BUILD`). **Why:** the release identity
+is a deliberate human decision, and one launcher-level gate is simpler and more correct than two
+independent per-game version checks over a merged file.
+
 **OOT (`soh/soh/SaveManager.cpp`):** `SaveFileThreaded` write, `LoadFile` read, and the
 `StartupCheckAndInitMeta`/`Init` metadata scan route through the callbacks (fall back to `file{N}.sav`
 when unset); a corrupt container section skips the slot instead of `assert`-aborting. `global.sav` and

--- a/mm/2s2h/BenJsonConversions.hpp
+++ b/mm/2s2h/BenJsonConversions.hpp
@@ -153,10 +153,13 @@ inline void from_json(const json& j, ShipSaveInfo& shipSaveInfo) {
     j.at("commitHash").get_to(shipSaveInfo.commitHash);
 
     if (shipSaveInfo.saveType == SAVETYPE_RANDO) {
+#ifndef COMBO_BUILD
+        // ComboShip: tolerate cross-build rando saves on the combosave path (mirrors SoH's !comboSrc exemption).
         if (strcmp(shipSaveInfo.commitHash, gGitCommitHash) != 0) {
             SPDLOG_ERROR("Randomizer saves cannot be loaded from a different version.");
             throw new std::runtime_error("Randomizer saves cannot be loaded from a different version.");
         }
+#endif
 
         j.at("rando").get_to(shipSaveInfo.rando);
     }

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1617,8 +1617,10 @@ bool VerifyArchiveVersion(OTRVersion version) {
     return version.major != INT16_MAX && version.major != gBuildVersionMajor;
 }
 
-// ComboShip: forward declaration — defined further down with the combo exports.
+// ComboShip: forward declarations — defined further down with the combo exports.
 extern "C" void (*gComboSceneSwitchCallback)(int fileNum);
+// Launcher poll: returns the next save slot backed up for a release mismatch, or -1 if none.
+extern "C" int (*gComboOutdatedSaveNotice)();
 
 // ComboShip: InitOTR is split so the launcher can create the shared window (which needs only the
 // bundled soh.o2r, not a ROM) BEFORE the ROM archives exist, run its own unified extraction screen,
@@ -1800,6 +1802,18 @@ static void Combo_FinishInit() {
         }
         if (gGameState) {
             gGameState->running = false;
+        }
+    });
+
+    // ComboShip release gate: drain slots the launcher backed up for a version mismatch and show a
+    // popup on this (main) thread — the launcher only records slots, never touches ImGui.
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameFrameUpdate>([]() {
+        if (!gComboOutdatedSaveNotice)
+            return;
+        for (int slot; (slot = gComboOutdatedSaveNotice()) >= 0;) {
+            SohGui::RegisterPopup("Outdated ComboShip Save",
+                                  "The save in slot " + std::to_string(slot + 1) +
+                                      " was made by a different ComboShip version and has been backed up.");
         }
     });
 #endif
@@ -2767,6 +2781,12 @@ extern "C" __declspec(dllexport) void SOH_SetOnLoadSaveCallback(void (*cb)(int f
 }
 
 #ifdef COMBO_BUILD
+// ComboShip: launcher registers its release-eviction poll; OOT drains it each frame (main thread).
+extern "C" int (*gComboOutdatedSaveNotice)() = nullptr;
+extern "C" __declspec(dllexport) void SOH_SetOutdatedSaveNotice(int (*fn)()) {
+    gComboOutdatedSaveNotice = fn;
+}
+
 // ComboShip: Anchor transport seam. The persistent socket lives in ComboShip.exe; these exports
 // wire the launcher's connection to soh's in-place Anchor (declspec must follow extern "C" or the
 // symbol isn't exported). See docs/UPSTREAM_MERGES.md.


### PR DESCRIPTION
Combosave compatibility is now decided by a hand-bumped `COMBO_RELEASE_VERSION` (0.1.1), enforced solely at the launcher container level: each container stamps `comboRelease`, and one from a different release is backed up to `.bak` and recreated. OOT surfaces a popup for evicted slots on its main thread. The pin-derived triple and MM commit hash stay for the banner/diagnostics only (MM rando commitHash gate is now `COMBO_BUILD`-exempt), so combo rebuilds within a release keep saves.

Fixes the MM save half getting invalidated on every rebuild (its rando gate keyed on the volatile git commit hash). Code-reviewed clean; unplaytested — verify same-release rebuilds keep saves and a version bump backs up + pops the notice.

<!--- section:artifacts:start -->
### Build Artifacts
  - [comborando-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8617067459.zip)
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8617066998.zip)
<!--- section:artifacts:end -->