### PR TITLE
Resume the game a slot was last played in; fix MM return spot, owl save and shared settings

### DIFF
--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -194,7 +194,7 @@ static FnSOHDeinit SOH_Deinit = nullptr;
 static FnSOHPrepare SOH_PrepareForTransition = nullptr;
 static FnMMNotify MM_NotifyComboTransition = nullptr;
 
-typedef void (*FnMMSetReturnCb)(void (*)(void));
+typedef void (*FnMMSetReturnCb)(void (*)(int));
 static FnMMSetReturnCb MM_SetOnComboReturnCallback = nullptr;
 static bool g_pendingOOTReturn = false;
 
@@ -1838,8 +1838,12 @@ static void Combo_OnOOTSceneSwitch(int fileNum) {
     // OOT game loop is already exiting (gGameState->running = false set by the hook).
 }
 
-static void Combo_OnMMReturn(void) {
-    std::cout << "[ComboShip] MM Clock Tower entered -- returning to OOT" << std::endl;
+// Why MM handed control back: 0 = portal, 1 = Ctrl+R reset, 2 = owl-save quit (see BenPort.cpp).
+static int g_mmReturnKind = 0;
+
+static void Combo_OnMMReturn(int kind) {
+    g_mmReturnKind = kind;
+    std::cout << "[ComboShip] MM returning to OOT (kind=" << kind << ")" << std::endl;
     g_pendingOOTReturn = true;
 }
 
@@ -2460,8 +2464,17 @@ int main(int argc, char** argv) {
                     SOH_NotifyComboReturn();
                 ComboAnchor::SetActiveGame(0);                 // route Anchor back to OOT, deactivate MM's adapter
                 Combo_SetForegroundGame(ComboRando::GAME_OOT); // hide MM trackers, restore OOT's
-                if (g_PendingMMFileNum >= 0)
-                    Combo_SetLastGame(g_PendingMMFileNum, ComboRando::GAME_OOT);
+                if (g_PendingMMFileNum >= 0) {
+                    if (g_mmReturnKind == 0) {
+                        // Portal return: the player is continuing in OOT, so that's where a reload goes.
+                        // A reset or owl-save quit ends the session in MM — leave lastGame alone.
+                        Combo_SetLastGame(g_PendingMMFileNum, ComboRando::GAME_OOT);
+                    } else {
+                        // Session over: MM's dormant gSaveContext is post-quit state, so force the next
+                        // save-load to re-read it from the container (else the tracker peek shows junk).
+                        g_MmSaveInMemorySlot = -1;
+                    }
+                }
                 current = GAME_OOT;
             } else {
                 break;

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -453,7 +453,7 @@ static void Combo_SetLastGame(int fileNum, int game) {
     auto& c = LoadOrCreateContainer(fileNum);
     if (c.value("combo", nlohmann::json::object()).value("lastGame", -1) == game)
         return; // already correct — don't rewrite the container for nothing
-    std::cout << "[ComboShip] lastGame <- " << game << " (slot " << fileNum << ", transition)" << std::endl;
+    std::cout << "[ComboShip] lastGame <- " << game << " (slot " << fileNum << ")" << std::endl;
     c["combo"]["lastGame"] = game;
     FlushContainer(fileNum);
 }
@@ -1805,18 +1805,13 @@ static void Combo_OnOOTSaveLoad(int fileNum) {
 // file-select gate is load-bearing — OnLoadGame also fires on the MM->OOT return and from in-game
 // reloads, where this would bounce the player back into MM forever.
 static void Combo_ResumeMMIfLastSavedThere(int fileNum) {
-    const int onFileSelect = SOH_IsOnFileSelect ? (int)SOH_IsOnFileSelect() : -1;
-    const int lastGame = (fileNum >= 0 && fileNum <= 2) ? Combo_GetLastGame(fileNum) : -1;
-    std::cout << "[ComboShip] resume check: slot=" << fileNum << " lastGame=" << lastGame
-              << " onFileSelect=" << onFileSelect << " park=" << (SOH_ParkForComboMMResume ? 1 : 0)
-              << " mmRun=" << (MM_RunGame ? 1 : 0) << std::endl;
-    if (!SOH_ParkForComboMMResume || !MM_RunGame || onFileSelect != 1) {
+    if (!SOH_ParkForComboMMResume || !MM_RunGame || !SOH_IsOnFileSelect || !SOH_IsOnFileSelect()) {
         return;
     }
     if (fileNum < 0 || fileNum > 2) {
         return; // debug select (0xFF) / Boss Rush (0xFE) share FileChoose_LoadGame
     }
-    if (lastGame != ComboRando::GAME_MM) {
+    if (Combo_GetLastGame(fileNum) != ComboRando::GAME_MM) {
         return;
     }
     std::cout << "[ComboShip] Slot " << fileNum << " was last saved in MM — resuming MM" << std::endl;

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -405,6 +405,10 @@ static int Combo_TakeEvictionNotice() {
 static void EraseComboContainer(int slot) {
     std::lock_guard<std::mutex> lk(g_containerMutex);
     g_containerCache.erase(slot);
+    // MM's dormant save is now stale: leave it marked resident and the next load skips re-reading it,
+    // and any dormant MM write would put the erased save back into the slot.
+    if (g_MmSaveInMemorySlot == slot)
+        g_MmSaveInMemorySlot = -1;
     std::error_code ec;
     std::filesystem::remove(ComboContainerPath(slot), ec);
 }
@@ -416,6 +420,8 @@ static void Combo_CopyContainer(int from, int to) {
     nlohmann::json copy = LoadOrCreateContainer(from); // deep copy of the source container
     copy["slot"] = to;
     g_containerCache[to] = std::move(copy);
+    if (g_MmSaveInMemorySlot == to)
+        g_MmSaveInMemorySlot = -1; // the destination's MM save just changed under us
     FlushContainer(to);
 }
 
@@ -1712,6 +1718,9 @@ static int Combo_OnReloadRequest(const char* path) {
 }
 
 static void Combo_OnOOTSaveInit(int fileNum) {
+    // A new file starts in OOT. Explicit because not every delete path clears the container
+    // (DeleteFileOnDeath calls DeleteZeldaFile directly), so a stale MM could otherwise survive here.
+    Combo_SetLastGame(fileNum, ComboRando::GAME_OOT);
     // ComboShip: bind the pending consolidated seed to this slot — bake it into the container's
     // combo.rando (self-contained), then push it into both DLLs so foreign data is live immediately.
     if (!g_ConsolidatedJson.empty()) {

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -2434,6 +2434,8 @@ int main(int argc, char** argv) {
                     MM_SetOnComboReturnCallback(Combo_OnMMReturn);
                 ComboAnchor::SetActiveGame(1);                // route Anchor to MM, activate MM's adapter
                 Combo_SetForegroundGame(ComboRando::GAME_MM); // hide OOT trackers, show MM's
+                if (g_PendingMMFileNum >= 0)
+                    Combo_SetLastGame(g_PendingMMFileNum, ComboRando::GAME_MM);
                 current = GAME_MM;
             } else {
                 break;

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -317,14 +317,8 @@ static std::map<int, nlohmann::json> g_containerCache;
 // OOT drains it on the main thread (Combo_TakeEvictionNotice) to surface a popup.
 static std::vector<int> g_evictedSlots;
 
-// Foreground game (GameId: 0=OOT, 1=MM), mirrored from every ComboUI_OnForegroundGame notification.
-// Read by Combo_WriteGameSave off OOT's thread pool, hence atomic.
-static std::atomic<int> g_foregroundGame{ ComboRando::GAME_OOT };
-
-// Single place the foreground game changes: keeps comboui's tracker visibility and our own mirror in
-// step. Every transition point must go through this rather than calling ComboUI_OnForegroundGame.
+// Single place the foreground game changes, so every transition point notifies comboui consistently.
 static void Combo_SetForegroundGame(int game) {
-    g_foregroundGame.store(game);
     if (ComboUI_OnForegroundGame)
         ComboUI_OnForegroundGame(game);
 }
@@ -448,16 +442,12 @@ static void Combo_WriteGameSave(int game, int fileNum, const char* json) {
     try {
         c[key] = nlohmann::json::parse(json);
     } catch (...) { return; }
-    // combo.lastGame = where the player last SAVED, used to pick which game to resume on next load.
-    // Only the foreground game's own write counts: background writes (a cross-game grant or Anchor
-    // packet landing in the dormant game's save) must not claim the player was there.
-    if (game == g_foregroundGame.load())
-        c["combo"]["lastGame"] = game;
     FlushContainer(fileNum);
 }
 
-// Record which game the player is now in. Needed on the MM->OOT return: leaving MM persists MM (so
-// lastGame=MM) but the OOT side writes nothing, which would resume into MM after walking back to OOT.
+// Record which game the player is now in, so a quit-and-reload resumes there. Set at the two
+// transitions only — NOT from save writes: loading an OOT save itself writes sections (rando and
+// check-tracker OnLoadGame handlers), which would stamp OOT over the MM the player actually left in.
 static void Combo_SetLastGame(int fileNum, int game) {
     std::lock_guard<std::mutex> lk(g_containerMutex);
     auto& c = LoadOrCreateContainer(fileNum);

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -463,6 +463,7 @@ static void Combo_SetLastGame(int fileNum, int game) {
     auto& c = LoadOrCreateContainer(fileNum);
     if (c.value("combo", nlohmann::json::object()).value("lastGame", -1) == game)
         return; // already correct — don't rewrite the container for nothing
+    std::cout << "[ComboShip] lastGame <- " << game << " (slot " << fileNum << ", transition)" << std::endl;
     c["combo"]["lastGame"] = game;
     FlushContainer(fileNum);
 }
@@ -1814,13 +1815,18 @@ static void Combo_OnOOTSaveLoad(int fileNum) {
 // file-select gate is load-bearing — OnLoadGame also fires on the MM->OOT return and from in-game
 // reloads, where this would bounce the player back into MM forever.
 static void Combo_ResumeMMIfLastSavedThere(int fileNum) {
-    if (!SOH_ParkForComboMMResume || !MM_RunGame || !SOH_IsOnFileSelect || !SOH_IsOnFileSelect()) {
+    const int onFileSelect = SOH_IsOnFileSelect ? (int)SOH_IsOnFileSelect() : -1;
+    const int lastGame = (fileNum >= 0 && fileNum <= 2) ? Combo_GetLastGame(fileNum) : -1;
+    std::cout << "[ComboShip] resume check: slot=" << fileNum << " lastGame=" << lastGame
+              << " onFileSelect=" << onFileSelect << " park=" << (SOH_ParkForComboMMResume ? 1 : 0)
+              << " mmRun=" << (MM_RunGame ? 1 : 0) << std::endl;
+    if (!SOH_ParkForComboMMResume || !MM_RunGame || onFileSelect != 1) {
         return;
     }
     if (fileNum < 0 || fileNum > 2) {
         return; // debug select (0xFF) / Boss Rush (0xFE) share FileChoose_LoadGame
     }
-    if (Combo_GetLastGame(fileNum) != ComboRando::GAME_MM) {
+    if (lastGame != ComboRando::GAME_MM) {
         return;
     }
     std::cout << "[ComboShip] Slot " << fileNum << " was last saved in MM — resuming MM" << std::endl;

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -178,6 +178,13 @@ typedef void (*FnGetPlayerName)(unsigned char*);
 static FnMMInitSaveNamed MM_InitSaveFile = nullptr;
 static FnGetPlayerName SOH_GetCurrentPlayerName = nullptr;
 static FnMMInitSave MM_LoadSaveForCombo = nullptr;
+// #89 resume-into-MM: drop out of OOT's loop before it runs a Play frame / tell MM how it was entered.
+// SOH_IsOnFileSelect distinguishes a real file-select load from the OnLoadGame that TitleSetup fires
+// on the MM->OOT return (which must not bounce the player straight back into MM).
+typedef unsigned char (*FnIsOnFileSelect)();
+static FnVoid SOH_ParkForComboMMResume = nullptr;
+static FnMMInitSave MM_SetComboEntryIsResume = nullptr;
+static FnIsOnFileSelect SOH_IsOnFileSelect = nullptr;
 // OOT slot whose MM save is live in MM's dormant memory (-1 = none). Guards Combo_OnOOTSaveLoad
 // against reloading stale disk state over MM's in-memory progress after round trips.
 static int g_MmSaveInMemorySlot = -1;
@@ -310,6 +317,18 @@ static std::map<int, nlohmann::json> g_containerCache;
 // OOT drains it on the main thread (Combo_TakeEvictionNotice) to surface a popup.
 static std::vector<int> g_evictedSlots;
 
+// Foreground game (GameId: 0=OOT, 1=MM), mirrored from every ComboUI_OnForegroundGame notification.
+// Read by Combo_WriteGameSave off OOT's thread pool, hence atomic.
+static std::atomic<int> g_foregroundGame{ ComboRando::GAME_OOT };
+
+// Single place the foreground game changes: keeps comboui's tracker visibility and our own mirror in
+// step. Every transition point must go through this rather than calling ComboUI_OnForegroundGame.
+static void Combo_SetForegroundGame(int game) {
+    g_foregroundGame.store(game);
+    if (ComboUI_OnForegroundGame)
+        ComboUI_OnForegroundGame(game);
+}
+
 static std::filesystem::path ComboContainerPath(int fileNum) {
     return std::filesystem::path("Save") / ("file" + std::to_string(fileNum + 1) + ".combosav");
 }
@@ -429,7 +448,31 @@ static void Combo_WriteGameSave(int game, int fileNum, const char* json) {
     try {
         c[key] = nlohmann::json::parse(json);
     } catch (...) { return; }
+    // combo.lastGame = where the player last SAVED, used to pick which game to resume on next load.
+    // Only the foreground game's own write counts: background writes (a cross-game grant or Anchor
+    // packet landing in the dormant game's save) must not claim the player was there.
+    if (game == g_foregroundGame.load())
+        c["combo"]["lastGame"] = game;
     FlushContainer(fileNum);
+}
+
+// Record which game the player is now in. Needed on the MM->OOT return: leaving MM persists MM (so
+// lastGame=MM) but the OOT side writes nothing, which would resume into MM after walking back to OOT.
+static void Combo_SetLastGame(int fileNum, int game) {
+    std::lock_guard<std::mutex> lk(g_containerMutex);
+    auto& c = LoadOrCreateContainer(fileNum);
+    if (c.value("combo", nlohmann::json::object()).value("lastGame", -1) == game)
+        return; // already correct — don't rewrite the container for nothing
+    c["combo"]["lastGame"] = game;
+    FlushContainer(fileNum);
+}
+
+// Which game a slot was last saved in (GameId). Absent => OOT, so pre-lastGame saves resume as before.
+static int Combo_GetLastGame(int fileNum) {
+    std::lock_guard<std::mutex> lk(g_containerMutex);
+    auto& c = LoadOrCreateContainer(fileNum);
+    int g = c.value("combo", nlohmann::json::object()).value("lastGame", (int)ComboRando::GAME_OOT);
+    return (g == ComboRando::GAME_MM) ? ComboRando::GAME_MM : ComboRando::GAME_OOT;
 }
 
 // ComboShip (issue #1): erasing a slot from either game's file-select wipes BOTH saves — each game
@@ -1733,6 +1776,8 @@ static void Combo_OnOOTSaveInit(int fileNum) {
     g_MmSaveInMemorySlot = fileNum;
 }
 
+static void Combo_ResumeMMIfLastSavedThere(int fileNum);
+
 // ComboShip: OOT loaded a save (file select / warp). Bring the matching MM save into MM's dormant
 // memory so the combo tracker peek shows real MM items before MM is visited. Skipped when that
 // slot's MM save is already live in memory — reloading from disk would clobber newer progress.
@@ -1756,15 +1801,39 @@ static void Combo_OnOOTSaveLoad(int fileNum) {
         }
     }
     if (!MM_LoadSaveForCombo || g_MmSaveInMemorySlot == fileNum) {
+        Combo_ResumeMMIfLastSavedThere(fileNum);
         return;
     }
     std::cout << "[ComboShip] Loading MM save for OOT slot " << fileNum << " (tracker peek)" << std::endl;
     MM_LoadSaveForCombo(fileNum);
     g_MmSaveInMemorySlot = fileNum;
+    Combo_ResumeMMIfLastSavedThere(fileNum);
+}
+
+// ComboShip (#89): resume MM instead of starting OOT when the slot was last played in MM. The
+// file-select gate is load-bearing — OnLoadGame also fires on the MM->OOT return and from in-game
+// reloads, where this would bounce the player back into MM forever.
+static void Combo_ResumeMMIfLastSavedThere(int fileNum) {
+    if (!SOH_ParkForComboMMResume || !MM_RunGame || !SOH_IsOnFileSelect || !SOH_IsOnFileSelect()) {
+        return;
+    }
+    if (fileNum < 0 || fileNum > 2) {
+        return; // debug select (0xFF) / Boss Rush (0xFE) share FileChoose_LoadGame
+    }
+    if (Combo_GetLastGame(fileNum) != ComboRando::GAME_MM) {
+        return;
+    }
+    std::cout << "[ComboShip] Slot " << fileNum << " was last saved in MM — resuming MM" << std::endl;
+    if (MM_SetComboEntryIsResume)
+        MM_SetComboEntryIsResume(1); // a real save load: honors MM's Remember Save Location
+    g_PendingMMFileNum = fileNum;
+    SOH_ParkForComboMMResume(); // drops out of OOT's game loop; the launcher then enters MM
 }
 
 static void Combo_OnOOTSceneSwitch(int fileNum) {
     std::cout << "[ComboShip] Mask Shop entered — switching to MM, slot " << fileNum << std::endl;
+    if (MM_SetComboEntryIsResume)
+        MM_SetComboEntryIsResume(0); // portal entry: always arrives in South Clock Town
     g_PendingMMFileNum = fileNum;
     // OOT game loop is already exiting (gGameState->running = false set by the hook).
 }
@@ -1904,6 +1973,9 @@ int main(int argc, char** argv) {
     MM_InitSaveFile = (FnMMInitSaveNamed)GetSym(mmModule, "MM_InitSaveFile");
     SOH_GetCurrentPlayerName = (FnGetPlayerName)GetSym(sohModule, "SOH_GetCurrentPlayerName");
     MM_LoadSaveForCombo = (FnMMInitSave)GetSym(mmModule, "MM_LoadSaveForCombo");
+    SOH_ParkForComboMMResume = (FnVoid)GetSym(sohModule, "SOH_ParkForComboMMResume");
+    MM_SetComboEntryIsResume = (FnMMInitSave)GetSym(mmModule, "MM_SetComboEntryIsResume");
+    SOH_IsOnFileSelect = (FnIsOnFileSelect)GetSym(sohModule, "SOH_IsOnFileSelect");
     SOH_SetOnSceneSwitchCallback = (FnSetSceneSwitchCallback)GetSym(sohModule, "SOH_SetOnSceneSwitchCallback");
     MM_RunGame = (FnMMRunGame)GetSym(mmModule, "MM_RunGame");
     SOH_Deinit = (FnSOHDeinit)GetSym(sohModule, "SOH_Deinit");
@@ -2238,8 +2310,7 @@ int main(int argc, char** argv) {
 
     // ComboShip: OOT owns the foreground at startup — hide MM's (now-registered) tracker windows so
     // only OOT's Check/Item trackers can show. See combo/gui/ComboTrackerVisibility.cpp.
-    if (ComboUI_OnForegroundGame)
-        ComboUI_OnForegroundGame(0);
+    Combo_SetForegroundGame(ComboRando::GAME_OOT);
 
     // --- 5. Register OOT callbacks ---
     // Note: MM_InitArchives (dormant archive pre-load) is skipped — Ship::ArchiveManager::Init
@@ -2361,9 +2432,8 @@ int main(int argc, char** argv) {
                     MM_NotifyComboTransition();
                 if (MM_SetOnComboReturnCallback)
                     MM_SetOnComboReturnCallback(Combo_OnMMReturn);
-                ComboAnchor::SetActiveGame(1); // route Anchor to MM, activate MM's adapter
-                if (ComboUI_OnForegroundGame)  // hide OOT trackers, show MM's
-                    ComboUI_OnForegroundGame(1);
+                ComboAnchor::SetActiveGame(1);                // route Anchor to MM, activate MM's adapter
+                Combo_SetForegroundGame(ComboRando::GAME_MM); // hide OOT trackers, show MM's
                 current = GAME_MM;
             } else {
                 break;
@@ -2386,9 +2456,10 @@ int main(int argc, char** argv) {
                     MM_PrepareForTransition();
                 if (SOH_NotifyComboReturn)
                     SOH_NotifyComboReturn();
-                ComboAnchor::SetActiveGame(0); // route Anchor back to OOT, deactivate MM's adapter
-                if (ComboUI_OnForegroundGame)  // hide MM trackers, restore OOT's
-                    ComboUI_OnForegroundGame(0);
+                ComboAnchor::SetActiveGame(0);                 // route Anchor back to OOT, deactivate MM's adapter
+                Combo_SetForegroundGame(ComboRando::GAME_OOT); // hide MM trackers, restore OOT's
+                if (g_PendingMMFileNum >= 0)
+                    Combo_SetLastGame(g_PendingMMFileNum, ComboRando::GAME_OOT);
                 current = GAME_OOT;
             } else {
                 break;

--- a/docs/deviations/boot-shutdown.md
+++ b/docs/deviations/boot-shutdown.md
@@ -243,13 +243,20 @@ A slot always resumed OOT even when the player's last session was MM, and leavin
 Link's House instead of the Mask Shop.
 
 **`combo.lastGame` (`combo/ComboShip.cpp`).** New container field (GameId: `0`=OOT, `1`=MM); absent
-means OOT, so older saves behave as before. Stamped in `Combo_WriteGameSave` **only when the writing
-game is the foreground game** (`g_foregroundGame`, mirrored by `Combo_SetForegroundGame` at the three
-transition points). That filter is load-bearing: cross-game grants, Anchor packets and
-`SOH_MarkForeignObtained` all write into the *dormant* game's section, and must not claim the player was
-there. `Combo_SetLastGame` additionally stamps it at both transitions — MM on portal entry, OOT on the
-return — so it tracks where the player actually is even when neither game writes a save (leaving MM
-persists MM, but nothing on the OOT side writes one, which would otherwise keep resuming into MM).
+means OOT, so older saves behave as before. Written by `Combo_SetLastGame` at the **two transitions
+only** — MM when the portal hands off, OOT on a portal return.
+
+It is deliberately **not** derived from save writes. Two separate write classes make that unworkable:
+background writes into the *dormant* game's section (cross-game grants, Anchor packets,
+`SOH_MarkForeignObtained`), and — the one that actually broke it — OOT's own **load-time** writes.
+Loading an OOT save persists sections from the rando and check-tracker `OnLoadGame` handlers, which run
+*before* the launcher's `Combo_OnOOTSaveLoad`, so a foreground-filtered write-stamp set `lastGame` to OOT
+microseconds before the resume decision read it, and the slot never resumed MM.
+
+Transition stamps alone are sufficient: entering MM stamps MM (so an owl-save quit, which fires no
+transition, still resumes MM), a portal return stamps OOT (so quitting from OOT resumes OOT), and an
+absent field defaults to OOT for a first-ever session. A reset or owl-save quit deliberately leaves the
+field alone — see the return-kind note below.
 
 **The intercept.** `Combo_OnOOTSaveLoad` already fires at the ideal moment: `FileChoose_LoadGame` runs
 `GameInteractor_ExecuteOnLoadGame` at its tail (`soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c`),

--- a/docs/deviations/boot-shutdown.md
+++ b/docs/deviations/boot-shutdown.md
@@ -247,8 +247,9 @@ means OOT, so older saves behave as before. Stamped in `Combo_WriteGameSave` **o
 game is the foreground game** (`g_foregroundGame`, mirrored by `Combo_SetForegroundGame` at the three
 transition points). That filter is load-bearing: cross-game grants, Anchor packets and
 `SOH_MarkForeignObtained` all write into the *dormant* game's section, and must not claim the player was
-there. Also stamped to OOT on the MM→OOT return (`Combo_SetLastGame`) — leaving MM persists MM's save,
-but nothing on the OOT side writes one, so the slot would otherwise still resume into MM.
+there. `Combo_SetLastGame` additionally stamps it at both transitions — MM on portal entry, OOT on the
+return — so it tracks where the player actually is even when neither game writes a save (leaving MM
+persists MM, but nothing on the OOT side writes one, which would otherwise keep resuming into MM).
 
 **The intercept.** `Combo_OnOOTSaveLoad` already fires at the ideal moment: `FileChoose_LoadGame` runs
 `GameInteractor_ExecuteOnLoadGame` at its tail (`soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c`),
@@ -271,14 +272,22 @@ exactly once) and does **not** fire `OnExitGame` (the dormant tracker peek needs
 `OnLoadGame` just built). On the return, `SOH_ResumeGame` → `SOH_ResetFrameLoopForResume` re-seeds
 `RunFrame` from overlay[0] (`TitleSetup`), which then takes the normal `gComboReturnFileNum` path.
 
-**MM spawn point.** `gComboEntryIsResume` (`MM_SetComboEntryIsResume`) separates the two ways MM is
-entered, which want opposite entrances. Portal entry keeps the fixed `ENTRANCE(SOUTH_CLOCK_TOWN, 0)`
-arrival; a boot resume calls `Combo_SetMMResumeEntrance` (`mm/src/code/z_sram_NES.c`), which mirrors
-`Sram_OpenSave`'s selection — `shipSaveInfo.pauseSaveEntrance` when Remember Save Location stored one,
-else `sOwlWarpEntrances[owlWarpId]`, plus the swamp/mountain-village variant fixups. That logic is
-duplicated rather than called because combo's MM entry never runs `Sram_OpenSave` and the table is
-file-static. **Note:** with Remember Save Location off, MM's authentic resume is the *owl statue*, not
-Clock Town — forcing Clock Town there was wrong.
+**MM spawn point.** South Clock Town is the arrival for both portal entry and a boot resume; the
+resume only differs when Remember Save Location is on, in which case it uses
+`gSaveContext.save.shipSaveInfo.pauseSaveEntrance` (where that enhancement stores the spot — *not*
+`save.entrance`, and combo never runs `Sram_OpenSave`, which is what normally applies it).
+`gComboEntryIsResume` (`MM_SetComboEntryIsResume`) tells MM which kind of entry it is. Deliberately
+**not** MM's authentic owl-statue resume: Clock Town is the intended combo default.
+
+**Owl save (`mm/src/code/z_play.c`).** MM's owl save sets `GAMEMODE_OWL_SAVE` (`z_message.c`) and
+`z_play.c` then does `SET_NEXT_GAMESTATE(TitleSetup_Init)` — "save and quit to MM's file select". In
+combo that re-ran MM's whole boot (the combo entry block is skipped because `gComboStartFileNum` is back
+to `-1`), so the attract path's `Sram_InitNewSave` wiped the save and MM's file select then wrote the
+wipe into the container: **the slot's MM section was corrupted by an ordinary owl save.** A
+`COMBO_BUILD` seam calls `Combo_RequestOwlSaveQuit()` instead, which routes through the existing return
+hook and `SOH_SetComboBootToTitle` so the session lands on **OOT's title/file select**. No extra persist
+is needed — the owl save's own flashrom write already went through the container seam. `lastGame` stays
+MM, so reselecting the slot resumes MM.
 
 **#87 entrance clobber (`soh/src/code/title_setup.c`).** The Mask-Shop arrival entrance is now assigned
 *after* `GameInteractor_ExecuteOnLoadGame`, because the rando handler's `Entrance_SetSavewarpEntrance()`

--- a/docs/deviations/boot-shutdown.md
+++ b/docs/deviations/boot-shutdown.md
@@ -237,6 +237,7 @@ to cleanup-and-return, since a cosmetic photo must never terminate the process; 
 unguarded and will conflict if upstream reworks these functions. Note the hook is
 `COND_VB_SHOULD(VB_PICTO_TAKE, true, ...)` — a literal `true`, so the ColorPictograph CVar does not
 gate it.
+
 ## Resume the game the slot was last played in (issues #89/#87/#83, 2026-07-25)
 
 A slot always resumed OOT even when the player's last session was MM, and leaving MM landed them at

--- a/docs/deviations/boot-shutdown.md
+++ b/docs/deviations/boot-shutdown.md
@@ -237,6 +237,77 @@ to cleanup-and-return, since a cosmetic photo must never terminate the process; 
 unguarded and will conflict if upstream reworks these functions. Note the hook is
 `COND_VB_SHOULD(VB_PICTO_TAKE, true, ...)` — a literal `true`, so the ColorPictograph CVar does not
 gate it.
+## Resume the game the slot was last played in (issues #89/#87/#83, 2026-07-25)
+
+A slot always resumed OOT even when the player's last session was MM, and leaving MM landed them at
+Link's House instead of the Mask Shop.
+
+**`combo.lastGame` (`combo/ComboShip.cpp`).** New container field (GameId: `0`=OOT, `1`=MM); absent
+means OOT, so older saves behave as before. Stamped in `Combo_WriteGameSave` **only when the writing
+game is the foreground game** (`g_foregroundGame`, mirrored by `Combo_SetForegroundGame` at the three
+transition points). That filter is load-bearing: cross-game grants, Anchor packets and
+`SOH_MarkForeignObtained` all write into the *dormant* game's section, and must not claim the player was
+there. Also stamped to OOT on the MM→OOT return (`Combo_SetLastGame`) — leaving MM persists MM's save,
+but nothing on the OOT side writes one, so the slot would otherwise still resume into MM.
+
+**The intercept.** `Combo_OnOOTSaveLoad` already fires at the ideal moment: `FileChoose_LoadGame` runs
+`GameInteractor_ExecuteOnLoadGame` at its tail (`soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c`),
+i.e. after `Sram_OpenSave` rebuilt `gRandoContext` and after the launcher loaded the dormant MM save,
+but before OOT executes a single Play frame. `Combo_ResumeMMIfLastSavedThere` decides there, so no
+vendored file-select edit is needed. It is gated on `SOH_IsOnFileSelect()` because `OnLoadGame` also
+fires from `TitleSetup` on the MM→OOT return and from in-game reloads (`Warping`, `BetterSaveMenu`) —
+ungated, walking out of MM after an owl save would bounce the player straight back into MM forever. It
+also ignores `fileNum` outside 0..2, since debug-select (`0xFF`) and Boss Rush (`0xFE`) share
+`FileChoose_LoadGame`.
+
+**Leaving OOT's loop (`SOH_ParkForComboMMResume`, `soh/soh/OTRGlobals.cpp`).** Sets
+`gGameState->init = nullptr` **and** `running = false`. `RunFrame`'s outer loop is
+`while (runFrameContext.nextOvl)` and only falls through to `WindowClose()` when
+`Graph_GetNextGameState` returns NULL. The Mask-Shop switch gets away with `running = false` alone
+because `GameState_Init` already nulled `init`, but `FileChoose_LoadGame` has *queued* `Play_Init` — so
+without clearing it OOT would build Play and keep running, and the handoff would never happen. It
+deliberately does **not** save the file (that would stamp `lastGame` back to OOT, making the resume work
+exactly once) and does **not** fire `OnExitGame` (the dormant tracker peek needs the rando context that
+`OnLoadGame` just built). On the return, `SOH_ResumeGame` → `SOH_ResetFrameLoopForResume` re-seeds
+`RunFrame` from overlay[0] (`TitleSetup`), which then takes the normal `gComboReturnFileNum` path.
+
+**MM spawn point.** `gComboEntryIsResume` (`MM_SetComboEntryIsResume`) separates the two ways MM is
+entered, which want opposite entrances. Portal entry keeps the fixed `ENTRANCE(SOUTH_CLOCK_TOWN, 0)`
+arrival; a boot resume calls `Combo_SetMMResumeEntrance` (`mm/src/code/z_sram_NES.c`), which mirrors
+`Sram_OpenSave`'s selection — `shipSaveInfo.pauseSaveEntrance` when Remember Save Location stored one,
+else `sOwlWarpEntrances[owlWarpId]`, plus the swamp/mountain-village variant fixups. That logic is
+duplicated rather than called because combo's MM entry never runs `Sram_OpenSave` and the table is
+file-static. **Note:** with Remember Save Location off, MM's authentic resume is the *owl statue*, not
+Clock Town — forcing Clock Town there was wrong.
+
+**#87 entrance clobber (`soh/src/code/title_setup.c`).** The Mask-Shop arrival entrance is now assigned
+*after* `GameInteractor_ExecuteOnLoadGame`, because the rando handler's `Entrance_SetSavewarpEntrance()`
+recomputes from `savedSceneNum` (never set by the portal handoff) and overwrote it with
+`ENTR_LINKS_HOUSE_CHILD_SPAWN`. Wrapped in `Entrance_OverrideNextIndex()` so it stays correct once
+entrance shuffle is generated for combo seeds. (Safe only because every combo save forces
+`QUEST_RANDOMIZER`, so `Entrance_Init` always ran.)
+
+**#89(b) attract-demo guard (`mm/2s2h/BenPort.cpp`).** MM's title path runs `Sram_InitNewSave()` and
+then a live `Play` for the attract demo, which scene-hops through the Clock Tower interior — tripping
+the MM→OOT return trigger and persisting the *wiped* save over the slot. Both the trigger and the
+return's persist call now require `gSaveContext.gameMode == GAMEMODE_NORMAL`. The guard sits at the
+return call site, **not** inside `SaveManager_SaveCurrentForCombo`: that function has six callers, and
+four of them (new-rando-save creation, dormant cross-game grants, `MM_MarkForeignObtained`, Anchor
+dormant persist) legitimately run while MM is dormant with a stale `gameMode`.
+
+**#83 shared settings.** MM keeps targeting/audio/language in `global.json`, which combo never writes
+(its file select is never reached), so `SaveContext_Init`'s defaults applied — notably Switch targeting.
+`Combo_AdoptOOTGlobalOptions` (`mm/2s2h/BenPort.cpp`) pulls OOT's values via the new
+`SOH_GetGlobalOptions` export after `Sram_LoadGlobalOptions`. **Language is excluded on purpose:** the
+enums disagree (OOT `ENG=0`, MM `JPN=0`), and MM's runtime reads `options.language`, not the
+`options.languageSetting` field that gets serialized.
+
+**Dormant check-tracker recalc (part of #81).** `InternalRecalculateAvailableChecks`
+(`randomizer_check_tracker.cpp`) no longer early-returns when `gPlayState == nullptr`; it starts the
+traversal from `gSaveContext.entranceIndex` instead. Required by the intercept, which leaves OOT with no
+play state at all, and it also fixes the pre-existing frozen-tracker complaint while MM is foreground.
+It now returns `bool` so the caller only clears `recalculateAvailable` when the recalc really ran,
+instead of consuming and dropping the request.
 
 ## ComboShip-owned unified ROM extraction (OoT + MM) (2026-06-21)
 

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -155,6 +155,14 @@ static bool sComboResetReturnPending = false;
 extern "C" __declspec(dllexport) void MM_RequestComboReturn(void) {
     sComboResetReturnPending = true;
 }
+// ComboShip (#89): owl save. MM would SET_NEXT_GAMESTATE(TitleSetup_Init) here (z_play.c) and quit to
+// its own file select, which combo can't enter — it re-runs MM's boot, wipes the save and lets MM's
+// file select write the wipe into the container. Quit to OOT's title instead; the owl save's own
+// flashrom write has already persisted the MM section.
+static bool sComboOwlSaveQuitPending = false;
+extern "C" void Combo_RequestOwlSaveQuit(void) {
+    sComboOwlSaveQuitPending = true;
+}
 // MM's own ResourceManager, created at first boot and kept alive for the whole process. A combo
 // transition swaps the Context's active RM between MM's and OOT's, so each game keeps its archives +
 // resource cache resident and nothing is ever unloaded (no dangling cached pointers). See MM_ResumeGame.
@@ -1112,14 +1120,29 @@ extern "C" void InitOTR(int argc, char* argv[]) {
         }
     });
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameStateMainStart>([]() {
-        if (!sComboReturnPending && !sComboResetReturnPending)
+        if (!sComboReturnPending && !sComboResetReturnPending && !sComboOwlSaveQuitPending)
             return;
         const bool isReset = sComboResetReturnPending;
+        const bool isOwlSaveQuit = sComboOwlSaveQuitPending;
         sComboReturnPending = false;
         sComboResetReturnPending = false;
+        sComboOwlSaveQuitPending = false;
+        // An owl save quit lands on OOT's title, like Ctrl+R, rather than resuming OOT gameplay.
+        if (isOwlSaveQuit) {
+            static void (*sFn)(void) = nullptr;
+            static bool sTried = false;
+            if (!sTried) {
+                sTried = true;
+                if (HMODULE h = GetModuleHandleA("soh.dll"))
+                    sFn = (void (*)(void))GetProcAddress(h, "SOH_SetComboBootToTitle");
+            }
+            if (sFn)
+                sFn();
+        }
         // Portal return always persists MM; a reset persists only when autosave is enabled. Never
-        // persist outside gameplay: the title/attract path wipes save first (Sram_InitNewSave).
-        if ((!isReset || CVarGetInteger("gEnhancements.Saving.Autosave", 0)) &&
+        // persist outside gameplay: the title/attract path wipes save first (Sram_InitNewSave). An owl
+        // save has already written itself through the flashrom seam.
+        if (!isOwlSaveQuit && (!isReset || CVarGetInteger("gEnhancements.Saving.Autosave", 0)) &&
             gSaveContext.gameMode == GAMEMODE_NORMAL)
             SaveManager_SaveCurrentForCombo();
         if (gComboReturnCallback)

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -144,8 +144,10 @@ extern "C"
     sComboTransitionActive = true;
 }
 
-extern "C" void (*gComboReturnCallback)(void) = nullptr;
-extern "C" __declspec(dllexport) void MM_SetOnComboReturnCallback(void (*cb)(void)) {
+// kind: 0 = portal (walked out the Clock Tower), 1 = Ctrl+R reset, 2 = owl-save quit. Only a portal
+// return continues the session in OOT; the other two end it and boot OOT to its title.
+extern "C" void (*gComboReturnCallback)(int kind) = nullptr;
+extern "C" __declspec(dllexport) void MM_SetOnComboReturnCallback(void (*cb)(int kind)) {
     gComboReturnCallback = cb;
 }
 static bool sComboReturnPending = false;
@@ -1146,7 +1148,7 @@ extern "C" void InitOTR(int argc, char* argv[]) {
             gSaveContext.gameMode == GAMEMODE_NORMAL)
             SaveManager_SaveCurrentForCombo();
         if (gComboReturnCallback)
-            gComboReturnCallback();
+            gComboReturnCallback(isOwlSaveQuit ? 2 : (isReset ? 1 : 0));
         if (auto fast3d = std::dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetInstance()->GetWindow())) {
             fast3d->SetIsRunning(false);
         }

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -1104,7 +1104,10 @@ extern "C" void InitOTR(int argc, char* argv[]) {
     // Reverse MM->OOT trigger: the Clock Tower interior's South-Clock-Town door (spawn 1 only —
     // cycle resets respawn in this scene at spawns 0/2/3/6 and must stay in MM).
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneInit>([](s8 sceneId, s8 spawnNum) {
-        if (sceneId == SCENE_INSIDETOWER && spawnNum == 1) {
+        // GAMEMODE_NORMAL only: MM's attract demo (GAMEMODE_TITLE_SCREEN, after Sram_InitNewSave wiped
+        // the save) scene-hops through here, and would both teleport the player to OOT and persist the
+        // wiped save over the slot.
+        if (sceneId == SCENE_INSIDETOWER && spawnNum == 1 && gSaveContext.gameMode == GAMEMODE_NORMAL) {
             sComboReturnPending = true;
         }
     });
@@ -1114,8 +1117,10 @@ extern "C" void InitOTR(int argc, char* argv[]) {
         const bool isReset = sComboResetReturnPending;
         sComboReturnPending = false;
         sComboResetReturnPending = false;
-        // Portal return always persists MM; a reset persists only when autosave is enabled.
-        if (!isReset || CVarGetInteger("gEnhancements.Saving.Autosave", 0))
+        // Portal return always persists MM; a reset persists only when autosave is enabled. Never
+        // persist outside gameplay: the title/attract path wipes save first (Sram_InitNewSave).
+        if ((!isReset || CVarGetInteger("gEnhancements.Saving.Autosave", 0)) &&
+            gSaveContext.gameMode == GAMEMODE_NORMAL)
             SaveManager_SaveCurrentForCombo();
         if (gComboReturnCallback)
             gComboReturnCallback();
@@ -2536,6 +2541,34 @@ extern "C" __declspec(dllexport) void MM_InitArchives() {
 // ComboShip: -1 = normal MM boot; >= 0 = game-switch: skip title/file-select and load this slot.
 // extern "C" so title_setup.c (a C file) can link to it without name mangling.
 extern "C" int gComboStartFileNum = -1;
+
+// ComboShip (#89): how MM is being entered. 0 = through the Happy Mask Shop portal, which always
+// arrives in South Clock Town (the fixed portal exit). 1 = resuming a slot that was last saved in MM,
+// which is a real save load and so honors Remember Save Location. Set by the launcher before each
+// MM_RunGame/MM_ResumeGame; read by title_setup.c.
+extern "C" int gComboEntryIsResume = 0;
+extern "C" __declspec(dllexport) void MM_SetComboEntryIsResume(int isResume) {
+    gComboEntryIsResume = isResume ? 1 : 0;
+}
+
+// ComboShip (#83): adopt OOT's targeting/audio. MM normally reads these from global.json, which combo
+// never writes (its file select is never reached), leaving SaveContext_Init's defaults — so
+// Z-targeting silently reverted to Switch. Queries soh.dll; no-op if the export is missing.
+extern "C" void Combo_AdoptOOTGlobalOptions(void) {
+    static void (*sFn)(int*, int*) = nullptr;
+    static bool sTried = false;
+    if (!sTried) {
+        sTried = true;
+        if (HMODULE h = GetModuleHandleA("soh.dll"))
+            sFn = (void (*)(int*, int*))GetProcAddress(h, "SOH_GetGlobalOptions");
+    }
+    if (!sFn)
+        return;
+    int zTarget = 0, audio = 0;
+    sFn(&zTarget, &audio);
+    gSaveContext.options.zTargetSetting = (u8)zTarget;
+    gSaveContext.options.audioSetting = (u8)audio;
+}
 
 // C-callable wrapper used by title_setup.c (which is a C file) to load a MM save from disk.
 extern "C" void Combo_LoadMMSaveFile(int mmFileNum) {

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -165,6 +165,13 @@ static bool sComboOwlSaveQuitPending = false;
 extern "C" void Combo_RequestOwlSaveQuit(void) {
     sComboOwlSaveQuitPending = true;
 }
+// Drop any unconsumed return request. Called as MM is entered: one left over from the previous session
+// would immediately quit the new one.
+static void Combo_ClearReturnRequests(void) {
+    sComboReturnPending = false;
+    sComboResetReturnPending = false;
+    sComboOwlSaveQuitPending = false;
+}
 // MM's own ResourceManager, created at first boot and kept alive for the whole process. A combo
 // transition swaps the Context's active RM between MM's and OOT's, so each game keeps its archives +
 // resource cache resident and nothing is ever unloaded (no dangling cached pointers). See MM_ResumeGame.
@@ -2574,6 +2581,7 @@ extern "C" int gComboStartFileNum = -1;
 extern "C" int gComboEntryIsResume = 0;
 extern "C" __declspec(dllexport) void MM_SetComboEntryIsResume(int isResume) {
     gComboEntryIsResume = isResume ? 1 : 0;
+    Combo_ClearReturnRequests(); // a stale request would quit the session we're about to start
 }
 
 // ComboShip (#83): adopt OOT's targeting/audio. MM normally reads these from global.json, which combo

--- a/mm/2s2h/BenPort.h
+++ b/mm/2s2h/BenPort.h
@@ -180,6 +180,12 @@ bool Ship_HandleConsoleCrashAsReset();
 
 // ComboShip: file slot to load on MM boot (-1 = normal boot).
 extern int gComboStartFileNum;
+// ComboShip (#89): 0 = entered through the Mask Shop portal, 1 = resuming a slot last saved in MM.
+extern int gComboEntryIsResume;
+// ComboShip (#83): copy OOT's targeting/audio into gSaveContext.options.
+void Combo_AdoptOOTGlobalOptions(void);
+// ComboShip (#89): set save.entrance for a boot resume (defined in z_sram_NES.c).
+void Combo_SetMMResumeEntrance(void);
 // Load an existing MM save from disk into gSaveContext (C-callable wrapper).
 void Combo_LoadMMSaveFile(int mmFileNum);
 

--- a/mm/2s2h/BenPort.h
+++ b/mm/2s2h/BenPort.h
@@ -200,7 +200,7 @@ uint64_t GetUnixTimestamp();
 #ifdef _WIN32
 __declspec(dllexport)
 #endif
-    void MM_SetOnComboReturnCallback(void (*cb)(void));
+    void MM_SetOnComboReturnCallback(void (*cb)(int kind));
 #ifdef _WIN32
 __declspec(dllexport)
 #endif

--- a/mm/2s2h/BenPort.h
+++ b/mm/2s2h/BenPort.h
@@ -184,8 +184,8 @@ extern int gComboStartFileNum;
 extern int gComboEntryIsResume;
 // ComboShip (#83): copy OOT's targeting/audio into gSaveContext.options.
 void Combo_AdoptOOTGlobalOptions(void);
-// ComboShip (#89): set save.entrance for a boot resume (defined in z_sram_NES.c).
-void Combo_SetMMResumeEntrance(void);
+// ComboShip (#89): owl save quits to OOT's title instead of MM's own file select.
+void Combo_RequestOwlSaveQuit(void);
 // Load an existing MM save from disk into gSaveContext (C-callable wrapper).
 void Combo_LoadMMSaveFile(int mmFileNum);
 

--- a/mm/src/code/title_setup.c
+++ b/mm/src/code/title_setup.c
@@ -67,10 +67,11 @@ void Setup_InitImpl(SetupState* this) {
         gSaveContext.flashSaveAvailable = true;
         // Load the MM save that matches the OOT slot (OOT slot N → MM file N+1).
         Combo_LoadMMSaveFile(gComboStartFileNum + 1);
-        // Portal entry always arrives at the fixed portal exit; a boot resume spawns where the save
-        // says (pause save if Remember Save Location was on, else the owl statue).
-        if (gComboEntryIsResume) {
-            Combo_SetMMResumeEntrance();
+        // South Clock Town is the default arrival for both portal entry and a resume. Only a resume
+        // with Remember Save Location on returns to the stored spot (set by SavingEnhancements).
+        if (gComboEntryIsResume && CVarGetInteger("gEnhancements.Saving.RememberSaveLocation", 0) &&
+            gSaveContext.save.shipSaveInfo.pauseSaveEntrance != -1) {
+            gSaveContext.save.entrance = gSaveContext.save.shipSaveInfo.pauseSaveEntrance;
         } else {
             gSaveContext.save.entrance = ENTRANCE(SOUTH_CLOCK_TOWN, 0);
         }

--- a/mm/src/code/title_setup.c
+++ b/mm/src/code/title_setup.c
@@ -61,12 +61,19 @@ void Setup_InitImpl(SetupState* this) {
 
 #ifdef COMBO_BUILD
     if (gComboStartFileNum >= 0) {
+        // Sram_LoadGlobalOptions above found no global.json in combo, so take OOT's settings.
+        Combo_AdoptOOTGlobalOptions();
         // Set flashSaveAvailable so Sram_Alloc allocates saveBuf (normally set by the title screen).
         gSaveContext.flashSaveAvailable = true;
         // Load the MM save that matches the OOT slot (OOT slot N → MM file N+1).
         Combo_LoadMMSaveFile(gComboStartFileNum + 1);
-        // Always spawn in South Clock Town regardless of save state.
-        gSaveContext.save.entrance = ENTRANCE(SOUTH_CLOCK_TOWN, 0);
+        // Portal entry always arrives at the fixed portal exit; a boot resume spawns where the save
+        // says (pause save if Remember Save Location was on, else the owl statue).
+        if (gComboEntryIsResume) {
+            Combo_SetMMResumeEntrance();
+        } else {
+            gSaveContext.save.entrance = ENTRANCE(SOUTH_CLOCK_TOWN, 0);
+        }
         gSaveContext.save.cutsceneIndex = 0;
         // Reset magicLevel like Sram_OpenSave does — re-arms the magic meter grow animation
         // (Interface_Update only steps magicCapacity when magicLevel == 0).

--- a/mm/src/code/z_play.c
+++ b/mm/src/code/z_play.c
@@ -756,8 +756,13 @@ void Play_UpdateTransition(PlayState* this) {
                     }
 
                     if (gSaveContext.gameMode == GAMEMODE_OWL_SAVE) {
+#ifdef COMBO_BUILD
+                        // ComboShip: quit to OOT's title; MM's own file select is unreachable here.
+                        Combo_RequestOwlSaveQuit();
+#else
                         STOP_GAMESTATE(&this->state);
                         SET_NEXT_GAMESTATE(&this->state, TitleSetup_Init, sizeof(TitleSetupState));
+#endif
                     } else if (gSaveContext.gameMode != GAMEMODE_FILE_SELECT) {
                         STOP_GAMESTATE(&this->state);
                         SET_NEXT_GAMESTATE(&this->state, Play_Init, sizeof(PlayState));

--- a/mm/src/code/z_play.c
+++ b/mm/src/code/z_play.c
@@ -758,6 +758,9 @@ void Play_UpdateTransition(PlayState* this) {
                     if (gSaveContext.gameMode == GAMEMODE_OWL_SAVE) {
 #ifdef COMBO_BUILD
                         // ComboShip: quit to OOT's title; MM's own file select is unreachable here.
+                        // STOP_GAMESTATE still runs, or this branch re-fires every frame (transitionMode
+                        // stays TRANS_MODE_INSTANCE_RUNNING) and leaks the request into the next session.
+                        STOP_GAMESTATE(&this->state);
                         Combo_RequestOwlSaveQuit();
 #else
                         STOP_GAMESTATE(&this->state);

--- a/mm/src/code/z_play.c
+++ b/mm/src/code/z_play.c
@@ -757,10 +757,10 @@ void Play_UpdateTransition(PlayState* this) {
 
                     if (gSaveContext.gameMode == GAMEMODE_OWL_SAVE) {
 #ifdef COMBO_BUILD
-                        // ComboShip: quit to OOT's title; MM's own file select is unreachable here.
-                        // STOP_GAMESTATE still runs, or this branch re-fires every frame (transitionMode
-                        // stays TRANS_MODE_INSTANCE_RUNNING) and leaks the request into the next session.
-                        STOP_GAMESTATE(&this->state);
+                        // ComboShip: quit to OOT's title; MM's own file select is unreachable here. Play
+                        // must keep running (the return hook drives the handoff), so end the transition
+                        // instead of the gamestate — otherwise this branch re-fires every frame.
+                        this->transitionMode = TRANS_MODE_OFF;
                         Combo_RequestOwlSaveQuit();
 #else
                         STOP_GAMESTATE(&this->state);

--- a/mm/src/code/z_sram_NES.c
+++ b/mm/src/code/z_sram_NES.c
@@ -1321,6 +1321,27 @@ static u16 sOwlWarpEntrances[OWL_WARP_MAX - 1] = {
     ENTRANCE(STONE_TOWER, 3),              // OWL_WARP_STONE_TOWER
 };
 
+#ifdef COMBO_BUILD
+// ComboShip (#89): entrance for a boot resume into MM. Mirrors the pause-save/owl-warp selection in
+// Sram_OpenSave below, which combo's MM entry path never runs (sOwlWarpEntrances is file-static here).
+void Combo_SetMMResumeEntrance(void) {
+    if (gSaveContext.save.shipSaveInfo.pauseSaveEntrance != -1) {
+        gSaveContext.save.entrance = gSaveContext.save.shipSaveInfo.pauseSaveEntrance;
+    } else if (gSaveContext.save.owlWarpId > OWL_WARP_MAX) {
+        gSaveContext.save.entrance = 0;
+    } else {
+        gSaveContext.save.entrance = sOwlWarpEntrances[(void)0, gSaveContext.save.owlWarpId];
+    }
+    if ((gSaveContext.save.entrance == ENTRANCE(SOUTHERN_SWAMP_POISONED, 10)) &&
+        CHECK_WEEKEVENTREG(WEEKEVENTREG_CLEARED_WOODFALL_TEMPLE)) {
+        gSaveContext.save.entrance = ENTRANCE(SOUTHERN_SWAMP_CLEARED, 10);
+    } else if ((gSaveContext.save.entrance == ENTRANCE(MOUNTAIN_VILLAGE_WINTER, 8)) &&
+               CHECK_WEEKEVENTREG(WEEKEVENTREG_CLEARED_SNOWHEAD_TEMPLE)) {
+        gSaveContext.save.entrance = ENTRANCE(MOUNTAIN_VILLAGE_SPRING, 8);
+    }
+}
+#endif
+
 void Sram_OpenSave(FileSelectState* fileSelect, SramContext* sramCtx) {
     s32 i;
     s32 pad;

--- a/mm/src/code/z_sram_NES.c
+++ b/mm/src/code/z_sram_NES.c
@@ -1321,27 +1321,6 @@ static u16 sOwlWarpEntrances[OWL_WARP_MAX - 1] = {
     ENTRANCE(STONE_TOWER, 3),              // OWL_WARP_STONE_TOWER
 };
 
-#ifdef COMBO_BUILD
-// ComboShip (#89): entrance for a boot resume into MM. Mirrors the pause-save/owl-warp selection in
-// Sram_OpenSave below, which combo's MM entry path never runs (sOwlWarpEntrances is file-static here).
-void Combo_SetMMResumeEntrance(void) {
-    if (gSaveContext.save.shipSaveInfo.pauseSaveEntrance != -1) {
-        gSaveContext.save.entrance = gSaveContext.save.shipSaveInfo.pauseSaveEntrance;
-    } else if (gSaveContext.save.owlWarpId > OWL_WARP_MAX) {
-        gSaveContext.save.entrance = 0;
-    } else {
-        gSaveContext.save.entrance = sOwlWarpEntrances[(void)0, gSaveContext.save.owlWarpId];
-    }
-    if ((gSaveContext.save.entrance == ENTRANCE(SOUTHERN_SWAMP_POISONED, 10)) &&
-        CHECK_WEEKEVENTREG(WEEKEVENTREG_CLEARED_WOODFALL_TEMPLE)) {
-        gSaveContext.save.entrance = ENTRANCE(SOUTHERN_SWAMP_CLEARED, 10);
-    } else if ((gSaveContext.save.entrance == ENTRANCE(MOUNTAIN_VILLAGE_WINTER, 8)) &&
-               CHECK_WEEKEVENTREG(WEEKEVENTREG_CLEARED_SNOWHEAD_TEMPLE)) {
-        gSaveContext.save.entrance = ENTRANCE(MOUNTAIN_VILLAGE_SPRING, 8);
-    }
-}
-#endif
-
 void Sram_OpenSave(FileSelectState* fileSelect, SramContext* sramCtx) {
     s32 i;
     s32 pad;

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -1006,7 +1006,7 @@ void SetAreaSpoiled(RandomizerCheckArea rcArea) {
     SaveManager::Instance->SaveSection(gSaveContext.fileNum, sectionId, true);
 }
 
-void InternalRecalculateAvailableChecks(RandomizerRegion startingRegion, RandoAgeTime startingAgeTime);
+bool InternalRecalculateAvailableChecks(RandomizerRegion startingRegion, RandoAgeTime startingAgeTime);
 
 void CheckTrackerWindow::DrawElement() {
     Color_Background = CVarGetColor(CVAR_TRACKER_CHECK("BgColor.Value"), Color_Bg_Default);
@@ -1092,9 +1092,11 @@ comboSkipDisplayGates:;
             return;
         }
 
-        if (recalculateAvailable) {
+        // Only consume the request if the recalc actually ran, otherwise it is silently lost and the
+        // counts/logic glyphs freeze until something else happens to request another one.
+        if (recalculateAvailable &&
+            InternalRecalculateAvailableChecks(availableChecksStartingRegion, availableChecksStartingAgeTime)) {
             recalculateAvailable = false;
-            InternalRecalculateAvailableChecks(availableChecksStartingRegion, availableChecksStartingAgeTime);
             availableChecksStartingRegion = RR_ROOT;
             availableChecksStartingAgeTime = RAT_NONE;
         }
@@ -2252,24 +2254,21 @@ void ImGuiDrawTwoColorPickerSection(const char* text, const char* cvarMainName, 
     UIWidgets::PopStyleCombobox();
 }
 
-void InternalRecalculateAvailableChecks(RandomizerRegion startingRegion, RandoAgeTime startingAgeTime) {
+// Returns false when it bailed without recomputing, so the caller can keep the request pending.
+bool InternalRecalculateAvailableChecks(RandomizerRegion startingRegion, RandoAgeTime startingAgeTime) {
     if (!enableAvailableChecks || !GameInteractor::IsSaveLoaded()) {
-        return;
+        return false;
     }
-#ifdef COMBO_BUILD
-    // ComboShip: drawn as a dormant peek from the other game's thread; no play state to walk from.
-    if (gPlayState == nullptr) {
-        return;
-    }
-#endif
-
     ResetPerformanceTimer(PT_RECALCULATE_AVAILABLE_CHECKS);
     StartPerformanceTimer(PT_RECALCULATE_AVAILABLE_CHECKS);
 
     const auto& ctx = Rando::Context::GetInstance();
     logic = ctx->GetLogic();
 
-    int16_t entranceIndex = gPlayState->nextEntranceIndex;
+    // ComboShip: on a dormant peek (drawn while the other game is foreground) there is no play state,
+    // so start from the saved entrance instead. Everything else here reads gSaveContext already.
+    int16_t entranceIndex =
+        (gPlayState != nullptr) ? gPlayState->nextEntranceIndex : (int16_t)gSaveContext.entranceIndex;
     if (startingRegion == RR_ROOT && entranceIndex >= 0 && entranceIndex < ENTR_MAX) {
         // Try to find a mapped entrance
         // e.g. ENTR_DEKU_TREE_0_1 (index 1) is not mapped, but ENTR_DEKU_TREE_ENTRANCE (index 0) is mapped
@@ -2328,6 +2327,7 @@ void InternalRecalculateAvailableChecks(RandomizerRegion startingRegion, RandoAg
     StopPerformanceTimer(PT_RECALCULATE_AVAILABLE_CHECKS);
     SPDLOG_INFO("Recalculate Available Checks Time: {}ms",
                 GetPerformanceTimer(PT_RECALCULATE_AVAILABLE_CHECKS).count());
+    return true;
 }
 
 void RecalculateAvailableChecks(RandomizerRegion startingRegion /* = RR_ROOT */,

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -3208,6 +3208,12 @@ bool Combo_OotIsForeground(void) {
 // SOH_ResumeGame so OOT boots to the title sequence instead of resuming the dormant save.
 static bool sComboResetPending = false;
 
+// ComboShip (#89): MM-initiated equivalent of the reset flag — an owl save quits to OOT's title
+// rather than MM's own file select, which combo has no path to.
+extern "C" __declspec(dllexport) void SOH_SetComboBootToTitle(void) {
+    sComboResetPending = true;
+}
+
 // Handle a reset request. If MM is foreground, bounce back to OOT (MM saves if autosave is on, then
 // goes dormant) and flag OOT to boot to the title sequence on resume. Returns true if it took over the
 // reset; false lets the caller run OOT's normal reset (which already lands on the boot sequence).

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -2756,6 +2756,17 @@ extern "C" __declspec(dllexport) void SOH_GetCurrentPlayerName(unsigned char out
     }
 }
 
+// ComboShip (#83): OOT persists these per-save; MM keeps its equivalents in global.json, which combo
+// never writes (MM's file select is never reached), so MM falls back to SaveContext_Init's hardcoded
+// defaults — notably Switch targeting. MM adopts OOT's values on entry instead. Language is
+// deliberately excluded: the two games' enums disagree (OOT ENG=0, MM JPN=0).
+extern "C" __declspec(dllexport) void SOH_GetGlobalOptions(int* zTarget, int* audio) {
+    if (zTarget)
+        *zTarget = gSaveContext.zTargetSetting;
+    if (audio)
+        *audio = gSaveContext.audioSetting;
+}
+
 extern "C" void (*gComboSceneSwitchCallback)(int fileNum) = nullptr;
 
 extern "C" __declspec(dllexport) void SOH_SetOnSceneSwitchCallback(void (*cb)(int fileNum)) {
@@ -4531,6 +4542,16 @@ extern "C" __declspec(dllexport) void SOH_TriggerComboGenerate(void) {
 extern "C" void FileChoose_Main(GameState* thisx);
 extern "C" __declspec(dllexport) uint8_t SOH_IsOnFileSelect(void) {
     return (gPlayState == NULL && gGameState != NULL && gGameState->main == (GameStateFunc)FileChoose_Main) ? 1 : 0;
+}
+
+// ComboShip (#89): leave OOT's game loop before its first Play frame so the launcher can enter MM.
+// Clearing init is what ends RunFrame's `while (nextOvl)` (FileChoose queued Play_Init); no save and no
+// OnExitGame here — both would break the resume. See docs/deviations/boot-shutdown.md.
+extern "C" __declspec(dllexport) void SOH_ParkForComboMMResume(void) {
+    if (!gGameState)
+        return;
+    gGameState->init = nullptr;
+    gGameState->running = false;
 }
 
 extern "C" __declspec(dllexport) void SOH_SetSeedGenerated(uint8_t g) {

--- a/soh/src/code/title_setup.c
+++ b/soh/src/code/title_setup.c
@@ -2,6 +2,7 @@
 
 #ifdef COMBO_BUILD
 #include "soh/Enhancements/game-interactor/GameInteractor_Hooks.h"
+#include "soh/Enhancements/randomizer/randomizer_entrance.h" // Entrance_OverrideNextIndex
 // Set by SOH_ResumeGame (OTRGlobals.cpp) on a combo MM->OOT return. >= 0 means: skip the title /
 // file-select screens, load this save slot, and spawn straight into Play in the Market outside the
 // Happy Mask Shop (the fixed arrival point for the cross-game portal return).
@@ -21,7 +22,6 @@ void TitleSetup_InitImpl(GameState* gameState) {
         gSaveContext.fileNum = gComboReturnFileNum;
         gSaveContext.gameMode = GAMEMODE_NORMAL;
         Sram_OpenSave();
-        gSaveContext.entranceIndex = ENTR_MARKET_DAY_OUTSIDE_HAPPY_MASK_SHOP;
         // Mirror FileChoose_LoadGame's magic staging so Play_Init refills the meter normally.
         gSaveContext.magicFillTarget = gSaveContext.magic;
         gSaveContext.magic = 0;
@@ -30,6 +30,9 @@ void TitleSetup_InitImpl(GameState* gameState) {
         // recreated gRandoContext, and consumers like the check tracker must tear down + re-init.
         GameInteractor_ExecuteOnExitGame(gSaveContext.fileNum);
         GameInteractor_ExecuteOnLoadGame(gSaveContext.fileNum);
+        // Must follow OnLoadGame: the rando handler's Entrance_SetSavewarpEntrance() recomputes from
+        // savedSceneNum (never set by the portal handoff) and would clobber this with Link's House.
+        gSaveContext.entranceIndex = Entrance_OverrideNextIndex(ENTR_MARKET_DAY_OUTSIDE_HAPPY_MASK_SHOP);
         gComboReturnFileNum = -1;
         gameState->running = false;
         SET_NEXT_GAMESTATE(gameState, Play_Init, PlayState);


### PR DESCRIPTION
Closes #89, closes #87, closes #83. Playtested end to end: resume-into-MM, owl-save quit, portal round trip and both spawn points all behave.

Also lands part of **#81** — the dormant check-tracker recalc — because the resume depends on it (see below). #81's remaining mechanism needs #90 first, so that issue stays open.

### #89 — resume the game the slot was last played in
New `combo.lastGame` in the save container (`0`=OOT, `1`=MM; absent means OOT, so older saves behave as before). `Combo_OnOOTSaveLoad` already fires at the ideal moment — `FileChoose_LoadGame` runs `OnLoadGame` at its tail, after `Sram_OpenSave` rebuilt `gRandoContext` and after the dormant MM save is loaded, but before OOT executes a Play frame — so the decision lives in the combo layer and needs no vendored file-select edit.

`SOH_ParkForComboMMResume` clears `gGameState->init` as well as `running`: `RunFrame`'s outer `while (nextOvl)` only reaches `WindowClose()` when `Graph_GetNextGameState` returns NULL, and `FileChoose_LoadGame` has already queued `Play_Init`. It deliberately does not save (that would stamp `lastGame` back to OOT) and does not fire `OnExitGame` (the dormant tracker peek needs the rando context just built).

**`lastGame` is written at the two transitions only, never from save writes.** That was the subtle one: loading an OOT save writes OOT sections itself (rando + check-tracker `OnLoadGame` handlers), which stamped OOT over MM microseconds before the resume decision read it.

MM's spawn: South Clock Town for both portal entry and resume; only a resume with Remember Save Location on uses `shipSaveInfo.pauseSaveEntrance` — where that enhancement actually stores the spot, and which combo never applies because it never runs `Sram_OpenSave`.

### #89 — owl save no longer corrupts the MM save
An owl save sets `GAMEMODE_OWL_SAVE`, and `z_play.c` natively quits to MM's own file select. In combo that re-ran MM's boot (`gComboStartFileNum` is `-1` by then), so the attract path's `Sram_InitNewSave` wiped the save and MM's file select wrote the wipe into the container — **an ordinary owl save destroyed the slot's MM section.** A `COMBO_BUILD` seam ends the *transition* (not the gamestate — that hung, since the return hook drives the handoff) and quits to OOT's title instead.

The return callback now reports its kind (portal / reset / owl-save quit). Only a portal return moves `lastGame` to OOT; a reset or quit instead invalidates MM's in-memory slot so the trackers re-read it.

### #87 — leaving MM no longer spawns at Link's House
The Mask Shop arrival entrance is assigned *after* `GameInteractor_ExecuteOnLoadGame`; the rando handler's `Entrance_SetSavewarpEntrance()` recomputes from `savedSceneNum` (never set by the portal handoff) and was overwriting it. Wrapped in `Entrance_OverrideNextIndex()` so it stays correct once entrance shuffle is generated for combo seeds.

### #83 — MM inherits OOT's targeting and audio
MM keeps these in `global.json`, which combo never writes, so `SaveContext_Init`'s defaults applied and Z-targeting silently reverted to Switch. **Language is excluded on purpose:** the enums disagree (OOT `ENG=0`, MM `JPN=0`) and MM's runtime reads `options.language`, not the `languageSetting` field that gets serialized.

### Notes for reviewers
- The `GAMEMODE_NORMAL` guard sits at the return **call site**, not inside `SaveManager_SaveCurrentForCombo` — that function has six callers and four legitimately run while MM is dormant with a stale `gameMode` (new-rando-save creation, dormant cross-game grants, `MM_MarkForeignObtained`, Anchor persist). Guarding inside it silently discarded the MM half of freshly generated seeds.
- Because entry stamps MM, entering the portal and quitting without saving in MM resumes MM rather than OOT. Intended: the flag tracks where the player was.
- Vendored footprint: one `#ifdef COMBO_BUILD` seam in `mm/src/code/z_play.c` with vanilla preserved verbatim in the `#else`; the `title_setup.c` changes on both sides sit inside pre-existing combo blocks. No vendored deletions. Rationale is in `docs/deviations/boot-shutdown.md`.
- Known minor edge, developer-tools only: with `DebugEnabled`, picking file 1 opens the debug map select but still fires `OnLoadGame`, so a slot-0 `lastGame=MM` would route to MM instead. Not gated because the clean check (queued next state == `Play_Init`) isn't exposed.

<!--- section:artifacts:start -->
### Build Artifacts
  - [comborando-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8621709585.zip)
  - [ComboShip-package-zip.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8621709009.zip)
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8621708570.zip)
<!--- section:artifacts:end -->