### PR TITLE
fix(combo): make the headless gentest/playthrough paths mirror RunComboFill

### DIFF
--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -1576,7 +1576,7 @@ static void RunComboPlaythrough(const std::string& inputSeed) {
             continue;
         }
         fill = ComboRando::CrossWorldCombinedFill(sohDump, mmDump, masterSeed, ootOracle, mmOracle, nullptr, forcedOot,
-                                                 ComboRando::OotAccessFromDump(sohDump));
+                                                  ComboRando::OotAccessFromDump(sohDump));
         if (!fill.success)
             Combo_MM_Rando_Restore();
     }

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -1452,13 +1452,6 @@ static int RunComboGenTest(int numSeeds, uint32_t seedBase) {
         std::cerr << "[GENTEST] dump functions not resolved — cannot run\n";
         return -1;
     }
-    std::string sohDump = SOH_DumpRandoStaticData();
-    std::string mmDump = MM_DumpRandoStaticData();
-    if (sohDump.empty() || mmDump.empty()) {
-        std::cerr << "[GENTEST] empty dump — cannot run\n";
-        return -1;
-    }
-
     ComboRando::OracleFns ootOracle = { Combo_SOH_Rando_Reset, Combo_SOH_Rando_SetOwnedItems,
                                         Combo_SOH_Rando_GetReachableChecks, Combo_SOH_Rando_PlaceItem,
                                         Combo_SOH_Rando_GetPortalOpen };
@@ -1470,19 +1463,41 @@ static int RunComboGenTest(int numSeeds, uint32_t seedBase) {
     int failures = 0;
     auto t0 = std::chrono::steady_clock::now();
     for (int i = 0; i < numSeeds; ++i) {
-        uint32_t seed = seedBase + static_cast<uint32_t>(i);
-        // Per-seed OOT entrance layout, exactly like the real generator (no-op when the options are off).
-        if (SOH_ShuffleEntrancesForCombo && !SOH_ShuffleEntrancesForCombo(seed)) {
-            std::cerr << "[GENTEST]   seed " << seed << " FAIL: OOT entrance shuffle found no valid layout\n";
-            ++failures;
-            continue;
+        const uint32_t baseSeed = seedBase + static_cast<uint32_t>(i);
+        ComboRando::CombinedFillResult result{};
+        // Mirror RunComboFill's whole-fill retries: a seed rejected on attempt 0 is a PASS in-game
+        // after one reroll, so counting it FAIL here would inflate the failure rate.
+        for (int attempt = 0; attempt < ComboRando::kFillAttempts && !result.success; ++attempt) {
+            const uint32_t seed = baseSeed + attempt * 0x9E3779B9u;
+            // Seeds before the dump (shop/scrub choices are seed-derived and made inside it); forced
+            // placements before the shuffle, whose ItemReset wipes the placement they read.
+            if (SOH_SetComboRandoSeed)
+                SOH_SetComboRandoSeed(seed);
+            if (MM_SetComboRandoSeed)
+                MM_SetComboRandoSeed(seed);
+            std::string sohDump = SOH_DumpRandoStaticData();
+            std::string mmDump = MM_DumpRandoStaticData();
+            if (sohDump.empty() || mmDump.empty()) {
+                std::cerr << "[GENTEST] empty dump — cannot run\n";
+                return -1;
+            }
+            std::string forcedOot;
+            if (SOH_GetForcedPlacements)
+                forcedOot = SOH_GetForcedPlacements(seed);
+            // Per-seed OOT entrance layout, exactly like the real generator (no-op when the options are off).
+            if (SOH_ShuffleEntrancesForCombo && !SOH_ShuffleEntrancesForCombo(seed)) {
+                result.error = "OOT entrance shuffle found no valid layout";
+                Combo_MM_Rando_Restore();
+                continue; // a different masterSeed yields a different layout — reroll, like RunComboFill
+            }
+            result = ComboRando::CrossWorldCombinedFill(sohDump, mmDump, seed, ootOracle, mmOracle, nullptr, forcedOot,
+                                                        ComboRando::OotAccessFromDump(sohDump));
+            Combo_MM_Rando_Restore(); // reset the MM oracle's snapshot guard for the next fill
         }
-        auto result = ComboRando::CrossWorldCombinedFill(sohDump, mmDump, seed, ootOracle, mmOracle, nullptr);
-        Combo_MM_Rando_Restore(); // reset the MM oracle's snapshot guard for the next fill
         if (result.success) {
-            std::cout << "[GENTEST]   seed " << seed << " PASS\n";
+            std::cout << "[GENTEST]   seed " << baseSeed << " PASS\n";
         } else {
-            std::cerr << "[GENTEST]   seed " << seed << " FAIL: " << result.error << "\n";
+            std::cerr << "[GENTEST]   seed " << baseSeed << " FAIL: " << result.error << "\n";
             ++failures;
         }
     }
@@ -1534,17 +1549,38 @@ static void RunComboPlaythrough(const std::string& inputSeed) {
     ComboRando::OracleFns mmOracle = { Combo_MM_Rando_Reset, Combo_MM_Rando_SetOwnedItems,
                                        Combo_MM_Rando_GetReachableChecks, Combo_MM_Rando_PlaceItem };
     std::string seedStr = inputSeed.empty() ? "1" : inputSeed;
-    std::string sohDump = SOH_DumpRandoStaticData();
-    std::string mmDump = MM_DumpRandoStaticData();
-    const uint32_t masterSeed = ComboHash(seedStr.c_str());
-    // OOT entrance layout, same as the real generator (no-op when the options are off).
-    if (SOH_ShuffleEntrancesForCombo && !SOH_ShuffleEntrancesForCombo(masterSeed)) {
-        std::cerr << "[PLAYTHROUGH] OOT entrance shuffle found no valid layout\n";
-        return;
+    const uint32_t baseSeed = ComboHash(seedStr.c_str());
+    std::string sohDump, mmDump;
+    ComboRando::CombinedFillResult fill{};
+    // Mirror RunComboFill including its retries — the player's seed may have come from attempt 1, and
+    // validating only attempt 0 would either report "did not generate" or log a world they never got.
+    for (int attempt = 0; attempt < ComboRando::kFillAttempts && !fill.success; ++attempt) {
+        const uint32_t masterSeed = baseSeed + attempt * 0x9E3779B9u;
+        if (SOH_SetComboRandoSeed)
+            SOH_SetComboRandoSeed(masterSeed);
+        if (MM_SetComboRandoSeed)
+            MM_SetComboRandoSeed(masterSeed);
+        sohDump = SOH_DumpRandoStaticData();
+        mmDump = MM_DumpRandoStaticData();
+        if (sohDump.empty() || mmDump.empty()) {
+            std::cerr << "[PLAYTHROUGH] empty static-data dump\n";
+            return;
+        }
+        // Read before the entrance shuffle: its ItemReset wipes the placement this reads.
+        std::string forcedOot;
+        if (SOH_GetForcedPlacements)
+            forcedOot = SOH_GetForcedPlacements(masterSeed);
+        if (SOH_ShuffleEntrancesForCombo && !SOH_ShuffleEntrancesForCombo(masterSeed)) {
+            fill.error = "OOT entrance shuffle found no valid layout";
+            Combo_MM_Rando_Restore();
+            continue;
+        }
+        fill = ComboRando::CrossWorldCombinedFill(sohDump, mmDump, masterSeed, ootOracle, mmOracle, nullptr, forcedOot,
+                                                 ComboRando::OotAccessFromDump(sohDump));
+        if (!fill.success)
+            Combo_MM_Rando_Restore();
     }
-    auto fill = ComboRando::CrossWorldCombinedFill(sohDump, mmDump, masterSeed, ootOracle, mmOracle, nullptr);
     if (!fill.success) {
-        Combo_MM_Rando_Restore();
         std::cerr << "[PLAYTHROUGH] seed '" << seedStr << "' did not generate: " << fill.error << "\n";
         return;
     }


### PR DESCRIPTION
Found while reviewing #110; independent of it (different files, no overlap).

## The problem

`COMBO_GENTEST=<count>` and `COMBO_PLAYTHROUGH=<seed>` both call
`ComboRando::CrossWorldCombinedFill` differently from the real generator
`RunComboFill` (`ComboShip.cpp:1140-1193`), so both validate a world the generator never
builds. Five deviations:

1. **No `ootAccess`** — defaulted to `ALL_REACHABLE`, so a No Logic or ALR-off seed was checked
   under the wrong mode and reported `did not generate: OOT All Locations Reachable violated`
   for a seed that generates fine in-game.
2. **No `forcedOot`** — Link's Pocket went unreserved, so the OOT pool kept an extra item and
   placements diverged from what the player received.
3. **Seeds not set before the dump** — `MM_DumpRandoStaticData` calls `Ship_Random_Seed` at its
   top and OOT's dump calls `Combo_SeedShopRng()` before `ComboFillConfined()`, so shop, scrub
   and merchant choices are seed-derived and made *inside* the dump. Both paths dumped with
   whatever seed happened to be set.
4. **`RunComboGenTest` dumped once for the whole seed range** instead of per seed, so every seed
   shared one confined placement / price roll.
5. **Neither retried.** `RunComboFill` runs `kFillAttempts` and re-derives the seed per attempt
   (`baseSeed + attempt * 0x9E3779B9u`). A seed the player got from attempt 1 was therefore
   either reported as ungeneratable, or — worse — the validator silently emitted a playthrough
   log for a world they never received. For gentest this inflated the failure rate, since a seed
   rejected on attempt 0 is a PASS in-game after one reroll.

## The fix

Both paths now follow the reference order exactly, inside the same retry loop:

```
set both RNG seeds -> dump -> read SOH_GetForcedPlacements -> entrance shuffle
  -> fill(forcedOot, OotAccessFromDump(sohDump))
```

The two ordering constraints are load-bearing and now honoured in both: seeds before the dump
(shop setup runs inside it), and forced placements before `SOH_ShuffleEntrancesForCombo`, whose
`ItemReset` wipes the live placement that read depends on.


<!--- section:artifacts:start -->
### Build Artifacts
  - [comborando-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8749769196.zip)
  - [ComboShip-package-zip.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8749768140.zip)
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8749767455.zip)
<!--- section:artifacts:end -->