### PR TITLE
fix: foreign animated-item crash, honest crash tracebacks, and foreign trap behaviour

### DIFF
--- a/combo/menu/ComboForeignAnim.h
+++ b/combo/menu/ComboForeignAnim.h
@@ -377,25 +377,8 @@ inline Gfx* CfaBuildScroll(PlayState* play, const CwAnimSegBind* b) {
                               b->xStep1, b->yStep1, b->xStep2, b->yStep2);
 }
 
-// Bind one described segment in the host frame and record it so the caller can restore it.
-inline void CfaBindSeg(PlayState* play, const CwAnimSegBind* b, int32_t* segs, int32_t* segCount) {
-    uintptr_t target = 0;
-    switch (b->kind) {
-        case CW_ANIM_SEG_EMPTY_DL:
-            target = (uintptr_t)CfaEmptyDL(play);
-            break;
-        case CW_ANIM_SEG_PATH:
-            target = (uintptr_t)b->path; // resolved against the owning RM by the bracket around the draw
-            break;
-        case CW_ANIM_SEG_TEXSCROLL:
-            target = (uintptr_t)CfaBuildScroll(play, b);
-            break;
-        case CW_ANIM_SEG_XLU_RENDERMODE_1CY:
-            target = (uintptr_t)CfaXluRenderModeDL(play);
-            break;
-        default:
-            return; // pre-validated; never submit a DL against a segment we could not bind
-    }
+// Emit the segment bind on the described streams. Split out so the RM scope can wrap ONLY this.
+inline void CfaEmitSeg(PlayState* play, const CwAnimSegBind* b, uintptr_t target) {
     OPEN_DISPS(play->state.gfxCtx);
     if (b->onOpa) {
         gSPSegment(POLY_OPA_DISP++, b->segment, target);
@@ -404,9 +387,45 @@ inline void CfaBindSeg(PlayState* play, const CwAnimSegBind* b, int32_t* segs, i
         gSPSegment(POLY_XLU_DISP++, b->segment, target);
     }
     CLOSE_DISPS(play->state.gfxCtx);
+}
+
+// Bind one described segment in the host frame and record it so the caller can restore it.
+// Returns false when the segment could not be bound — callers must then not submit its DL.
+inline bool CfaBindSeg(PlayState* play, const CwAnimSegBind* b, const char* game, int32_t* segs, int32_t* segCount) {
+    uintptr_t target = 0;
+    std::shared_ptr<Ship::ResourceManager> pathRm; // non-null only for CW_ANIM_SEG_PATH
+    switch (b->kind) {
+        case CW_ANIM_SEG_EMPTY_DL:
+            target = (uintptr_t)CfaEmptyDL(play);
+            break;
+        case CW_ANIM_SEG_PATH:
+            // The host's gSPSegment probes this path against the ACTIVE RM at record time, so the
+            // playback bracket cannot help — swap to the owning RM across the emit itself.
+            pathRm = Ship::CrossRMRegistry::Get(game);
+            if (pathRm == nullptr) {
+                return false;
+            }
+            target = (uintptr_t)b->path;
+            break;
+        case CW_ANIM_SEG_TEXSCROLL:
+            target = (uintptr_t)CfaBuildScroll(play, b);
+            break;
+        case CW_ANIM_SEG_XLU_RENDERMODE_1CY:
+            target = (uintptr_t)CfaXluRenderModeDL(play);
+            break;
+        default:
+            return false; // pre-validated; never submit a DL against a segment we could not bind
+    }
+    if (pathRm != nullptr) {
+        Ship::ResourceManagerScope rmScope(pathRm);
+        CfaEmitSeg(play, b, target);
+    } else {
+        CfaEmitSeg(play, b, target); // host-built Gfx pointer: no RM swap
+    }
     if (*segCount < CW_ANIM_MAX_SEGS + 1) {
         segs[(*segCount)++] = b->segment;
     }
+    return true;
 }
 
 // Restore every segment the recipe bound to a benign empty DL, on BOTH streams (harmless where a
@@ -504,8 +523,8 @@ inline void CfaDrawFlame(PlayState* play, const CwItemAnimDrawInfo* info, const 
     OPEN_DISPS(play->state.gfxCtx);
     CFA_SETUP_XLU(play->state.gfxCtx);
     CLOSE_DISPS(play->state.gfxCtx);
-    if (info->flameHasSeg) {
-        CfaBindSeg(play, &info->flameSeg, segs, segCount);
+    if (info->flameHasSeg && !CfaBindSeg(play, &info->flameSeg, game, segs, segCount)) {
+        return; // flameSeg's only consumer is the flame DL; skip it, the model still draws
     }
 
     Matrix_Push();
@@ -600,6 +619,9 @@ inline int32_t ComboForeignAnim_Draw(const CwItemAnimDrawInfo* info, const char*
     if (info->opa && !CfaValidateOpaInfo(info)) {
         return 0; // unexpressible recipe — sentinel beats an unbound-segment draw
     }
+    if (Ship::CrossRMRegistry::Get(game) == nullptr) {
+        return 0; // owning game not resident: bail before any Gfx is emitted
+    }
 
     static std::unordered_map<std::string, CfaSkelEntry> sSkelCache;
     static std::unordered_map<std::string, CfaTexAnimEntry> sTexAnimCache;
@@ -661,8 +683,9 @@ inline int32_t ComboForeignAnim_Draw(const CwItemAnimDrawInfo* info, const char*
             taIt = sTexAnimCache.emplace(info->texAnimPath, CfaTexAnimEntry{}).first;
             CfaTexAnimEntry& e = taIt->second;
             if (auto rm = Ship::CrossRMRegistry::Get(game)) {
-                // No RM swap needed: the TextureAnimation factory has no nested loads for the
-                // color types (TexCycle would, but validation rejects it anyway).
+                // Scoped like the skel/anim load: today's validated types don't nested-load, but
+                // that is a property of the validated subset, not of the factory.
+                Ship::ResourceManagerScope rmScope(rm);
                 e.res = rm->LoadResource(info->texAnimPath);
                 e.mat = e.res ? (const CfaMatEntry*)e.res->GetRawPointer() : nullptr;
                 e.ok = CfaValidateTexAnim(e.mat);
@@ -699,7 +722,13 @@ inline int32_t ComboForeignAnim_Draw(const CwItemAnimDrawInfo* info, const char*
         }
 
         for (int32_t i = 0; i < info->segCount; i++) {
-            CfaBindSeg(play, &info->segs[i], segs, &segCount);
+            if (!CfaBindSeg(play, &info->segs[i], game, segs, &segCount)) {
+                // Unbindable segment: sentinel beats a garbage DL. Unreachable today (both false kinds
+                // are pre-rejected above); the sentinel inherits this item's matrix, so it may be tiny.
+                CfaRestoreSegs(play, segs, segCount);
+                sCfaInfo = nullptr;
+                return 0;
+            }
         }
         // MM's AnimatedMat_Draw inside the enemy-soul funcs: bind the animated material on the OPA
         // stream (the skeleton samples it there), restored with the rest below.
@@ -841,6 +870,7 @@ inline bool ComboForeignTexAnim_Run(PlayState* play, const char* game, const cha
         it = sCache.emplace(texAnimPath, CfaStaticTexAnim{}).first;
         CfaStaticTexAnim& e = it->second;
         if (auto rm = Ship::CrossRMRegistry::Get(game)) {
+            Ship::ResourceManagerScope rmScope(rm); // as above: scope the load, not the draw
             e.res = rm->LoadResource(texAnimPath);
             e.mat = e.res ? (const CfaMatEntry*)e.res->GetRawPointer() : nullptr;
             e.ok = CfaValidateTexAnim(e.mat);

--- a/combo/rando/CrossForeign.h
+++ b/combo/rando/CrossForeign.h
@@ -212,8 +212,7 @@ inline void AssignTrapDisguises(nlohmann::json& foreignArr, const nlohmann::json
         fm["fakeDisplayName"] = dn;
         // Prefer the owning game's curated near-miss name; letter-doubling is only the fallback.
         const std::vector<std::string>* tn = (fmeta != meta.end()) ? &fmeta->second.trickNames : nullptr;
-        fm["fakeTrickName"] =
-            (tn != nullptr && !tn->empty()) ? (*tn)[next() % tn->size()] : MakeTrickName(dn, next());
+        fm["fakeTrickName"] = (tn != nullptr && !tn->empty()) ? (*tn)[next() % tn->size()] : MakeTrickName(dn, next());
     }
 }
 
@@ -241,9 +240,9 @@ inline nlohmann::json BuildForeignArray(const nlohmann::json& foreignArray,
             return s;
         };
         std::string displayName = tag(fm.value("displayName", itemName));
-        nlohmann::json entry = { { "checkGame", checkGame },     { "checkName", checkName },
-                                 { "itemGame", itemGame },       { "itemName", itemName },
-                                 { "displayName", displayName }, { "advancement", fm.value("advancement", false) },
+        nlohmann::json entry = { { "checkGame", checkGame },         { "checkName", checkName },
+                                 { "itemGame", itemGame },           { "itemName", itemName },
+                                 { "displayName", displayName },     { "advancement", fm.value("advancement", false) },
                                  { "trap", fm.value("trap", false) } };
         // Trap disguise: fakeItemName stays bare (it's a grant-namespace key); the shown names get tagged.
         std::string fakeItemName = fm.value("fakeItemName", "");

--- a/combo/rando/CrossForeign.h
+++ b/combo/rando/CrossForeign.h
@@ -63,6 +63,7 @@ struct ForeignItem {
     std::string itemName;     // friendly item name in itemGame (bare; resolved by that game's map)
     std::string displayName;  // human string for the "sent"/"received" text
     bool advancement = false; // progression in its home game -> drives the held-up pickup animation
+    bool trap = false;        // a trap in its home game -> fires on the FINDER, never cross-delivered
     // Trap disguise (empty = none). The name/model shown until the check is collected; the GRANT
     // always uses itemName. fakeItemName lives in itemGame's namespace (feeds the draw producers).
     std::string fakeItemName;
@@ -133,6 +134,7 @@ struct ForeignItemMeta {
     std::string displayName;
     bool advancement = false;
     bool trap = false;
+    std::vector<std::string> trickNames; // curated near-miss names for this item (may be empty)
 };
 
 inline std::unordered_map<std::string, ForeignItemMeta> ParseItemMeta(const std::string& dump) {
@@ -147,6 +149,7 @@ inline std::unordered_map<std::string, ForeignItemMeta> ParseItemMeta(const std:
             meta.displayName = it.value("displayName", n);
             meta.advancement = it.value("advancement", false);
             meta.trap = it.value("trap", false);
+            meta.trickNames = it.value("trickNames", std::vector<std::string>{});
             m.emplace(std::move(n), std::move(meta));
         }
     } catch (...) {}
@@ -195,6 +198,7 @@ inline void AssignTrapDisguises(nlohmann::json& foreignArr, const nlohmann::json
         auto mit = meta.find(fm.value("itemName", ""));
         if (mit == meta.end() || !mit->second.trap)
             continue;
+        fm["trap"] = true; // before the no-candidate bail: an undisguised trap is still a trap
         const auto& cand = (itemGame == "mm") ? mmCand : ootCand;
         if (cand.empty())
             continue; // no plausible model this seed -> stays undisguised rather than lying badly
@@ -206,7 +210,10 @@ inline void AssignTrapDisguises(nlohmann::json& foreignArr, const nlohmann::json
             (fmeta != meta.end() && !fmeta->second.displayName.empty()) ? fmeta->second.displayName : fake;
         fm["fakeItemName"] = fake;
         fm["fakeDisplayName"] = dn;
-        fm["fakeTrickName"] = MakeTrickName(dn, next());
+        // Prefer the owning game's curated near-miss name; letter-doubling is only the fallback.
+        const std::vector<std::string>* tn = (fmeta != meta.end()) ? &fmeta->second.trickNames : nullptr;
+        fm["fakeTrickName"] =
+            (tn != nullptr && !tn->empty()) ? (*tn)[next() % tn->size()] : MakeTrickName(dn, next());
     }
 }
 
@@ -236,7 +243,8 @@ inline nlohmann::json BuildForeignArray(const nlohmann::json& foreignArray,
         std::string displayName = tag(fm.value("displayName", itemName));
         nlohmann::json entry = { { "checkGame", checkGame },     { "checkName", checkName },
                                  { "itemGame", itemGame },       { "itemName", itemName },
-                                 { "displayName", displayName }, { "advancement", fm.value("advancement", false) } };
+                                 { "displayName", displayName }, { "advancement", fm.value("advancement", false) },
+                                 { "trap", fm.value("trap", false) } };
         // Trap disguise: fakeItemName stays bare (it's a grant-namespace key); the shown names get tagged.
         std::string fakeItemName = fm.value("fakeItemName", "");
         if (!fakeItemName.empty()) {
@@ -324,6 +332,8 @@ inline std::unordered_map<std::string, ForeignItem> LoadForeignForGame(int slot,
             fi.itemName = fm.value("itemName", "");
             fi.displayName = fm.value("displayName", fi.itemName);
             fi.advancement = fm.value("advancement", false);
+            // Absent in pre-trap-flag saves -> false -> the item cross-delivers as before.
+            fi.trap = fm.value("trap", false);
             // Absent in pre-disguise saves -> empty -> every consumer falls back to the true name.
             fi.fakeItemName = fm.value("fakeItemName", "");
             fi.fakeDisplayName = fm.value("fakeDisplayName", "");

--- a/docs/deviations/boot-shutdown.md
+++ b/docs/deviations/boot-shutdown.md
@@ -391,3 +391,56 @@ entry was fine because it CREATES the save (default `magicLevel` 0).
 
 **Vendored (inside the existing `COMBO_BUILD` block):** `mm/src/code/title_setup.c` — one line,
 `magicLevel = 0` after the save load, mirroring `Sram_OpenSave`.
+
+## Crash-handler tracebacks: honour SymFromAddr, always print module + RVA (2026-08-03)
+
+**Why:** a player's Release traceback named `MM_Anchor_RequestTeleport` three times in a crash with no
+Anchor involvement, and sent the investigation into the Anchor code for about an hour. Three
+compounding defects in `PrintStack`:
+
+1. `SymFromAddr`'s return value was ignored while a single `SYMBOL_INFO` buffer was reused, so a
+   FAILED lookup silently reprinted the **previous** frame's name.
+2. The printed address was `symbol->Address` (the symbol's base), not the PC — so every frame that
+   resolved to the same symbol showed one identical address, and no RVA could be derived.
+3. A Release build ships no PDBs, so dbghelp synthesizes symbols from the **export table** only.
+   Every `static` function (all of the Fast3D interpreter) collapses onto an unrelated neighbouring
+   export, and 2ship.dll exports only its handful of `MM_*` combo entry points — so an entire MM call
+   chain reports as ~3 names, each wildly far from the real function.
+
+**`libultraship/src/ship/debug/CrashHandler.cpp` (COMBO_BUILD-guarded; upstream preserved verbatim
+under `#else` so future lus merges stay mechanical):**
+- `SymSetOptions` gains `SYMOPT_LOAD_LINES | SYMOPT_UNDNAME`. Without `LOAD_LINES`,
+  `SymGetLineFromAddr` can fail even when PDBs are present, silently degrading Debug builds too.
+- Per frame: reset `displacement` and `symbol->Name[0]`, keep `SymFromAddr`'s result, and print
+  `<unresolved>` when it fails — never a stale name.
+- `symbol->Flags & SYMFLAG_EXPORT` is surfaced as a `~export(approx)` marker. That flag is set exactly
+  when dbghelp invented the name from the export table, i.e. on every Release frame. Defect 3 is
+  unfixable without shipping PDBs, so the fix is to make it *visible* rather than silently trusted.
+- The module lookup is hoisted so **both** print branches carry the real PC, the module path and an
+  RVA. The file/line branch had the same stale-name hazard (it printed `symbol->Name` too), which was
+  the most misleading output of the three: this frame's file and line beside the previous frame's name.
+- `AppendStrTrunc` no longer reads past the source string's terminator, and `AppendLine` no longer
+  writes its newline unchecked. The latter was a genuine 1-byte heap overflow: `AppendStr` caps the
+  index at `gMaxBufferSize - 1`, so `AppendLine` could push it to `gMaxBufferSize` and the next
+  `AppendStrTrunc` wrote the terminator one byte past the allocation — inside the crash handler, i.e.
+  corrupting the very log we needed. Reachable for real on a stack-overflow crash with thousands of
+  frames.
+
+**Reading a Release traceback offline** (the whole point of the RVA):
+
+    llvm-symbolizer --obj=<matching dll> --relative-address <rva>
+
+`--relative-address` is mandatory — without it PE addresses are interpreted against the image base
+(`0x180000000`) and every lookup silently returns `??`. Verified end to end: a frame printed as
+`MM_Anchor_RequestTeleport +0x50E4C ... RVA 0x28096C` mapped back to `CfaBindSeg` at
+`combo/menu/ComboForeignAnim.h:403`, matching the Debug trace exactly.
+
+**Deliberately NOT shared with `combo/ComboShip.cpp`'s late filter**, which does the same job
+correctly. `ComboShip.exe` does not link libultraship on purpose — its filter has to survive the
+window after `FreeLibrary`, when `libultraship.dll` may be gone. The ~15 duplicated lines are the
+price of that; do not "DRY" them.
+
+**Known gap:** the RVA is only actionable where we hold the matching linker PDB. Release currently
+produces PDBs for soh/2ship (via the unconditional `/DEBUG` in `mm/CMakeLists.txt`) but **not** for
+libultraship or ComboShip.exe — which is where the crash above actually faulted. PDBs must never ship
+(they are ~5x the download), but they should be generated and archived per tagged release.

--- a/docs/deviations/rando.md
+++ b/docs/deviations/rando.md
@@ -1194,9 +1194,10 @@ be a lot of work for no player-visible gain.
 
 **Anchor teammates still get trapped.** The grant and the broadcast were bundled in one branch; only
 the local cross-grant is skipped. `Anchor_BroadcastCrossItem` / `MMAnchor_BroadcastCrossItem` still
-fire, and the receive path springs the trap on teammates (`Packets/GiveItem.cpp`). Unverified
-assumption worth a two-client test: that the broadcast is not echoed back to the sender, or the finder
-freezes twice.
+fire, and the receive path springs the trap on teammates (`Packets/GiveItem.cpp`). Verified with two
+clients in OOT (2026-08-03): both froze once and the finder was not re-frozen, so the broadcast is not
+echoed back to the sender. Note a teammate playing the *other* game still banks the trap and springs
+it on switch — that is the item-routing model, not a bug in this change.
 
 **Trick names:** both games expose their tables through small `COMBO_BUILD` accessors
 (`Rando::Traps::GetTrickNamesEnglish`, `Rando::StaticData::GetTrickNames`), emitted as `trickNames`

--- a/docs/deviations/rando.md
+++ b/docs/deviations/rando.md
@@ -1154,3 +1154,56 @@ game owns an item isn't actionable. `RunPlaythrough` still emits the structured 
 so the flattening happens in `ComboRando::PlaythroughLines`, applied only where the consolidated spoiler
 is assembled. The validator builds its own `pt1` from its own `RunPlaythrough` call and never reads the
 spoiler's section, so the two formats don't collide.
+
+## Foreign traps fire on the finder, and use each game's curated trick names (2026-08-03)
+
+**Why (effect):** a foreign trap did nothing to the player who found it. MM's `CheckQueue` foreign
+branch showed "You found &lt;disguise&gt;!" and called `SendForeignCheck` — mailing the trap into the
+other game's save — so the freeze never happened where it was collected. Native `RI_TRAP` by contrast
+shows `GetTrapMessage()` and calls `OfferTrapItem()`.
+
+**Why (names):** both games ship curated near-miss name tables — OOT's `trickNameTable`
+(`soh/soh/Enhancements/randomizer/Traps.cpp`, trilingual) and MM's `fakeItemNames`
+(`mm/2s2h/Rando/StaticData/Items.cpp`, English) — but the combo layer used neither. `MakeTrickName`
+only doubled a letter, so a disguised trap read as "Ganon's Souul" instead of "Rauru's Medallion".
+Note upstream MM's own fallback is broken (`fakeItemName` is still empty when the `else` runs, so it
+indexes an empty string), which is why the curated table matters rather than the fallback.
+
+**Trap identity** now rides in the seed. Both dumps already emitted a per-item `trap` flag
+(`rg == RG_ICE_TRAP` / `id == RI_TRAP`) but only `AssignTrapDisguises` consumed it, to pick disguises.
+It now also stamps `fm["trap"] = true` — **before** the no-candidate bail, so a trap that got no
+disguise is still flagged — the emitter writes it into each `foreign[]` entry, and `ForeignItem` gained
+`bool trap`. Absent in older saves → defaults false → previous behaviour, so this needs a regenerated
+seed to take effect.
+
+**Firing:** each game springs its **own** flavour, so an OOT Ice Trap found in MM becomes an MM trap
+and an MM trap found in OOT becomes OOT's freeze. Porting trap implementations between engines would
+be a lot of work for no player-visible gain.
+- MM (`Rando/MiscBehavior/CheckQueue.cpp`): `GetTrapMessage()` + `OfferTrapItem()`, no cross-grant.
+  Fires on every collection, matching native — a Song of Time cycle reset re-arms a native trap check,
+  so a foreign one should re-arm too.
+- OOT (`Enhancements/randomizer/hook_handlers.cpp` `OOT_DeliverForeign`): `FreezePlayer()` directly.
+  **Not** `pendingIceTrapCount++` — that counter is consumed by `VB_SHORT_CIRCUIT_GIVE_ITEM_PROCESS`,
+  which has already run by grant time, so incrementing it springs the trap on the player's **next**
+  pickup and short-circuits that item's presentation instead.
+- OOT text (`Messages/ItemMessages.cpp`): a foreign trap taunts with OOT's real ice-trap tables via a
+  new `Rando::Traps::BuildIceTrapMessageNamed`, naming what it pretended to be. The stock
+  `BuildIceTrapMessage` resolves the name from the draw entry, which for a foreign sentinel would read
+  "Combo Foreign Item" — and a foreign disguise may be an item of the *other* game with no local
+  `RandomizerGet` to resolve at all.
+
+**Anchor teammates still get trapped.** The grant and the broadcast were bundled in one branch; only
+the local cross-grant is skipped. `Anchor_BroadcastCrossItem` / `MMAnchor_BroadcastCrossItem` still
+fire, and the receive path springs the trap on teammates (`Packets/GiveItem.cpp`). Unverified
+assumption worth a two-client test: that the broadcast is not echoed back to the sender, or the finder
+freezes twice.
+
+**Trick names:** both games expose their tables through small `COMBO_BUILD` accessors
+(`Rando::Traps::GetTrickNamesEnglish`, `Rando::StaticData::GetTrickNames`), emitted as `trickNames`
+beside the existing `advancement`/`trap` flags and parsed into `ForeignItemMeta`.
+`AssignTrapDisguises` prefers a curated name and falls back to letter-doubling only where an item has
+no entry. English only — OOT's table is trilingual but the foreign schema carries single strings, so
+localisation would mean widening `fakeTrickName` everywhere it is consumed.
+
+**Known nit:** the fallback doubles punctuation (`Tingle''s Clock Town Map`). Upstream skips spaces
+but not apostrophes.

--- a/docs/deviations/resource-mgmt.md
+++ b/docs/deviations/resource-mgmt.md
@@ -147,3 +147,55 @@ texture window alternate 32×32/32×31 across phases → animated water/lava fli
 Dropped in the 2026-08-01 `port-maintenance` switch: upstream landed it as **#1164**, and **#1135**
 then refined `GetTileSizeFromCoordinates()` to treat an unset tile (`high <= low`) as zero size
 rather than the phantom 1-texel our copy produced. We now carry upstream's version verbatim.
+
+## Foreign animated-item segment binds must resolve against the owning RM (2026-08-03)
+
+**Why:** `CfaBindSeg`'s `CW_ANIM_SEG_PATH` case put a raw FOREIGN resource path into the HOST's
+`gSPSegment`. On both hosts that is a real function (`soh/soh/GbiWrap.cpp:34`,
+`mm/src/code/stubs.c:149`) which probes the path at **record time** against
+`Context::GetRawInstance()->GetResourceManager()` — the ACTIVE (host) RM. A foreign path misses,
+`ResourceManager::LoadResource` returns nullptr, and both hosts' `ResourceMgr_LoadIfDListByName`
+dereferenced it unchecked → access violation reading `mInitData`. Reproduced from a player crash
+report: MM drawing a foreign OOT boss soul. Volvagia/Twinrova/Ganon are the only OOT items with a
+PATH segment — plus any Ice Trap *disguised* as one, which is how the player actually hit it, so the
+reach is far wider than the three items suggest.
+
+The old comment on that line claimed the draw-time bracket covered this. It does not: the
+`gSPComboRMPush` calls are GBI commands the interpreter consumes at **playback**
+(`interpreter.cpp` `gfx_combo_rm_push_handler_custom`) and cannot affect a record-time CPU lookup —
+and they are emitted after the bind anyway.
+
+**`combo/menu/ComboForeignAnim.h` (combo-owned):** the emit is split into `CfaEmitSeg` so a
+`Ship::ResourceManagerScope` wraps ONLY the two `gSPSegment` calls. `CfaBindSeg` now takes the owning
+`game` explicitly — never the `sCfaCurrentGame` static, which unlike `sCfaInfo` is never cleared and
+so can carry a stale value across items and across host/foreign direction changes — and returns
+`bool`. The value left in the segment is still the raw path: playback resolves it via `ActiveResMgr()`
+under the bracket, and for a Texture `LoadIfDListByName` correctly returns null so `target` is
+untouched. Failure propagates to the caller's sentinel: an early bail when
+`CrossRMRegistry::Get(game)` is null (before any Gfx is emitted), `CfaRestoreSegs` + `return 0`
+mid-recipe, and `CfaDrawFlame` skipping only its flame DL (the flame is `flameSeg`'s sole consumer,
+so the model still draws).
+
+**The scope MUST stay narrow.** Both archives share one resource path namespace, so a HOST lookup
+performed under the FOREIGN RM does not fail loudly — it silently returns the WRONG asset. soh's
+helper also mangles paths on MQ state, i.e. host state applied to a foreign archive. Wrapping
+`SkelAnime_Draw*`/`Matrix_*`/`OPEN_DISPS` would be worse than the original bug and buys nothing,
+since playback is already covered by the bracket.
+
+Two alternatives were rejected and should stay rejected:
+- **Route the path** as `__OTR__@<game>:` like limb DLs — impossible. Only the DL FILEPATH handler
+  parses the marker; `gfx_set_timg_handler_rdp` does not, so a routed string in a segment base breaks
+  playback.
+- **Bypass with `__gSPSegment`** (skipping the probe entirely) — smallest change and provably
+  crash-free, but only because every `CW_ANIM_SEG_PATH` is a Texture *today*. `CfaValidateSegBind`
+  only checks for an `__OTR__` prefix, so a future foreign *DisplayList* path would leave a heap
+  string in the segment; `ComboIsUnresolvedSegmentTarget` won't reject a real heap address and the
+  interpreter would run the string as GBI — the very class the guard above exists to close.
+
+**`mm/2s2h/BenPort.cpp` + `soh/soh/ResourceManagerHelpers.cpp` (COMBO_BUILD-guarded):**
+`ResourceMgr_LoadIfDListByName` returns null on a miss instead of dereferencing. Both callers already
+test the return (`stubs.c:163`, `GbiWrap.cpp:48`), so the function's contract already admitted null —
+it just failed to produce it. The sibling `ResourceMgr_LoadTexOrDListByName` has the identical
+unguarded deref but is left alone: no `Cfa*` path reaches it via `gSPSegmentLoadRes` today. The other
+~11 unchecked `GetResourceByName` sites in `BenPort.cpp` are a vendored 2Ship pattern whose callers
+deref unconditionally, so guarding them would relocate the crash rather than fix it.

--- a/libultraship/src/ship/debug/CrashHandler.cpp
+++ b/libultraship/src/ship/debug/CrashHandler.cpp
@@ -37,7 +37,12 @@ bool CrashHandler::CheckStrLen(const char* str) {
 }
 
 void CrashHandler::AppendStrTrunc(const char* str) {
+#ifdef COMBO_BUILD
+    // ComboShip: also stop at the source's end — upstream reads past it once the buffer fills.
+    while (*str != '\0' && mOutBuffersize < gMaxBufferSize - 1) {
+#else
     while (mOutBuffersize < gMaxBufferSize - 1) {
+#endif
         mOutBuffer[mOutBuffersize++] = *str++;
     }
     mOutBuffer[mOutBuffersize] = '\0';
@@ -56,7 +61,15 @@ void CrashHandler::AppendStr(const char* str) {
 
 void CrashHandler::AppendLine(const char* str) {
     AppendStr(str);
+#ifdef COMBO_BUILD
+    // ComboShip: upstream writes the newline unchecked, so a full buffer lands one byte past the end.
+    if (mOutBuffersize < gMaxBufferSize - 1) {
+        mOutBuffer[mOutBuffersize++] = '\n';
+    }
+    mOutBuffer[mOutBuffersize] = '\0';
+#else
     mOutBuffer[mOutBuffersize++] = '\n';
+#endif
 }
 
 /**
@@ -334,7 +347,12 @@ void CrashHandler::PrintStack(CONTEXT* ctx) {
     process = GetCurrentProcess();
     thread = GetCurrentThread();
 
-    SymSetOptions(SYMOPT_NO_IMAGE_SEARCH | SYMOPT_IGNORE_IMAGEDIR);
+    SymSetOptions(SYMOPT_NO_IMAGE_SEARCH | SYMOPT_IGNORE_IMAGEDIR
+#ifdef COMBO_BUILD
+                  // ComboShip: LOAD_LINES or SymGetLineFromAddr can fail even with PDBs present.
+                  | SYMOPT_LOAD_LINES | SYMOPT_UNDNAME
+#endif
+    );
     SymInitialize(process, "debug", true);
 
     constexpr DWORD machineType =
@@ -355,7 +373,32 @@ void CrashHandler::PrintStack(CONTEXT* ctx) {
         }
         symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
         symbol->MaxNameLen = MAX_SYM_NAME;
+#ifdef COMBO_BUILD
+        // ComboShip: a Release build ships no PDBs, so dbghelp invents names from the export table —
+        // statics collapse onto unrelated exports. Honour the lookup result, flag guesses, and always
+        // emit module+RVA so a log maps offline. See docs/deviations/boot-shutdown.md.
+        const DWORD64 pc = (DWORD64)stack.AddrPC.Offset;
+        displacement = 0;
+        symbol->Name[0] = '\0'; // never reprint the previous frame's name out of the shared buffer
+        const bool haveSym = SymFromAddr(process, pc, &displacement, symbol) != FALSE;
+        const char* symName = haveSym ? symbol->Name : "<unresolved>";
+        const bool exportOnly = haveSym && (symbol->Flags & SYMFLAG_EXPORT) != 0;
+
+        hModule = nullptr;
+        module[0] = '\0';
+        GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                          (LPCTSTR)pc, &hModule);
+        if (hModule == nullptr || GetModuleFileNameA(hModule, module, sizeof(module)) == 0) {
+            strcpy_s(module, sizeof(module), "???");
+        }
+
+        char frameInfo[160];
+        sprintf_s(frameInfo, std::size(frameInfo), "+0x%llX%s (0x%016llX, RVA 0x%llX)", displacement,
+                  exportOnly ? " ~export(approx)" : "", pc,
+                  (hModule != nullptr) ? pc - (DWORD64)hModule : 0);
+#else
         SymFromAddr(process, (ULONG64)stack.AddrPC.Offset, &displacement, symbol);
+#endif
 #if defined(_M_AMD64)
         IMAGEHLP_LINE64 line;
         line.SizeOfStruct = sizeof(IMAGEHLP_LINE64);
@@ -363,6 +406,22 @@ void CrashHandler::PrintStack(CONTEXT* ctx) {
         IMAGEHLP_LINE line;
         line.SizeOfStruct = sizeof(IMAGEHLP_LINE);
 #endif
+#ifdef COMBO_BUILD
+        // ComboShip: module+RVA on every frame; the file/line branch also used the shared name buffer.
+        AppendStr("    ");
+        AppendStr(symName);
+        AppendStr(" ");
+        AppendStr(frameInfo);
+        if (SymGetLineFromAddr(process, pc, &disp, &line)) {
+            AppendStr(" in ");
+            AppendStr(line.FileName);
+            char lineNumberStr[16];
+            sprintf_s(lineNumberStr, sizeof(lineNumberStr), " Line: %d", line.LineNumber);
+            AppendLine(lineNumberStr);
+        } else {
+            WRITE_VAR_LINE_M(" in ", module);
+        }
+#else
         if (SymGetLineFromAddr(process, stack.AddrPC.Offset, &disp, &line)) {
             AppendStr("    ");
             AppendStr(symbol->Name);
@@ -388,6 +447,7 @@ void CrashHandler::PrintStack(CONTEXT* ctx) {
                 WRITE_VAR_LINE_M(" in ", "???");
             }
         }
+#endif
     }
     PrintCommon();
     Context::GetRawInstance()->GetLogger()->flush();

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -1683,6 +1683,12 @@ extern "C" char* ResourceMgr_LoadTexOrDListByName(const char* filePath) {
 extern "C" char* ResourceMgr_LoadIfDListByName(const char* filePath) {
     auto res = GetResourceByName(filePath);
 
+#ifdef COMBO_BUILD
+    // ComboShip: a miss returns null here; callers already treat a null return as "not a DList".
+    if (res == nullptr) {
+        return nullptr;
+    }
+#endif
     if (res->GetInitData()->Type == static_cast<uint32_t>(Fast::ResourceType::DisplayList))
         return (char*)&((std::static_pointer_cast<Fast::DisplayList>(res))->Instructions[0]);
 

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -3299,9 +3299,12 @@ extern "C" __declspec(dllexport) const char* MM_DumpRandoStaticData(void) {
         // "displayName" is the human string for toasts/shops in the OTHER game (suffixed there).
         // advancement drives whether a foreign item plays the held-up pickup animation.
         // ComboShip: "trap" lets the cross-world layer disguise a foreign trap in the other game.
+        // ComboShip: "trickNames" are MM's curated fake names, so a foreign trap disguised as this
+        // item can lie with a real near-miss name instead of a letter-doubled one.
         nlohmann::json entry = { { "name", Rando::StaticData::GetItemDisplayName(id) },
                                  { "advancement", isAdvancement(item) },
-                                 { "trap", id == RI_TRAP } };
+                                 { "trap", id == RI_TRAP },
+                                 { "trickNames", Rando::StaticData::GetTrickNames(id) } };
         if (item.name && item.name[0] != '\0') {
             entry["displayName"] = item.name;
         }

--- a/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
@@ -150,11 +150,15 @@ void Rando::MiscBehavior::CheckQueue() {
                         // id (before ConvertItem) so the sentinel is matched directly.
                         if (randoSaveCheck.randoItemId == RI_COMBO_FOREIGN) {
                             RandoCheckId cid = (RandoCheckId)CUSTOM_ITEM_PARAM;
+                            const ComboRando::ForeignItem* fi = Rando::MiscBehavior::MM_LookupForeign(cid);
+                            // A foreign trap fires on the FINDER, like a native RI_TRAP: MM's own trap
+                            // message + effect, and never cross-delivered (nothing to send).
+                            const bool foreignTrap = fi != nullptr && fi->trap;
                             std::string foreignName = Rando::StaticData::GetItemName(RI_COMBO_FOREIGN, false, cid);
                             CustomMessage::Entry entry = {
                                 .textboxType = 2,
                                 .icon = Rando::StaticData::GetIconForZMessage(RI_COMBO_FOREIGN),
-                                .msg = "You found " + foreignName + "!",
+                                .msg = foreignTrap ? GetTrapMessage() : ("You found " + foreignName + "!"),
                             };
                             if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
                                 CustomMessage::SetActiveCustomMessage(entry.msg, entry);
@@ -169,7 +173,15 @@ void Rando::MiscBehavior::CheckQueue() {
                             randoSaveCheck.cycleObtained = true;
                             randoSaveCheck.obtained = true;
                             randoSaveCheck.eligible = false;
-                            if (!wasObtained) {
+                            if (foreignTrap) {
+                                Rando::MiscBehavior::OfferTrapItem(); // fires here, not cross-granted
+                                if (!wasObtained) {
+                                    // Teammates still receive it; Anchor's receive path springs it.
+                                    MMAnchor_BroadcastCrossItem((int)fi->itemGame, fi->itemName.c_str(),
+                                                                Rando::StaticData::GetCheckDisplayName(cid).c_str());
+                                }
+                                SaveManager_SaveCurrentForCombo();
+                            } else if (!wasObtained) {
                                 Rando::MiscBehavior::SendForeignCheck(cid); // cross-deliver + toast + save
                             }
                             queued = false;

--- a/mm/2s2h/Rando/StaticData/Items.cpp
+++ b/mm/2s2h/Rando/StaticData/Items.cpp
@@ -725,6 +725,14 @@ const std::map<RandoItemId, std::vector<std::string>> fakeItemNames = {
     { RI_WALLET_ADULT, { "Silver Wallet", "Medium Wallet" } },
 };
 
+#ifdef COMBO_BUILD
+// ComboShip: expose the curated fake names so the combo dump can pass them cross-game.
+std::vector<std::string> GetTrickNames(RandoItemId id) {
+    auto it = fakeItemNames.find(id);
+    return it != fakeItemNames.end() ? it->second : std::vector<std::string>{};
+}
+#endif
+
 std::string GetItemName(RandoItemId randoItemId, bool includeArticle, RandoCheckId randoCheckId) {
     std::string result;
 

--- a/mm/2s2h/Rando/StaticData/StaticData.h
+++ b/mm/2s2h/Rando/StaticData/StaticData.h
@@ -60,6 +60,8 @@ RandoItemId GetItemIdFromName(const char* name);
 // ComboShip: friendly item name <-> id for the normalized combo spoiler (see Items.cpp).
 const std::string& GetItemDisplayName(RandoItemId id);
 RandoItemId GetItemIdFromDisplayName(const char* name);
+// ComboShip: MM's curated fake names for an item, so the dump can hand them to the cross-world layer.
+std::vector<std::string> GetTrickNames(RandoItemId id);
 #endif
 RandoItemId GetItemIdFromVanillaItemId(u32 itemId);
 u8 GetIconForZMessage(RandoItemId itemId);

--- a/soh/soh/Enhancements/randomizer/Messages/ItemMessages.cpp
+++ b/soh/soh/Enhancements/randomizer/Messages/ItemMessages.cpp
@@ -241,6 +241,11 @@ void BuildComboForeignMessage(Player* player, CustomMessage& msg) {
         } else if (fi != nullptr && !fi->displayName.empty()) {
             name = fi->displayName;
         }
+        // A foreign trap taunts with OOT's own ice-trap tables, naming what it pretended to be.
+        if (fi != nullptr && fi->trap) {
+            Rando::Traps::BuildIceTrapMessageNamed(msg, name);
+            return;
+        }
     }
     msg = CustomMessage("You found %g[[name]]%w!", "Du erhältst %g[[name]]%w!", "Vous avez trouvé %g[[name]]%w!",
                         TEXTBOX_TYPE_BLUE);

--- a/soh/soh/Enhancements/randomizer/Traps.cpp
+++ b/soh/soh/Enhancements/randomizer/Traps.cpp
@@ -1441,6 +1441,23 @@ Text Rando::Traps::GetTrapName(uint16_t id, uint64_t* state) {
     return ShipUtils::RandomElement(trickNameTable[id], state);
 }
 
+#ifdef COMBO_BUILD
+// ComboShip: all English trick names for an id (empty if none). Ensures the table is built.
+std::vector<std::string> Rando::Traps::GetTrickNamesEnglish(uint16_t id) {
+    if (!initTrickNames) {
+        InitTrickNames();
+        initTrickNames = true;
+    }
+    std::vector<std::string> out;
+    if (id < RG_MAX) {
+        for (const Text& t : trickNameTable[id]) {
+            out.push_back(t.GetEnglish());
+        }
+    }
+    return out;
+}
+#endif
+
 // ComboShip: whether id can disguise an ice trap (has a fake-name entry). Ensures the table is built.
 bool Rando::Traps::CanBeTrapModel(uint16_t id) {
     if (!initTrickNames) {
@@ -1799,6 +1816,27 @@ static std::string ReplaceItemName(const char* c_str, GetItemEntry getItemEntry)
 
     return str;
 }
+
+#ifdef COMBO_BUILD
+// ComboShip: ReplaceItemName resolves the name from the draw entry; a foreign disguise has no local
+// RandomizerGet, so substitute the caller's string into the same taunt tables.
+static std::string ReplaceItemNameWith(const char* c_str, const std::string& name) {
+    const static std::string placeholder = "${itemName}";
+    std::string str = std::string(c_str);
+    for (size_t i = str.find(placeholder); i != std::string::npos; i = str.find(placeholder, i + name.length())) {
+        str.replace(i, placeholder.length(), name);
+    }
+    return str;
+}
+
+void Rando::Traps::BuildIceTrapMessageNamed(CustomMessage& msg, const std::string& itemName) {
+    msg = CustomMessage(ReplaceItemNameWith(ShipUtils::RandomElement(englishIceTrapMessages), itemName),
+                        ReplaceItemNameWith(ShipUtils::RandomElement(germanIceTrapMessages), itemName),
+                        ReplaceItemNameWith(ShipUtils::RandomElement(frenchIceTrapMessages), itemName),
+                        { QM_BLUE, QM_BLUE, QM_BLUE });
+    msg.AutoFormat();
+}
+#endif
 
 void Rando::Traps::BuildIceTrapMessage(CustomMessage& msg, GetItemEntry getItemEntry) {
     if (CVarGetInteger(CVAR_GENERAL("LetItSnow"), 0)) {

--- a/soh/soh/Enhancements/randomizer/Traps.h
+++ b/soh/soh/Enhancements/randomizer/Traps.h
@@ -16,5 +16,12 @@ RandomizerGet GetTrapTrickModel(uint64_t* state = nullptr);
 bool CanBeTrapModel(uint16_t id);
 bool ShouldJunkItemBeTrap();
 void BuildIceTrapMessage(CustomMessage& msg, GetItemEntry getItemEntry);
+#ifdef COMBO_BUILD
+// ComboShip: same taunt tables, but naming an arbitrary item — a foreign trap's disguise may be an
+// item of the OTHER game, which has no RandomizerGet to resolve a name from.
+void BuildIceTrapMessageNamed(CustomMessage& msg, const std::string& itemName);
+// ComboShip: every English trick name for an id, so the dump can hand them to the cross-world layer.
+std::vector<std::string> GetTrickNamesEnglish(uint16_t id);
+#endif
 } // namespace Traps
 } // namespace Rando

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -455,7 +455,18 @@ void OOT_DeliverForeign(RandomizerCheck rc) {
     const std::string checkName = Rando::StaticData::GetLocation(rc)->GetName();
     const ComboRando::ForeignItem* fi = OOT_LookupForeign(slot, checkName);
 
-    if (fi) {
+    if (fi && fi->trap) {
+        // A foreign trap fires on the FINDER; each game springs its own flavour, so an MM trap becomes
+        // OOT's freeze. Deferred exactly like a native ice trap: VB_SHORT_CIRCUIT_GIVE_ITEM_PROCESS is
+        // checked from the per-frame Player_ActionHandler_2, so this springs once the get-item
+        // presentation ends. Freezing directly here resets the held-up animation mid-textbox, which
+        // re-triggers the pickup and loops forever. Never cross-delivered.
+        gSaveContext.ship.pendingIceTrapCount++;
+        // Teammates still receive it — Anchor's receive path springs a trap on them (GiveItem.cpp).
+        // Only the LOCAL cross-grant is skipped, because it fired here instead.
+        Anchor_BroadcastCrossItem((int)fi->itemGame, fi->itemName.c_str(), checkName.c_str());
+        SPDLOG_INFO("[ComboShip] OOT sprang foreign trap '{}' locally (from check '{}')", fi->itemName, checkName);
+    } else if (fi) {
         // Grant straight into the dormant target game's resident save (and persist it there), then
         // share with networked teammates. Replaces the old JSON mailbox + per-frame drain.
         if (gComboCrossDeliver)

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -4015,10 +4015,13 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoStaticData(void) {
         // dump schema symmetric with MM's (which needs the distinction: RI_* vs human).
         // advancement drives whether a foreign item plays the held-up pickup animation.
         // ComboShip: "trap" lets the cross-world layer disguise a foreign trap in the other game.
+        // ComboShip: "trickNames" are OOT's curated fake names, so a foreign trap disguised as this
+        // item can lie with a real near-miss name instead of a letter-doubled one.
         items.push_back({ { "name", name },
                           { "displayName", name },
                           { "advancement", comboIsAdv(static_cast<RandomizerGet>(rg)) },
-                          { "trap", rg == RG_ICE_TRAP } });
+                          { "trap", rg == RG_ICE_TRAP },
+                          { "trickNames", Rando::Traps::GetTrickNamesEnglish(static_cast<uint16_t>(rg)) } });
     }
 
     cached = nlohmann::json{

--- a/soh/soh/ResourceManagerHelpers.cpp
+++ b/soh/soh/ResourceManagerHelpers.cpp
@@ -363,6 +363,12 @@ extern "C" char* ResourceMgr_LoadTexOrDListByName(const char* filePath) {
 extern "C" char* ResourceMgr_LoadIfDListByName(const char* filePath) {
     auto res = ResourceMgr_GetResourceByNameHandlingMQ(filePath);
 
+#ifdef COMBO_BUILD
+    // ComboShip: a miss returns null here; callers already treat a null return as "not a DList".
+    if (res == nullptr) {
+        return nullptr;
+    }
+#endif
     if (res->GetInitData()->Type == static_cast<uint32_t>(Fast::ResourceType::DisplayList)) {
         return (char*)&((std::static_pointer_cast<Fast::DisplayList>(res))->Instructions[0]);
     }


### PR DESCRIPTION
Started from a player crash report: MM crashed cutting grass in Termina Field. Three separate defects came out of it.

## 1. The crash — foreign segment binds resolved against the wrong ResourceManager

`CfaBindSeg`'s `CW_ANIM_SEG_PATH` case put a raw **foreign** resource path into the **host's** `gSPSegment`, which probes it at *record time* against the active (host) RM. The miss returned a null `shared_ptr` that both hosts dereferenced unchecked.

Reproduced with the player's save: a foreign OOT boss soul drawn in MM. Volvagia, Twinrova and Ganon are the only OOT items with a PATH segment — **plus any Ice Trap disguised as one**, which is how the player actually hit it, so the reach is much wider than three items.

Fix: hold a narrow `ResourceManagerScope` over the emit only. The segment still receives the raw path, resolved at playback under the existing bracket. The scope must stay narrow — both archives share one resource path namespace, so a host lookup under the foreign RM returns the *wrong asset silently* rather than failing.

Also guards `ResourceMgr_LoadIfDListByName` in both hosts; the callers already treated a null return as "not a DList".

## 2. The crash handler that misdirected the investigation

The player's traceback named `MM_Anchor_RequestTeleport` three times in a crash with no Anchor involvement. `PrintStack` ignored `SymFromAddr`'s return while reusing one symbol buffer, printed the symbol base instead of the PC, and Release ships no PDBs so dbghelp guesses names from the export table.

Now honours the lookup, flags export-table guesses as `~export(approx)`, and prints module + RVA on every frame so a Release log maps offline with `llvm-symbolizer --relative-address`. Verified end to end: the frame reported as `MM_Anchor_RequestTeleport +0x50E4C` maps to `CfaBindSeg` at `ComboForeignAnim.h:403`.

Also fixes an `AppendLine` newline written unchecked — a 1-byte heap overflow inside the crash handler.

## 3. Foreign traps did nothing to the finder

Exposed once the crash was gone: a foreign trap was mailed to the other game instead of springing where it was found. Each game now springs its own flavour, deferred so it lands *after* the get-item textbox, and is not cross-granted. Anchor teammates still get trapped — only the local grant is skipped. OOT taunts with its own ice-trap tables. Trick names now come from each game's curated table, so a disguise reads "Rauru's Medallion" rather than "Light Medallionn".

## Verification

- Volvagia + Ganon souls render in MM; MM souls render in OOT (no crash)
- Crash handler proven in Debug **and** Release, RVA→source confirmed
- Both trap directions fire after the textbox; two-client Anchor test: both froze once, finder not re-frozen

## Notes for reviewers

- Vendored hunks are all `COMBO_BUILD`-guarded with upstream preserved verbatim under `#else`
- Deviations documented in `docs/deviations/{resource-mgmt,boot-shutdown,rando}.md`
- The trap flag is written at **generation** time, so trap behaviour needs a regenerated seed

<!--- section:artifacts:start -->
### Build Artifacts
  - [comborando-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8864032741.zip)
  - [ComboShip-package-zip.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8864031146.zip)
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8864030099.zip)
<!--- section:artifacts:end -->