### PR TITLE
ci: only build the artifacts each trigger actually consumes

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -1,9 +1,10 @@
 name: Build Artifacts (Windows)
 
 # Nightly / PR build: runs the reusable build pipeline (build.yml) on PRs and on every develop push,
-# producing the runnable ComboShip Release ZIP + comborando validator as downloadable artifacts
-# (pr-artifacts.yml posts nightly.link links; validate-seed.yml pulls comborando from the latest
-# develop run). Releases are cut separately from v* tags — see release.yml.
+# producing the runnable ComboShip Release ZIP as a downloadable artifact (pr-artifacts.yml posts
+# nightly.link links). develop pushes additionally produce the comborando validator, which
+# validate-seed.yml pulls from the latest successful develop run. Releases are cut separately from
+# v* tags — see release.yml.
 
 on:
   pull_request:
@@ -26,3 +27,7 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/build.yml
+    with:
+      # Only develop's validator artifact is ever consumed (validate-seed.yml fetches the latest
+      # successful develop run), so PRs skip building and uploading it.
+      validator: ${{ github.ref == 'refs/heads/develop' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,18 @@ name: Build (reusable)
 
 on:
   workflow_call:
+    inputs:
+      # The raw cpack .zip, uploaded for release.yml to attach as a Release asset. An artifact is
+      # itself zipped on download, so this one arrives as a zip-inside-a-zip — fine for release.yml
+      # (it unwraps it) but noise on a PR, where pr-artifacts.yml would advertise it as a download.
+      release_zip:
+        type: boolean
+        default: false
+      # comborando + its runtime DLLs (~60MB). validate-seed.yml only ever fetches this from the
+      # latest successful develop run, so building/uploading it on a PR is dead weight.
+      validator:
+        type: boolean
+        default: false
 
 jobs:
   # Fast gate so the ~40-min Windows build doesn't run on a PR that already has committed conflict
@@ -84,7 +96,9 @@ jobs:
         run: cmake --build build/x64 --target 2ship --config Release
       # Headless seed validator (pulls libultraship/soh/2ship as deps, already built above). Uploaded
       # below so validate-seed.yml can download it from develop instead of doing its own build.
+      # Nothing else depends on it, so it is skipped unless a caller asks for the validator.
       - name: Build comborando
+        if: inputs.validator
         run: cmake --build build/x64 --target comborando --config Release
       - name: Build comboui
         run: cmake --build build/x64 --target comboui --config Release
@@ -123,8 +137,8 @@ jobs:
           if-no-files-found: error
 
       # The raw cpack .zip (not the staged tree) for release.yml to attach directly as a Release asset.
-      # Nightly/PR runs ignore it; only release.yml downloads this artifact.
       - name: Upload package zip (release asset)
+        if: inputs.release_zip
         uses: actions/upload-artifact@v4
         with:
           name: ComboShip-package-zip
@@ -134,6 +148,7 @@ jobs:
       # comborando.exe + its deployed runtime DLLs (no o2r — the reachability oracle needs none).
       # validate-seed.yml downloads this from the latest successful develop run instead of rebuilding.
       - name: Upload comborando validator
+        if: inputs.validator
         uses: actions/upload-artifact@v4
         with:
           name: comborando-windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/build.yml
+    with:
+      release_zip: true # the publish job below attaches this artifact as the Release asset
 
   publish:
     needs: build


### PR DESCRIPTION
`build.yml` uploaded the raw cpack zip and built the `comborando` validator on **every** run, but nothing consumes either on a PR:

- `ComboShip-package-zip` is read only by `release.yml`. And because an artifact is itself zipped on download, it arrives as a **zip inside a zip** — fine for `release.yml` (it unwraps it), but `pr-artifacts.yml` lists every artifact, so each PR advertised it as a download.
- `comborando-windows` is only ever fetched by `validate-seed.yml` from the *latest successful develop run*, so every PR's copy was dead weight — and its `x64/Release/*.dll` glob carries the whole runtime (~60MB) already present in the package artifact.

Both are now behind `workflow_call` inputs: `release.yml` asks for the zip, `develop` pushes ask for the validator.

| trigger | `ComboShip-windows` | `ComboShip-package-zip` | `comborando-windows` |
|---|---|---|---|
| PR | yes | — | — |
| `develop` push / dispatch | yes | — | yes |
| `v*` tag | yes | yes | — |

A PR goes from three artifacts to one. No change to the released ZIP — `comborando` was never packaged (it is `EXCLUDE_FROM_ALL` with no `install()` rule, and the ZIP is restricted to the `combo`/`ship`/`2s2h` components).

Only verifiable by an actual run: this PR should produce exactly one artifact, and merging should leave `validate-seed.yml` working from develop.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8863513115.zip)
<!--- section:artifacts:end -->