### PR TITLE
chore: COMBO_RELEASE_VERSION 0.1.1 -> 0.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(COMBO_EPOCH 1)  # ← bump for ComboShip-owned breaks / o2r-forcing releases
 
 # Manual release identity; SOLE authority for combosave compat (gated in combo/ComboShip.cpp).
 # See docs/UPSTREAM_MERGES.md for the bump rule.
-set(COMBO_RELEASE_VERSION "0.1.1" CACHE STRING "ComboShip release version (manual; gates combosave compat)" FORCE)
+set(COMBO_RELEASE_VERSION "0.2.0" CACHE STRING "ComboShip release version (manual; gates combosave compat)" FORCE)
 
 set(COMBO_PINS "${CMAKE_CURRENT_SOURCE_DIR}/upstream-pins.json")
 # Reconfigure whenever the pins change so the derived version stays in sync.


### PR DESCRIPTION
The manual release string was never bumped for the v0.2.0 pre-release, so those builds self-reported as `v0.1.1` — which is why a player's crash log named the wrong build and sent triage looking at the wrong commit.

**Existing combosaves will not load on 0.2.0.** Two independent reasons:

1. `COMBO_RELEASE_VERSION` is the sole combosave-compat gate, so the launcher files a mismatched container away as outdated.
2. Independently, the MM pin bump grew `RC_MAX` from 2401 to 2690, so an older save's rando block cannot be parsed at all — this is unavoidable regardless of the version string.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8863453364.zip)
<!--- section:artifacts:end -->