### PR TITLE
Fix Link's Voice Pitch Multiplier: CVar clash crash + config wipe + frozen slider

### DIFF
--- a/docs/deviations/ui-menu.md
+++ b/docs/deviations/ui-menu.md
@@ -249,3 +249,9 @@ file (the `ofstream` opened before `unflatten`).
 **On future merges:** if upstream SoH renames the CVar or grows its own `.Enable`, drop the macro
 seam and re-check the migration. Audited 2026-08-04: this was the only cross-game leaf-vs-subtree
 CVar pair (other candidates were Color-CVar bases, never stored as leaves).
+
+Follow-up (same day): the checkbox still didn't enable the slider — MM's `disabledMap` per-frame
+refresh lives only in `Menu::DrawElement`, which never runs under comboui, so popout windows
+(Audio Editor, Mod Menu) that draw via `MenuDrawItem` read a frozen disable flag.
+`mm/2s2h/BenGui/Menu.cpp` (`Menu::MenuDrawItem`, `COMBO_BUILD`-guarded) now refreshes the map once
+per ImGui frame. SoH needs no parity fix: its popout-drawn widgets have no disable-map preFuncs.

--- a/docs/deviations/ui-menu.md
+++ b/docs/deviations/ui-menu.md
@@ -223,3 +223,29 @@ One inline editor (OOT's) covers both games: controls are shared `gSettings.Cont
 `MM_ReloadControls` reloads MM from them, and MM's Controls sidebar is hidden in the overlay (above),
 so no MM-side change is needed. **On future merges:** if SoH renames the "Configure Controller"
 window, update the name string here.
+
+## Link's Voice Pitch Multiplier CVar collision (2026-08-04)
+
+**Why:** SoH stores its pitch slider as a float **leaf** `gAudioEditor.LinkVoiceFreqMultiplier`
+while 2Ship stores **children** of that exact path (`.Enable`/`.Scale`). Upstream never meet; in the
+shared ComboShip CVar table + single config both coexist, and `Config::Save`'s `unflatten()` throws
+(json can't make one key both scalar and object) — an uncaught crash that also truncated the config
+file (the `ofstream` opened before `unflatten`).
+
+**Vendored (`COMBO_BUILD`-guarded):**
+- `soh/soh/cvar_prefixes.h` — `CVAR_LINK_VOICE_FREQ_MULTIPLIER` resolves to the `.Scale` child in
+  combo builds (upstream leaf otherwise); used at the 3 SoH sites (widget, reset button, z_actor.c
+  read). Side effect: both games share one pitch value; MM still gates behind `.Enable`.
+- `soh/soh/OTRGlobals.cpp` (`Combo_FinishInit`, after `RunVersionUpdates()`) — one-shot migration of
+  the old leaf to `.Scale` (covers old combo configs, the legacy `gLinkVoiceFreqMultiplier` updater
+  target, and launcher-imported standalone SoH configs, which all still produce the leaf). Gated on
+  table presence (not float type — a legacy int leaf must still be cleared) and followed by
+  `CVarSave()` so a mid-session `ConsoleVariable::Load` can't resurrect the leaf from disk.
+- `libultraship/src/ship/config/Config.{h,cpp}` — all four `unflatten()` sites (`Save`, `Nested`,
+  `SetBlock`, `EraseBlock`) route through a `TryUnflatten` helper that logs instead of throwing
+  (the exception would unwind across the game-DLL boundary); `Save()` unflattens **before**
+  opening/truncating the file; `Nested()` falls back to the last-good nested state on failure.
+
+**On future merges:** if upstream SoH renames the CVar or grows its own `.Enable`, drop the macro
+seam and re-check the migration. Audited 2026-08-04: this was the only cross-game leaf-vs-subtree
+CVar pair (other candidates were Color-CVar bases, never stored as leaves).

--- a/libultraship/include/ship/config/Config.h
+++ b/libultraship/include/ship/config/Config.h
@@ -226,6 +226,10 @@ class Config {
     template <typename T> std::vector<T> GetArray(const std::string& key);
 
   private:
+    // ComboShip: unflatten throws on a leaf-vs-subtree key clash; all unflatten sites go through
+    // this so the exception can't unwind across the game-DLL boundary. Returns false on failure.
+    bool TryUnflatten(nlohmann::json& out);
+
     nlohmann::json mFlattenedJson;
     nlohmann::json mNestedJson;
     std::string mPath;

--- a/libultraship/src/ship/config/Config.cpp
+++ b/libultraship/src/ship/config/Config.cpp
@@ -35,13 +35,27 @@ std::string Config::FormatNestedKey(const std::string& key) {
     return tmp;
 }
 
+bool Config::TryUnflatten(nlohmann::json& out) {
+    try {
+        out = mFlattenedJson.unflatten();
+        return true;
+    } catch (const nlohmann::json::exception& e) {
+        SPDLOG_ERROR("Failed to unflatten config {}: {}", mPath, e.what());
+        return false;
+    }
+}
+
 nlohmann::json Config::Nested(const std::string& key) {
     std::vector<std::string> dots = StringHelper::Split(key, ".");
     if (!mFlattenedJson.is_object()) {
         return mFlattenedJson;
     }
 
-    nlohmann::json gjson = mFlattenedJson.unflatten();
+    // ComboShip: on a clash, fall back to the last successfully unflattened state instead of crashing.
+    nlohmann::json gjson;
+    if (!TryUnflatten(gjson)) {
+        gjson = mNestedJson;
+    }
 
     if (dots.size() > 1) {
         for (auto& dot : dots) {
@@ -129,7 +143,11 @@ void Config::Erase(const std::string& key) {
 }
 
 void Config::SetBlock(const std::string& key, nlohmann::json block) {
-    nlohmann::json gjson = mFlattenedJson.unflatten();
+    // ComboShip: skip (with the helper's error log) rather than crash on a key clash.
+    nlohmann::json gjson;
+    if (!TryUnflatten(gjson)) {
+        return;
+    }
     if (key.find(".") != std::string::npos) {
         nlohmann::json* gjson2 = &gjson;
         std::vector<std::string> dots = StringHelper::Split(key, ".");
@@ -158,7 +176,11 @@ void Config::SetBlock(const std::string& key, nlohmann::json block) {
 }
 
 void Config::EraseBlock(const std::string& key) {
-    nlohmann::json gjson = mFlattenedJson.unflatten();
+    // ComboShip: skip (with the helper's error log) rather than crash on a key clash.
+    nlohmann::json gjson;
+    if (!TryUnflatten(gjson)) {
+        return;
+    }
     if (key.find(".") != std::string::npos) {
         nlohmann::json* gjson2 = &gjson;
         std::vector<std::string> dots = StringHelper::Split(key, ".");
@@ -212,8 +234,12 @@ void Config::Reload() {
 }
 
 void Config::Save() {
+    // ComboShip: unflatten before opening (and thereby truncating) the file, or a leaf-vs-subtree
+    // key clash both crashes and wipes the config.
+    if (!TryUnflatten(mNestedJson)) {
+        return;
+    }
     std::ofstream file(mPath);
-    mNestedJson = mFlattenedJson.unflatten();
     file << mNestedJson.dump(4);
 }
 

--- a/mm/2s2h/BenGui/Menu.cpp
+++ b/mm/2s2h/BenGui/Menu.cpp
@@ -257,6 +257,17 @@ std::unordered_map<uint32_t, disabledInfo>& Menu::GetDisabledMap() {
 }
 
 void Menu::MenuDrawItem(WidgetInfo& widget, uint32_t width, UIWidgets::Colors menuThemeIndex) {
+#ifdef COMBO_BUILD
+    // ComboShip: comboui owns the menu, so DrawElement's per-frame disable pass never runs for
+    // popout windows (Audio Editor, Mod Menu) that draw via MenuDrawItem; refresh once per frame.
+    static int32_t lastDisablePassFrame = -1;
+    if (int32_t frame = ImGui::GetFrameCount(); frame != lastDisablePassFrame) {
+        lastDisablePassFrame = frame;
+        for (auto& [reason, info] : disabledMap) {
+            info.active = info.evaluation(info);
+        }
+    }
+#endif
     disabledTempTooltip = "This setting is disabled because: \n\n";
     disabledValue = false;
     disabledTooltip = " ";

--- a/soh/soh/Enhancements/audio/AudioEditor.cpp
+++ b/soh/soh/Enhancements/audio/AudioEditor.cpp
@@ -607,7 +607,7 @@ void AudioEditor::DrawElement() {
                 ImGui::SetCursorPosY(ImGui::GetCursorPos().y + 40.f);
                 if (UIWidgets::Button("Reset##linkVoiceFreqMultiplier",
                                       UIWidgets::ButtonOptions().Size(ImVec2(80, 36)).Padding(ImVec2(5.0f, 0.0f)))) {
-                    CVarSetFloat(CVAR_AUDIO("LinkVoiceFreqMultiplier"), 1.0f);
+                    CVarSetFloat(CVAR_LINK_VOICE_FREQ_MULTIPLIER, 1.0f);
                 }
                 SohGui::mSohMenu->MenuDrawItem(randomAudioGenModes,
                                                static_cast<uint32_t>(ImGui::GetContentRegionAvail().x), THEME_COLOR);
@@ -929,7 +929,7 @@ void RegisterAudioWidgets() {
     SohGui::mSohMenu->AddSearchWidget({ ovlDuration, "Enhancements", "Audio Editor", "Audio Options" });
 
     voicePitch = { .name = "Link's Voice Pitch Multiplier", .type = WidgetType::WIDGET_CVAR_SLIDER_FLOAT };
-    voicePitch.CVar(CVAR_AUDIO("LinkVoiceFreqMultiplier"))
+    voicePitch.CVar(CVAR_LINK_VOICE_FREQ_MULTIPLIER)
         .Options(FloatSliderOptions()
                      .Color(THEME_COLOR)
                      .IsPercentage()

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1746,6 +1746,21 @@ static void Combo_FinishInit() {
     conf->RegisterVersionUpdater(std::make_shared<SOH::ConfigVersion7Updater>());
     conf->RunVersionUpdates();
 
+#ifdef COMBO_BUILD
+    // ComboShip: SoH's old float leaf clashes with 2Ship's LinkVoiceFreqMultiplier.{Enable,Scale}
+    // children (Config::Save unflatten throws); migrate it to the .Scale child once and persist
+    // immediately (a mid-session ConsoleVariable::Load would otherwise resurrect it from disk).
+    static const char* kOldVoicePitchCVar = "gAudioEditor.LinkVoiceFreqMultiplier";
+    if (OTRGlobals::Instance->context->GetConsoleVariables()->Get(kOldVoicePitchCVar) != nullptr) {
+        float oldPitch = CVarGetFloat(kOldVoicePitchCVar, (float)CVarGetInteger(kOldVoicePitchCVar, 0));
+        CVarClear(kOldVoicePitchCVar);
+        if (oldPitch > 0.0f) {
+            CVarSetFloat(CVAR_LINK_VOICE_FREQ_MULTIPLIER, oldPitch);
+        }
+        CVarSave();
+    }
+#endif
+
     SohGui::SetupGuiElements();
     SohGui::SetupMenuElements();
 

--- a/soh/soh/cvar_prefixes.h
+++ b/soh/soh/cvar_prefixes.h
@@ -2,6 +2,13 @@
 #define CVAR_RANDOMIZER_SETTING(var) CVAR_PREFIX_RANDOMIZER_SETTING "." var
 #define CVAR_COSMETIC(var) CVAR_PREFIX_COSMETIC "." var
 #define CVAR_AUDIO(var) CVAR_PREFIX_AUDIO "." var
+// ComboShip: 2Ship owns LinkVoiceFreqMultiplier.{Enable,Scale}; SoH's float leaf at the parent path
+// makes the shared config's json unflatten throw, so combo builds store it at the .Scale child.
+#ifdef COMBO_BUILD
+#define CVAR_LINK_VOICE_FREQ_MULTIPLIER CVAR_AUDIO("LinkVoiceFreqMultiplier.Scale")
+#else
+#define CVAR_LINK_VOICE_FREQ_MULTIPLIER CVAR_AUDIO("LinkVoiceFreqMultiplier")
+#endif
 #define CVAR_CHEAT(var) CVAR_PREFIX_CHEAT "." var
 #define CVAR_ENHANCEMENT(var) CVAR_PREFIX_ENHANCEMENT "." var
 #define CVAR_SETTING(var) CVAR_PREFIX_SETTING "." var

--- a/soh/src/code/z_actor.c
+++ b/soh/src/code/z_actor.c
@@ -2243,7 +2243,7 @@ void Player_PlaySfx(Actor* actor, u16 sfxId) {
         Audio_PlaySoundGeneral(sfxId, &actor->projectedPos, 4, &gSfxDefaultFreqAndVolScale, &gSfxDefaultFreqAndVolScale,
                                &gSfxDefaultReverb);
     } else {
-        freqMultiplier = CVarGetFloat(CVAR_AUDIO("LinkVoiceFreqMultiplier"), 1.0);
+        freqMultiplier = CVarGetFloat(CVAR_LINK_VOICE_FREQ_MULTIPLIER, 1.0);
         if (freqMultiplier <= 0) {
             freqMultiplier = 1;
         }


### PR DESCRIPTION
Fixes the reported crash when enabling **Enable Link's Voice Pitch Multiplier** in 2Ship after touching SoH's pitch slider, plus two issues found underneath it.

## Crash + config wipe
SoH stores its pitch slider as a float **leaf** `gAudioEditor.LinkVoiceFreqMultiplier`; 2Ship stores **children** of that exact path (`.Enable`/`.Scale`). In our shared CVar table + single config, once both exist `Config::Save`'s `unflatten()` throws (a JSON key can't be both scalar and object) — uncaught crash, and the `ofstream` had already truncated the config to zero bytes.

- SoH's CVar moves to the `.Scale` child in combo builds via a `CVAR_LINK_VOICE_FREQ_MULTIPLIER` seam in `cvar_prefixes.h` (upstream name untouched otherwise); both games now share one pitch value, MM still gates behind its `.Enable`.
- One-shot persisted migration in `Combo_FinishInit` (covers old combo configs, the legacy `gLinkVoiceFreqMultiplier` updater target, and launcher-imported standalone SoH configs).
- LUS `Config`: all four `unflatten()` sites route through a non-throwing `TryUnflatten`; `Save()` unflattens **before** opening/truncating the file. A future clash logs instead of crashing and wiping the config.
- Audited both games: this was the only cross-game leaf-vs-subtree CVar pair.

## Slider frozen after ticking the checkbox
Separate bug: MM's `disabledMap` per-frame refresh lives only in `Menu::DrawElement`, which never runs under comboui — popouts (Audio Editor, Mod Menu) drawing via `MenuDrawItem` read a frozen disable flag. `Menu::MenuDrawItem` now refreshes the map once per ImGui frame (`COMBO_BUILD`-guarded). SoH needs no parity fix (no disable-map preFuncs in its popout-drawn widgets).

Details in `docs/deviations/ui-menu.md`. Playtested: no crash, config intact, slider enables/disables with the checkbox.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8876220461.zip)
<!--- section:artifacts:end -->