### PR TITLE
fix(lus): quit-time AV in spdlog registry teardown

### DIFF
--- a/docs/deviations/boot-shutdown.md
+++ b/docs/deviations/boot-shutdown.md
@@ -141,6 +141,19 @@ filter in ComboShip.cpp (`ComboLateCrashFilter` -> combo_late_crash.txt) which c
 post-Context window where lus's CrashHandler is gone/unusable; the filter + cerr shutdown markers
 are kept permanently.
 
+**`libultraship` `Context::~Context` + `luslog.cpp` (spdlog registry — 4th X-close crash class,
+2026-08-04):** every quit AV'd after `main()` returned (silently — only `combo_late_crash.txt`
+showed it). `InitLogging` registers the shared logger in spdlog's registry (a static inside
+libultraship.dll) and both game DLLs `set_pattern` it — spdlog.lib is statically linked into every
+module, so the per-sink `pattern_formatter` vtables land inside soh.dll/2ship.dll. `~Context` never
+unregistered the
+logger, so the registry's static dtor destroyed the sinks at `DLL_PROCESS_DETACH`, after
+`FreeLibrary` unmapped those vtables. Fixed: `~Context` calls `spdlog::shutdown()`
+(COMBO_BUILD-guarded) so the registry (and its `init_thread_pool` worker — a latent loader-lock
+join) dies while everything is mapped, then installs a lus-owned null-sink default logger so any
+late `SPDLOG_*` call stays safe; `luslog()` also null-guards `default_logger_raw()`. Must live in
+lus code — the registry singleton is per-module.
+
 ## Cross-game erase: deleting a slot wipes both OOT and MM saves (issue #1, 2026-06-19)
 
 **Why:** a ComboShip save *slot* (file 1/2/3) is one combined OOT+MM playthrough, but each game's

--- a/libultraship/src/libultraship/log/luslog.cpp
+++ b/libultraship/src/libultraship/log/luslog.cpp
@@ -9,7 +9,10 @@ void luslog(const char* file, int32_t line, int32_t logLevel, const char* msg) {
     spdlog::level::level_enum lvl = (spdlog::level::level_enum)logLevel;
     auto loc = spdlog::source_loc{ file, line, SPDLOG_FUNCTION };
 
-    spdlog::default_logger_raw()->log(loc, lvl, str);
+    // ComboShip: the default logger can be gone (spdlog::shutdown from ~Context / CrashHandler).
+    if (auto* logger = spdlog::default_logger_raw()) {
+        logger->log(loc, lvl, str);
+    }
 }
 
 void lusprintf(const char* file, int32_t line, int32_t logLevel, const char* fmt, ...) {

--- a/libultraship/src/ship/Context.cpp
+++ b/libultraship/src/ship/Context.cpp
@@ -5,6 +5,7 @@
 #include <SDL2/SDL.h>
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/sinks/null_sink.h>
 #include "ship/install_config.h"
 #include "ship/config/ConsoleVariable.h"
 #include "ship/controller/controldeck/ControlDeck.h"
@@ -67,7 +68,18 @@ Context::~Context() {
         GetConfig()->Save();
     }
     mConfig = nullptr;
-    mLogger->flush();
+    if (mLogger != nullptr) { // ComboShip: a headless CreateUninitializedInstance() never ran InitLogging.
+        mLogger->flush();
+    }
+#ifdef COMBO_BUILD
+    // Drop the registry/default-logger refs + registry thread pool while the game DLLs (whose
+    // set_pattern formatter vtables live in them) are still mapped; the registry's static dtor
+    // would otherwise destroy the sinks at DLL_PROCESS_DETACH, after FreeLibrary -> AV.
+    spdlog::shutdown();
+    // Lus-owned null default logger: late SPDLOG_* calls (game-DLL static dtors) stay crash-proof.
+    spdlog::set_default_logger(
+        std::make_shared<spdlog::logger>("null", std::make_shared<spdlog::sinks::null_sink_mt>()));
+#endif
     mLogger = nullptr;
 #ifndef _DEBUG
     mLogThreadPool = nullptr;


### PR DESCRIPTION
Every quit wrote `combo_late_crash.txt` (exception 0xC0000005 after `main()` returned), silently swallowed by `ComboLateCrashFilter`.

**Root cause:** `Context::InitLogging` registers the shared logger in libultraship.dll's spdlog registry and never unregisters it, so the registry's static dtor destroyed the sinks at `DLL_PROCESS_DETACH` — after `FreeLibrary` had unmapped soh.dll/2ship.dll, whose statically-linked spdlog put the `set_pattern` formatter vtables inside those DLLs.

**Fix (`~Context`, COMBO_BUILD-guarded):** `spdlog::shutdown()` while all modules are still mapped (also removes the registry thread pool's latent loader-lock join at DLL detach), then a lus-owned null-sink default logger so late `SPDLOG_*` calls stay safe. Plus null guards around `mLogger->flush()` (headless uninitialized Context) and in `luslog()`.

Documented in `docs/deviations/boot-shutdown.md`. Playtested: quitting no longer produces `combo_late_crash.txt`.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8876990478.zip)
<!--- section:artifacts:end -->