### PR TITLE
fix(combo): gate combosave compat on major.minor only

### DIFF
--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -320,7 +320,7 @@ static FnDumpData SOH_DumpEntranceOverrides = nullptr;
 // (pushed into each DLL at boot), so the in-process cache stays authoritative. Single mutex serializes
 // OOT's thread-pool writes, MM's synchronous writes, and Anchor cross-writes. Write = temp+rename,
 // never torn on crash. Each container carries "comboRelease" (COMBO_RELEASE_VERSION); a container from a
-// different release is backed up to .bak and recreated — the launcher is the sole save-compat gate.
+// different major.minor is backed up to .bak and recreated — the launcher is the sole save-compat gate.
 // See docs/deviations/boot-shutdown.md.
 static std::mutex g_containerMutex;
 static std::map<int, nlohmann::json> g_containerCache;
@@ -336,6 +336,12 @@ static void Combo_SetForegroundGame(int game) {
 
 static std::filesystem::path ComboContainerPath(int fileNum) {
     return std::filesystem::path("Save") / ("file" + std::to_string(fileNum + 1) + ".combosav");
+}
+
+// Save compat is gated on major.minor only: patch releases must never change save-affecting behavior.
+static std::string ComboReleaseMajorMinor(const std::string& v) {
+    size_t dot = v.find('.');
+    return v.substr(0, dot == std::string::npos ? std::string::npos : v.find('.', dot + 1));
 }
 
 // Hold g_containerMutex. Returns a ref into the cache; loads from disk or creates a fresh container.
@@ -361,11 +367,13 @@ static nlohmann::json& LoadOrCreateContainer(int fileNum) {
     if (existed && !parsed) {
         std::filesystem::rename(path, path.string() + ".corrupt-" + std::to_string(std::time(nullptr)), ec);
     }
-    // COMBO_RELEASE_VERSION gate: a container from a different ComboShip release is outdated. Back it
-    // up aside and start fresh; record the slot so OOT can surface a popup on its main thread.
+    // COMBO_RELEASE_VERSION gate (major.minor only; patch releases keep saves): a container from a
+    // different release is outdated. Back it up aside and start fresh; record the slot so OOT can
+    // surface a popup on its main thread.
     if (parsed) {
         auto rel = j.find("comboRelease");
-        if (rel == j.end() || !rel->is_string() || rel->get<std::string>() != COMBO_RELEASE_VERSION) {
+        if (rel == j.end() || !rel->is_string() ||
+            ComboReleaseMajorMinor(rel->get<std::string>()) != ComboReleaseMajorMinor(COMBO_RELEASE_VERSION)) {
             std::filesystem::rename(path, path.string() + "-" + std::to_string(std::time(nullptr)) + ".bak", ec);
             g_evictedSlots.push_back(fileNum); // caller holds g_containerMutex
             parsed = false;

--- a/docs/UPSTREAM_MERGES.md
+++ b/docs/UPSTREAM_MERGES.md
@@ -139,9 +139,9 @@ top-level project) changes on every merge, and the rando-save gate fires on its 
 
 **`COMBO_RELEASE_VERSION` (manual, e.g. `0.1.1`)** is separate from the pin-derived triple and is the
 **sole authority for combosave compatibility** (gated at the launcher container level — see
-`docs/deviations/boot-shutdown.md`). Bump rule: `patch` = combo-side changes; `minor` = a counter of the
-currently-ahead game's upstream releases; `major` = ticks when the trailing game catches up (both synced),
-resetting `minor`. Any bump retires existing combosaves once; not bumping it keeps saves across rebuilds.
+`docs/deviations/boot-shutdown.md`). Only `major.minor` gates saves. Bump rule: `patch` = fixes that
+cannot affect logic, in-game events, or save contents (saves survive); `minor`/`major` = anything
+save-affecting (upstream pin updates, schema or rando-logic changes) and retires existing combosaves once.
 
 **The two o2r version checks are NOT the same granularity** (this bit me once — get it right):
 

--- a/docs/deviations/boot-shutdown.md
+++ b/docs/deviations/boot-shutdown.md
@@ -210,8 +210,8 @@ container, since there's no per-game `.sav` to copy).
 **Release-version save gate:** `COMBO_RELEASE_VERSION` (root `CMakeLists.txt`, manual — e.g. `0.1.1`)
 is the sole authority for combosave compatibility, enforced at the launcher container level, not in
 either game. It is compiled into the `ComboShip` target only. Every container write stamps
-`comboRelease`; on load, a container missing it or carrying a different string is renamed aside to a
-timestamped `.bak`, its slot recorded, and a fresh container created. OOT drains the recorded slots on
+`comboRelease`; on load, a container missing it or differing in `major.minor` (patch releases keep
+saves) is renamed aside to a timestamped `.bak`, its slot recorded, and a fresh container created. OOT drains the recorded slots on
 its main thread (`SOH_SetOutdatedSaveNotice` → `Combo_TakeEvictionNotice`) and shows an "Outdated
 ComboShip Save" popup — the launcher never touches ImGui (`Combo_ReadGameSave` may run off-thread). The
 old pin-derived `major.minor.patch` triple + MM git commit hash remain for the in-game banner/diagnostics


### PR DESCRIPTION
Patch releases (fixes that cannot affect logic, in-game events, or save contents) no longer retire existing combosaves; only minor/major bumps do.

- Gate in `LoadOrCreateContainer` now compares the `major.minor` prefix of the stored `comboRelease` against `COMBO_RELEASE_VERSION` instead of the full string.
- Docs updated with the revised bump rule: anything save-affecting, **including upstream pin updates** (vendor save-schema changes are taken verbatim), must bump at least minor.
- Existing containers keep their original `comboRelease` stamp; only the prefix is compared.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8935936653.zip)
<!--- section:artifacts:end -->