### PR TITLE
fix: MM doors not loading when Actors aren't properly destroyed

### DIFF
--- a/docs/deviations/resource-mgmt.md
+++ b/docs/deviations/resource-mgmt.md
@@ -199,3 +199,18 @@ it just failed to produce it. The sibling `ResourceMgr_LoadTexOrDListByName` has
 unguarded deref but is left alone: no `Cfa*` path reaches it via `gSPSegmentLoadRes` today. The other
 ~11 unchecked `GetResourceByName` sites in `BenPort.cpp` are a vendored 2Ship pattern whose callers
 deref unconditionally, so guarding them would relocate the crash rather than fix it.
+
+## MM transition-actor ids re-normalized on scene load (Woodfall door fix) (2026-08-05)
+
+**Why:** MM's `play->transitionActors.list` aliases the cached LUS scene resource, so the negated
+"already spawned" ids written by `Actor_SpawnTransitionActors` persist across scene loads whenever a
+door's Destroy doesn't restore them. ComboShip's MM→OOT reload (Ctrl+R) cuts the frame loop
+without `Play_Destroy`, skipping every live door's restore, so a door left alive at handoff
+(e.g. Woodfall Temple room 0) never respawns for the rest of the process. `Door_Shutter`
+variants with `room = -1` leak the same way even in stock 2ship. SoH has carried the equivalent fix for
+years (`z_scene_otr.cpp`, `Scene_CommandTransitionActorList`); MM never received it.
+
+**`mm/2s2h/z_scene_2SH.cpp` (COMBO_BUILD-guarded — preserve on future mm merges unless upstreamed):**
+in `Scene_CommandTransiActorList`, `ABS()`-normalize every transition actor id before
+`MapDisp_InitTransitionActorData`. Same code as SoH's fix, wrapped in `#ifdef COMBO_BUILD` with a
+`// ComboShip:` comment.

--- a/mm/2s2h/z_scene_2SH.cpp
+++ b/mm/2s2h/z_scene_2SH.cpp
@@ -257,6 +257,18 @@ void Scene_CommandTransiActorList(PlayState* play, SOH::ISceneCommand* cmd) {
 
     play->transitionActors.count = list->numTransitionActors;
     play->transitionActors.list = (TransitionActorEntry*)list->GetRawPointer();
+
+#ifdef COMBO_BUILD
+    // ComboShip: the list aliases the cached scene resource, so the negated "already spawned" ids
+    // written by Actor_SpawnTransitionActors persist across scene loads whenever a door's Destroy
+    // doesn't restore them, the combo handoff (portal return / Ctrl+R / owl-save quit) cuts the
+    // frame loop without Play_Destroy, so a door alive at handoff never respawns until app restart.
+    // Reset the markers on every scene load, mirroring SoH's Scene_CommandTransitionActorList fix.
+    for (s32 i = 0; i < play->transitionActors.count; i++) {
+        play->transitionActors.list[i].id = ABS(play->transitionActors.list[i].id);
+    }
+#endif
+
     MapDisp_InitTransitionActorData(play, play->transitionActors.count, play->transitionActors.list);
 }
 


### PR DESCRIPTION
### What doing?

If you interrupt MM's gameplay with a ctrl+R restart, actors don't get the chance to be destroyed. This fixes that by introducing SoH's unloaded doors fix for cached objects. Note: I could see this being potentially introduced upstream, but 2ship doesn't _currently_ have a save state mechanic that would trigger this issue reliably.

### Reproduction:

1. Enter Woodfall Temple
2. Ctrl + R
3. Go back to Woodfall Temple
4. Door is unloaded
<img width="1188" height="740" alt="image" src="https://github.com/user-attachments/assets/88d607c4-8170-43cf-968a-6a1a61a34559" />


<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8980581751.zip)
<!--- section:artifacts:end -->