### PR TITLE
fix(combo): bind empty-DL segments as ENDDL arrays, not a single ENDDL

### DIFF
--- a/combo/menu/ComboForeignAnim.h
+++ b/combo/menu/ComboForeignAnim.h
@@ -333,10 +333,17 @@ inline const CwAnimLimbDL* CfaFindLimbDL(s32 limbIndex) {
     return nullptr;
 }
 
+// An ARRAY of ENDDLs, not a single command: DLs may call through a bound segment at an index > 0
+// (MM's Scene_SetRenderModeXlu binds 4-entry ENDDL arrays for exactly this), so every slot an
+// indexed call can select must hold an ENDDL or execution runs off the allocation into whatever
+// follows it. 8 entries = MM's 4 with headroom.
+#define CFA_EMPTY_DL_ENTRIES 8
 inline Gfx* CfaEmptyDL(PlayState* play) {
-    Gfx* dl = (Gfx*)CFA_ALLOC(play->state.gfxCtx, sizeof(Gfx));
+    Gfx* dl = (Gfx*)CFA_ALLOC(play->state.gfxCtx, CFA_EMPTY_DL_ENTRIES * sizeof(Gfx));
     Gfx* p = dl;
-    gSPEndDisplayList(p++);
+    for (int32_t i = 0; i < CFA_EMPTY_DL_ENTRIES; i++) {
+        gSPEndDisplayList(p++);
+    }
     return dl;
 }
 
@@ -815,9 +822,7 @@ inline int32_t ComboForeignAnim_Draw(const CwItemAnimDrawInfo* info, const char*
     // Segment hygiene: re-point the segments the texanim wrote at a benign empty DL (XLU only —
     // the OPA stream was never touched). See docs/deviations/rando.md.
     if (writtenSegCount > 0) {
-        Gfx* empty = (Gfx*)CFA_ALLOC(play->state.gfxCtx, sizeof(Gfx));
-        Gfx* e = empty;
-        gSPEndDisplayList(e++);
+        Gfx* empty = CfaEmptyDL(play); // array-sized: indexed seg calls must stay in bounds
         for (int32_t i = 0; i < writtenSegCount; i++) {
             gSPSegment(POLY_XLU_DISP++, writtenSegs[i], (uintptr_t)empty);
         }
@@ -834,9 +839,7 @@ inline void ComboForeignTexAnim_Restore(PlayState* play, const int32_t* segs, in
     if (play == NULL || count <= 0) {
         return;
     }
-    Gfx* empty = (Gfx*)CFA_ALLOC(play->state.gfxCtx, sizeof(Gfx));
-    Gfx* e = empty;
-    gSPEndDisplayList(e++);
+    Gfx* empty = CfaEmptyDL(play); // array-sized: indexed seg calls must stay in bounds
     OPEN_DISPS(play->state.gfxCtx);
     for (int32_t i = 0; i < count; i++) {
         if (restoreOpa) {

--- a/combo/menu/ComboForeignDrawMM.h
+++ b/combo/menu/ComboForeignDrawMM.h
@@ -220,9 +220,12 @@ inline const ComboForeignDrawInfoOOT* ComboResolveForeignDrawInfoOOT(RandoCheckI
 // Mirrors the segment hygiene in ComboForeignAnim.h.
 inline void MM_RestoreForeignSegs(const int32_t* segs, int32_t count) {
     GraphicsContext* gfxCtx = gPlayState->state.gfxCtx;
-    Gfx* empty = (Gfx*)GRAPH_ALLOC(gfxCtx, sizeof(Gfx));
+    // Array of ENDDLs: DLs may call through a bound segment at an index > 0 — see CfaEmptyDL.
+    Gfx* empty = (Gfx*)GRAPH_ALLOC(gfxCtx, 8 * sizeof(Gfx));
     Gfx* e = empty;
-    gSPEndDisplayList(e++);
+    for (int32_t iEmpty = 0; iEmpty < 8; iEmpty++) {
+        gSPEndDisplayList(e++);
+    }
     OPEN_DISPS(gfxCtx);
     for (int32_t i = 0; i < count; i++) {
         gSPSegment(POLY_OPA_DISP++, segs[i], (uintptr_t)empty);

--- a/combo/menu/ComboForeignDrawOOT.h
+++ b/combo/menu/ComboForeignDrawOOT.h
@@ -201,9 +201,12 @@ inline const ComboForeignDrawInfo* ComboResolveForeignDrawInfo(RandomizerCheck r
 // Restore the segments a handler bound to a benign empty DL so later same-frame commands don't
 // sample our scroll DLs. Mirrors MM_RestoreForeignSegs / the hygiene in ComboForeignAnim.h.
 inline void OOT_RestoreForeignSegs(PlayState* play, const int32_t* segs, int32_t count) {
-    Gfx* empty = (Gfx*)Graph_Alloc(play->state.gfxCtx, sizeof(Gfx));
+    // Array of ENDDLs: DLs may call through a bound segment at an index > 0 — see CfaEmptyDL.
+    Gfx* empty = (Gfx*)Graph_Alloc(play->state.gfxCtx, 8 * sizeof(Gfx));
     Gfx* e = empty;
-    gSPEndDisplayList(e++);
+    for (int32_t iEmpty = 0; iEmpty < 8; iEmpty++) {
+        gSPEndDisplayList(e++);
+    }
     OPEN_DISPS(play->state.gfxCtx);
     for (int32_t i = 0; i < count; i++) {
         gSPSegment(POLY_OPA_DISP++, segs[i], (uintptr_t)empty);


### PR DESCRIPTION
This fixes where foreign models crash the game.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/8980593228.zip)
<!--- section:artifacts:end -->