### PR TITLE
fix: extract screen file drop

### DIFF
--- a/combo/gui/ComboExtractScreen.cpp
+++ b/combo/gui/ComboExtractScreen.cpp
@@ -10,6 +10,7 @@
 #include "ComboWidgetStyle.h" // ComboShip port style: ComboMenu_ThemeColor / PushButton / PopButton
 
 #include <libultraship/libultraship.h>
+#include <ship/window/FileDropMgr.h> // only forward-declared by the umbrella header
 #include <fast/Fast3dWindow.h>
 #include <imgui.h>
 
@@ -63,6 +64,18 @@ std::string PickRomFile() {
     }
 #endif
     return std::string();
+}
+
+// Dropped-file hand-off from the gfx backend's event pump (via FileDropMgr) to the PICK loop
+// below. Same thread — the pump runs inside wnd->HandleEvents() — so a plain string suffices.
+// Registered only while the extraction screen is up; returns true so FileDropMgr doesn't emit
+// its "unsupported file" overlay for what is actually the expected input here.
+std::string sDroppedRomPath;
+bool HandleRomDrop(char* path) {
+    if (path != nullptr) {
+        sDroppedRomPath = path;
+    }
+    return true;
 }
 
 // Non-recursive scan of a directory for candidate ROM files.
@@ -146,6 +159,15 @@ extern "C" __declspec(dllexport) int ComboUI_RunExtraction(const ComboExtractCal
         }
     }
 
+    // Accept ROMs dragged onto the window while this screen is up. The gfx backends hand drops
+    // to FileDropMgr (created by the window-only boot precisely so it exists here); the handler
+    // stashes the path and the PICK phase below routes it into a slot.
+    auto fileDropMgr = ctx->GetFileDropMgr();
+    sDroppedRomPath.clear();
+    if (fileDropMgr != nullptr) {
+        fileDropMgr->RegisterDropHandler(HandleRomDrop);
+    }
+
     enum Phase { PICK, EXTRACTING, FAILED };
     Phase phase = PICK;
     int activeSlot = -1; // slot currently extracting, -1 = pick next
@@ -202,8 +224,43 @@ extern "C" __declspec(dllexport) int ComboUI_RunExtraction(const ComboExtractCal
             ImGui::Separator();
 
             if (phase == PICK) {
+                // A ROM dropped onto the window: route it by the header-only classify (same
+                // routing as the auto-scan above), replacing a prior selection for that game —
+                // a drop is an explicit user action. If no slot claims it, park it in the first
+                // unfilled slot so the "Not a valid ... ROM" feedback explains what happened.
+                if (!sDroppedRomPath.empty()) {
+                    std::string dropped = std::move(sDroppedRomPath);
+                    sDroppedRomPath.clear();
+                    if (fileDropMgr != nullptr) {
+                        fileDropMgr->ClearDroppedFile();
+                    }
+                    bool placed = false;
+                    for (auto& s : slots) {
+                        if (!s.needed) {
+                            continue;
+                        }
+                        ComboFnValidateRom check = s.classify ? s.classify : s.validate;
+                        if (check && check(dropped.c_str())) {
+                            s.path = dropped;
+                            s.valid = true;
+                            placed = true;
+                            break;
+                        }
+                    }
+                    if (!placed) {
+                        for (auto& s : slots) {
+                            if (s.needed && !s.valid) {
+                                s.path = dropped;
+                                s.valid = false;
+                                break;
+                            }
+                        }
+                    }
+                }
+
                 ImGui::TextWrapped("ComboShip needs both an Ocarina of Time ROM and a Majora's Mask ROM. "
-                                   "Select each ROM below, then click Extract. Both are required.");
+                                   "Select each ROM below or drag and drop ROM files onto this window, "
+                                   "then click Extract. Both are required.");
                 ImGui::Spacing();
 
                 for (int i = 0; i < 2; i++) {
@@ -343,6 +400,12 @@ extern "C" __declspec(dllexport) int ComboUI_RunExtraction(const ComboExtractCal
         gui->EndDraw();
         wnd->EndFrame();
     }
+
+    if (fileDropMgr != nullptr) {
+        fileDropMgr->UnregisterDropHandler(HandleRomDrop);
+        fileDropMgr->ClearDroppedFile();
+    }
+    sDroppedRomPath.clear();
 
     return result;
 }

--- a/docs/deviations/boot-shutdown.md
+++ b/docs/deviations/boot-shutdown.md
@@ -457,3 +457,35 @@ price of that; do not "DRY" them.
 produces PDBs for soh/2ship (via the unconditional `/DEBUG` in `mm/CMakeLists.txt`) but **not** for
 libultraship or ComboShip.exe — which is where the crash above actually faulted. PDBs must never ship
 (they are ~5x the download), but they should be generated and archived per tagged release.
+
+## Extraction-screen ROM drop: FileDropMgr early init + backend null-guards (2026-08-08)
+
+**Why:** dragging a ROM onto the extraction screen crashed on a null `this` in
+`FileDropMgr::SetDroppedFile` (reported on the Linux AppImage; reproduced with an injected
+`SDL_DROPFILE`, and the identical latent crash on Windows via `WM_DROPFILES`). Root cause:
+`SOH_InitWindowOnly()` is only the OTRGlobals ctor, but upstream creates the FileDropMgr later in
+`Initialize()` — so for the whole extraction screen (which runs between the two)
+`GetFileDropMgr()` returns null, and both gfx backends called `->SetDroppedFile()` on it
+unguarded. Dropping a ROM there is the natural first move a new player makes.
+
+**`libultraship/src/fast/backends/gfx_sdl2.cpp` + `gfx_dxgi.cpp` (COMBO_BUILD-fenced; upstream
+line preserved verbatim under `#else`):** null-guard around the `SetDroppedFile` call at both
+drop sites (`SDL_DROPFILE` / `WM_DROPFILES`).
+
+**`soh/soh/OTRGlobals.cpp` ctor (COMBO_BUILD-guarded):** `context->InitFileDropMgr()` after
+`InitConsole()`, so the manager exists during the extraction screen. `Initialize()`'s own later
+call is idempotent (`Context::InitFileDropMgr` returns early if one exists), so the full-boot
+path is unchanged.
+
+**combo-owned, no fence (`combo/gui/ComboExtractScreen.cpp`):** the screen registers a drop
+handler for its lifetime and routes dropped files into the OoT/MM slot via the same header-only
+`SOH_ClassifyRom` / `MM_ClassifyRom` callbacks the auto-scan uses — content decides, not
+filename; a drop that classifies for neither game parks in the first unfilled slot so the
+"Not a valid … ROM" line explains what happened. The handler returns true so FileDropMgr skips
+its "Unsupported file dropped" overlay.
+
+Verified end to end on Linux with an `LD_PRELOAD` shim pushing synthetic `SDL_DROPFILE` events:
+the pre-fix segfault reproduced on demand; post-fix, `oot.z64` routes to the OoT slot
+(`SOH_ClassifyRom` accepts, MM never consulted) and `mm.z64` to the MM slot (SOH rejects, then
+`MM_ClassifyRom` accepts). Also verified by hand on Windows: ROMs dragged onto the extraction
+screen route through the `WM_DROPFILES`/DXGI path into the correct slots.

--- a/libultraship/src/fast/backends/gfx_dxgi.cpp
+++ b/libultraship/src/fast/backends/gfx_dxgi.cpp
@@ -493,7 +493,16 @@ static LRESULT CALLBACK gfx_dxgi_wnd_proc(HWND h_wnd, UINT message, WPARAM w_par
             break;
         case WM_DROPFILES:
             DragQueryFileA((HDROP)w_param, 0, fileName, 256);
+#ifdef COMBO_BUILD
+            // ComboShip: null-guard — a file dropped before full game init (e.g. on the ROM
+            // extraction screen, where only the window-only boot has run) reaches here with no
+            // FileDropMgr yet and would crash. Same guard as gfx_sdl2.cpp.
+            if (auto fileDropMgr = Ship::Context::GetRawInstance()->GetFileDropMgr()) {
+                fileDropMgr->SetDroppedFile(fileName);
+            }
+#else
             Ship::Context::GetRawInstance()->GetFileDropMgr()->SetDroppedFile(fileName);
+#endif
             break;
         case WM_DISPLAYCHANGE:
             self->monitor_list = GetMonitorList();

--- a/libultraship/src/fast/backends/gfx_sdl2.cpp
+++ b/libultraship/src/fast/backends/gfx_sdl2.cpp
@@ -655,7 +655,16 @@ void GfxWindowBackendSDL2::HandleSingleEvent(SDL_Event& event) {
             }
             break;
         case SDL_DROPFILE:
+#ifdef COMBO_BUILD
+            // ComboShip: null-guard — a file dropped before full game init (e.g. on the ROM
+            // extraction screen, where only the window-only boot has run) reaches here with no
+            // FileDropMgr yet and would crash.
+            if (auto fileDropMgr = Ship::Context::GetRawInstance()->GetFileDropMgr()) {
+                fileDropMgr->SetDroppedFile(event.drop.file);
+            }
+#else
             Ship::Context::GetRawInstance()->GetFileDropMgr()->SetDroppedFile(event.drop.file);
+#endif
             break;
         case SDL_QUIT:
             Close();

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -369,6 +369,14 @@ OTRGlobals::OTRGlobals() {
 #endif
     context->InitConsole();
 
+#ifdef COMBO_BUILD
+    // ComboShip: the ROM extraction screen runs between this ctor (SOH_InitWindowOnly) and
+    // Initialize() — without this, a file dropped there reaches the gfx backend with a null
+    // FileDropMgr, and the screen couldn't accept dropped ROMs. Initialize()'s own
+    // InitFileDropMgr call is idempotent, so the full-boot path is unchanged.
+    context->InitFileDropMgr();
+#endif
+
     auto sohInputEditorWindow =
         std::make_shared<SohInputEditorWindow>(CVAR_WINDOW("ControllerConfiguration"), "Configure Controller");
     sohFast3dWindow =


### PR DESCRIPTION
This was reported as a gap under the PR #121 and that was pre-existing on the Windows build. This allows a user to now drag and drop their ROMs into the window - preventing the crash and actually working as intended.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9028297998.zip)
<!--- section:artifacts:end -->