### PR TITLE
fix(combo): MM oracle zeroed inventory read as "owns Ocarina" (item id 0)

### DIFF
--- a/docs/deviations/rando.md
+++ b/docs/deviations/rando.md
@@ -1208,3 +1208,17 @@ localisation would mean widening `fakeTrickName` everywhere it is consumed.
 
 **Known nit:** the fallback doubles punctuation (`Tingle''s Clock Town Map`). Upstream skips spaces
 but not apostrophes.
+
+## MM oracle: zeroed inventory read as "owns Ocarina" (2026-08-09)
+
+`Combo_MM_Rando_Reset` (`mm/2s2h/BenPort.cpp`) resets the headless oracle save with a whole-struct
+`memset(0)`. MM's `ITEM_OCARINA_OF_TIME` is item id **0** and `HAS_ITEM` is an equality compare
+(`INV_CONTENT(item) == item`), so a zeroed slot reads as "ocarina owned" — every song became playable
+from sphere 0 and the fill placed MM's ocarina arbitrarily late (player-reported unbeatable seed:
+Snowhead at sphere 10, ocarina at sphere 23). A real fresh save inits `inventory.items` to
+`ITEM_NONE` (0xFF, `z_sram_NES.c`). Masked whenever `RI_OCARINA` was a starting item (the default
+kit); exposed by `gRando.StartingItems: []`, which shuffles the kit into the pool. The
+`--playthrough` validator shares the same oracle, so it could not catch it.
+
+Fix: after the memset, re-init `inventory.items` (48 slots, items + masks) to `ITEM_NONE`, plus a
+one-time sweep asserting no inventory-slot item reads as owned on the empty context.

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -3356,6 +3356,7 @@ static uint64_t sMM_OracleSavedRegionTime;
 // end of the whole fill. Without this flag the second Reset snapshots the already-zeroed context,
 // so Restore would write garbage (zeros) back into MM's live save after generation.
 static bool sMM_OracleActive = false;
+static bool sMM_OracleInventorySweepDone = false;
 using Rando::Logic::gCurrentRegionTime;
 
 // ComboShip (#61): cross-grant only set the trade item's obtained flag, leaving the shared trade
@@ -3753,6 +3754,19 @@ extern "C" __declspec(dllexport) void Combo_MM_Rando_Reset(void) {
         sMM_OracleActive = true;
     }
     memset(&gSaveContext, 0, sizeof(SaveContext));
+    // Empty inventory slots are ITEM_NONE (0xFF), not 0: ITEM_OCARINA_OF_TIME is item id 0, so a
+    // zeroed slot makes HAS_ITEM (an equality compare) report the ocarina owned and every song playable.
+    memset(gSaveContext.save.saveInfo.inventory.items, ITEM_NONE, sizeof(gSaveContext.save.saveInfo.inventory.items));
+    if (!sMM_OracleInventorySweepDone) { // one-time guard against future zero-collision regressions
+        sMM_OracleInventorySweepDone = true;
+        for (auto& [id, item] : Rando::StaticData::Items) {
+            u8 itemId = item.itemId;
+            if (itemId != ITEM_NONE && itemId < ARRAY_COUNT(gItemSlots) && gItemSlots[itemId] != SLOT_NONE &&
+                INV_CONTENT(itemId) == itemId) {
+                SPDLOG_ERROR("MM oracle: empty context reports item {} owned; fill will over-reach", (int)itemId);
+            }
+        }
+    }
 
     // ComboShip: the reachability logic reads RANDO_SAVE_OPTIONS (randoSaveOptions) and gates on
     // IS_RANDO (saveType == SAVETYPE_RANDO). The memset above wiped both, and nothing else repopulates


### PR DESCRIPTION
## Problem

Player-reported unbeatable seed: Snowhead Temple checks in sphere 10 require the Goron Lullaby, but MM's Ocarina of Time was placed in sphere 23.

`Combo_MM_Rando_Reset` resets the headless oracle save with `memset(0)`, but empty MM inventory slots are `ITEM_NONE` (0xFF) and `ITEM_OCARINA_OF_TIME` is item id **0**, so `HAS_ITEM` (an equality compare) reported the ocarina always owned and every song playable from sphere 0. Masked while `RI_OCARINA` was a starting item (default kit); exposed by `gRando.StartingItems: []`, which shuffles the whole kit into the pool. The `--playthrough` validator shares the same oracle, so it could not catch it.

## Fix

- Re-init `inventory.items` (48 slots, items + masks) to `ITEM_NONE` after the memset, mirroring a real fresh save.
- One-time sweep logging an error if any inventory-slot item reads as owned on the empty context (guards future zero-collision regressions).
- Deviation entry in `docs/deviations/rando.md`.

## Verification (headless, exact-seed repro: `--settings <player log> --master-seed 58234477`)

- Empty kit: the 4 kit items now enter the pool (546 → 550 advancement items); generation PASS; `--playthrough` forward walk PASS (beatable, sphere 17) with the ocarina correctly treated as a song gate.
- Fixed validator now correctly FAILs the player's original broken seed.
- Default-kit control: unchanged behavior.

Existing empty-kit seeds are not salvageable — regeneration required.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9045388603.zip)
<!--- section:artifacts:end -->