### PR TITLE
fix(lus): Config::SetBlock creates missing intermediate keys

### DIFF
--- a/docs/deviations/ui-menu.md
+++ b/docs/deviations/ui-menu.md
@@ -255,3 +255,16 @@ refresh lives only in `Menu::DrawElement`, which never runs under comboui, so po
 (Audio Editor, Mod Menu) that draw via `MenuDrawItem` read a frozen disable flag.
 `mm/2s2h/BenGui/Menu.cpp` (`Menu::MenuDrawItem`, `COMBO_BUILD`-guarded) now refreshes the map once
 per ImGui frame. SoH needs no parity fix: its popout-drawn widgets have no disable-map preFuncs.
+
+## Config::SetBlock drops writes when intermediate keys are missing (2026-08-10)
+
+**Why:** `SetBlock`'s dot-walk only descended into keys that already existed — a missing
+intermediate (e.g. `CVars.gRando` on a config that never saved a gRando key) made the whole write a
+silent no-op. Surfaced as `MM_RestoreRandoSettings` failing to restore an empty
+`gRando.StartingItems: []` kit: `SetStartingItemsInConfig` never landed, exact-seed repro fell back
+to the default kit. (Related pre-existing quirk, handled by callers: nlohmann `flatten()` turns an
+empty array into null; `GetStartingItemsFromConfig` treats null as empty.)
+
+**Vendored:** `libultraship/src/ship/config/Config.cpp` (`SetBlock`) — create missing intermediate
+objects and descend; a non-object in the path keeps the old silent no-op (`ComboShip:` comment at
+site).

--- a/libultraship/src/ship/config/Config.cpp
+++ b/libultraship/src/ship/config/Config.cpp
@@ -165,6 +165,15 @@ void Config::SetBlock(const std::string& key, nlohmann::json block) {
                 } else if (gjson2->contains(dot)) {
                     gjson2 = &gjson2->at(dot);
                     curDot++;
+                } else {
+                    // ComboShip: create missing intermediate keys — the walk used to fall through
+                    // silently, dropping the whole write (e.g. CVars.gRando.StartingItems on a config
+                    // that never saved a gRando key). A non-object in the path keeps the old no-op.
+                    if (!gjson2->is_object()) {
+                        return;
+                    }
+                    gjson2 = &((*gjson2)[dot] = nlohmann::json::object());
+                    curDot++;
                 }
             }
         }


### PR DESCRIPTION
## Problem

`Config::SetBlock`'s dot-walk only descended into keys that already existed — a missing intermediate (e.g. `CVars.gRando` on a config that never saved a gRando key) made the whole write a silent no-op. Surfaced as `MM_RestoreRandoSettings` failing to restore an empty `gRando.StartingItems: []` kit: `SetStartingItemsInConfig` never landed, so exact-seed repro (`comborando --settings <spoiler>`) silently generated with the default kit instead of the seed's.

## Fix

Create missing intermediate keys as objects and descend; a non-object in the path keeps the old silent no-op. Deviation documented in `docs/deviations/ui-menu.md` next to the existing `TryUnflatten` Config entries. (Second-order nlohmann behavior — `flatten()` turns an empty array into null — is already handled by `GetStartingItemsFromConfig`'s null branch.)

## Verification (Debug, headless)

- On a config with no `CVars.gRando` subtree, `comborando --settings <player spoiler> --master-seed 58234477` now honors the empty kit without manual config edits: sword/shield/ocarina/Song of Time enter the pool (546 → 550 advancement items), generation PASSes, and the emitted spoiler echoes `"gRando.StartingItems": []`.
- Default-kit control run unchanged (kit stays out of the pool).

Found while verifying #141; independent of it.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9045872274.zip)
<!--- section:artifacts:end -->