### PR TITLE
Tracker batch: MM spawn offset + draggable default, icon parity, OOT check tracker reset

### DIFF
--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -588,6 +588,11 @@ void DrawTrackerSharedPanel() {
             CVarSetInteger("gCombo.Tracker.IconSize", px);
             appearanceChanged = true;
         }
+        int spacing = CVarGetInteger("gCombo.Tracker.IconSpacing", ComboTracker::kDefaultIconSpacing);
+        if (ImGui::SliderInt("Icon spacing (px)", &spacing, 0, 50)) {
+            CVarSetInteger("gCombo.Tracker.IconSpacing", spacing);
+            appearanceChanged = true;
+        }
         float op = CVarGetFloat("gCombo.Tracker.Opacity", ComboTracker::kDefaultOpacity);
         if (ImGui::SliderFloat("Background opacity", &op, 0.0f, 1.0f, "%.2f")) {
             CVarSetFloat("gCombo.Tracker.Opacity", op);

--- a/combo/gui/ComboTrackerBridge.cpp
+++ b/combo/gui/ComboTrackerBridge.cpp
@@ -22,6 +22,18 @@ void ComboTracker::SyncAppearance() {
     CVarSetInteger("gTrackers.ItemTracker.IconSize", px);
     CVarSetFloat("gSettings.ItemTracker.Scale", std::clamp(px / 46.0f, 0.2f, 3.0f));
 
+    // Icon spacing: OOT native grid gap; MM pads its cells via a COMBO_BUILD seam so both grids
+    // share the same icon+gap pitch. Arrived after the first-run seed — latch separately so an
+    // existing OOT custom spacing is adopted rather than clobbered.
+    if (!CVarGetInteger("gCombo.Tracker.SpacingSeeded", 0)) {
+        CVarSetInteger("gCombo.Tracker.SpacingSeeded", 1);
+        CVarSetInteger("gCombo.Tracker.IconSpacing",
+                       CVarGetInteger("gTrackers.ItemTracker.IconSpacing", kDefaultIconSpacing));
+    }
+    int spacing = CVarGetInteger("gCombo.Tracker.IconSpacing", kDefaultIconSpacing);
+    CVarSetInteger("gTrackers.ItemTracker.IconSpacing", spacing);
+    CVarSetInteger("gSettings.ItemTracker.IconSpacing", spacing);
+
     // Opacity: MM has a float CVar; OOT dims via BgColor alpha (RGB preserved).
     float op = std::clamp(CVarGetFloat("gCombo.Tracker.Opacity", kDefaultOpacity), 0.0f, 1.0f);
     CVarSetFloat("gSettings.ItemTracker.Opacity", op);

--- a/combo/gui/ComboTrackerBridge.h
+++ b/combo/gui/ComboTrackerBridge.h
@@ -12,11 +12,13 @@
 namespace ComboTracker {
 
 // Canonical defaults, shared by the bridge and the Shared-panel widgets (single source; these
-// match vanilla OOT's tracker defaults, the reference look).
+// match vanilla OOT's tracker defaults, the reference look — except Draggable, on so first-time
+// players can immediately move the trackers).
 inline constexpr int kDefaultIconSize = 36;
+inline constexpr int kDefaultIconSpacing = 12;
 inline constexpr float kDefaultOpacity = 0.0f;
 inline constexpr int kDefaultWindowType = 0;
-inline constexpr int kDefaultDraggable = 0;
+inline constexpr int kDefaultDraggable = 1;
 inline constexpr int kDefaultCheckWindowType = 1; // TRACKER_WINDOW_WINDOW — OOT's check tracker default
 
 // Push all canonical gCombo.Tracker.* values into both games' CVars (seeding them from OOT on

--- a/combo/gui/ComboTrackerSwap.cpp
+++ b/combo/gui/ComboTrackerSwap.cpp
@@ -109,6 +109,12 @@ void PlaceMmWindowOnFirstShow(int kindIdx) {
     if (!oot) {
         return;
     }
+    // AlwaysAutoResize windows carry a placeholder rect through their first (hidden) sizing
+    // frames; placing from that puts MM inside OOT's eventual frame. Wait while OOT is actively
+    // sizing — a dormant OOT window (HideBackground) keeps its last measured rect and is fine.
+    if (oot->WasActive && oot->Hidden) {
+        return;
+    }
     ImGui::SetWindowPos(mm, ImVec2(oot->Pos.x + oot->Size.x + kFirstShowGapPx, oot->Pos.y), ImGuiCond_Always);
     CVarSetInteger(kind.mmPlacedCvar, 1);
     sLatched[kindIdx] = true;

--- a/docs/deviations/tracker.md
+++ b/docs/deviations/tracker.md
@@ -144,3 +144,33 @@ on boot.
 
 **On future merges:** if upstream renames the tracker ImGui windows or the settings windows,
 update `combo/gui/ComboTrackerCommon.h` (`kKinds[].imguiWin`) and the inline-widget window names.
+
+## Tracker batch: spawn offset, icon parity, OOT check-tracker reset (2026-08-10)
+
+**Why:** (1) First-show placement latched a bad MM position (OOT's AlwaysAutoResize width isn't
+settled the frame both windows appear), so new configs opened the trackers stacked. (2) The two
+grids had different density: OOT draws icon + IconSpacing gaps, MM packed 46px cells edge-to-edge.
+(3) The OOT Check Tracker could permanently zero: a threaded trackerData save queued before a
+reload runs against the freshly recreated (all-UNCHECKED) gRandoContext and persists
+`"checkStatus": []`; separately, incremental saves demote COLLECTED->SCUMMED on disk and nothing
+ever promotes back (autosave is blocked for the whole Ocarina-without-Song-of-Time stretch).
+
+**Combo-owned:** `ComboTrackerSwap.cpp` placement waits for settled rects; `ComboTrackerBridge.*`
+adds canonical `gCombo.Tracker.IconSpacing` (separately seeded) and flips Draggable default to on;
+`ComboMenu.cpp` gets the shared "Icon spacing (px)" slider.
+
+**Vendored (`COMBO_BUILD`-guarded):**
+- `mm/.../ItemTracker/ItemTracker.cpp` — cell padded around the icon by
+  `gSettings.ItemTracker.IconSpacing` (bridge-mirrored) so both grids share icon+gap pitch;
+  count text anchored to the icon rect. Vanilla path unchanged (pad 0 / `#else`).
+- `soh/soh/SaveManager.cpp` — `Save_LoadFile`: `ThreadPoolWait()` before recreating gRandoContext
+  (reload paths reach here before OnExitGame's drain), and early-return keeping the current
+  context when the container has no OOT block (previously reset-then-bail left it all-unchecked).
+- `soh/.../randomizer_check_tracker.cpp` — `CheckTrackerLoadGame` promotes a persisted status to
+  SAVED when the loaded save's own flags prove the check was obtained (`ComboCheckFlagObtained`);
+  genuine save-scums stay SCUMMED (their flags are absent). Also self-heals already-wiped saves.
+  Tripwire WARN when persisting an empty checkStatus for a rando file.
+- `soh/soh/OTRGlobals.cpp` — `SOH_MarkForeignObtained` persists via full `SaveFile` (a foreign
+  check has no OOT flag to promote it back from SCUMMED).
+- `soh/.../SeedContext.cpp` — WARN tripwires in `ItemReset`/`ClearItemLocations` when called with
+  a save loaded (suspected mid-session wipe path; not yet root-caused).

--- a/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.cpp
@@ -313,6 +313,15 @@ void DrawItemCounts(TrackerItemType itemType, u32 itemId, ImVec2 textureSize, fl
 bool DrawItemTrackerSlot(TrackerItemType itemType, u32 itemId, float scale, bool clickable) {
     ImVec2 currentPos = ImGui::GetCursorPos();
     ImVec2 cellSize(ITEM_TEXTURE_SIZE * scale, ITEM_TEXTURE_SIZE * scale);
+    ImVec2 iconSize = cellSize;
+#ifdef COMBO_BUILD
+    // ComboShip: pad the cell around the icon so the grid pitch matches OOT's icon+gap layout
+    // (bridge mirrors gCombo.Tracker.IconSpacing here).
+    int spacing = CVarGetInteger("gSettings.ItemTracker.IconSpacing", 0);
+    float pad = spacing > 0 ? (float)spacing : 0.0f;
+    cellSize.x += pad;
+    cellSize.y += pad;
+#endif
 
     TrackerImageObject imageObject = GetImageObject(itemType, itemId);
 
@@ -348,12 +357,12 @@ bool DrawItemTrackerSlot(TrackerItemType itemType, u32 itemId, float scale, bool
     float aspect = imageObject.textureDimensions.x / imageObject.textureDimensions.y;
 
     // fit to height
-    ImVec2 drawSize(cellSize.y * aspect, cellSize.y);
+    ImVec2 drawSize(iconSize.y * aspect, iconSize.y);
 
     // clamp if too wide
-    if (drawSize.x > cellSize.x) {
-        drawSize.x = cellSize.x;
-        drawSize.y = cellSize.x / aspect;
+    if (drawSize.x > iconSize.x) {
+        drawSize.x = iconSize.x;
+        drawSize.y = iconSize.x / aspect;
     }
 
     ImVec2 offset((cellSize.x - drawSize.x) * 0.5f, (cellSize.y - drawSize.y) * 0.5f);
@@ -401,7 +410,12 @@ bool DrawItemTrackerSlot(TrackerItemType itemType, u32 itemId, float scale, bool
     ImGuiLastItemData backup = g.LastItemData;
 
     if (CVarGetInteger("gSettings.ItemTracker.ItemCounts", 1)) {
+#ifdef COMBO_BUILD
+        // Anchor the count to the icon, not the padded cell.
+        DrawItemCounts(itemType, itemId, iconSize, scale, currentPos + ImVec2(pad * 0.5f, pad * 0.5f));
+#else
         DrawItemCounts(itemType, itemId, cellSize, scale, currentPos);
+#endif
     }
 
     // Restore last item data so drag/drop operations work correctly
@@ -420,6 +434,11 @@ void DrawItemTrackerGroup(TrackerGroup& trackerGroup) {
                       ? trackerGroup.scale
                       : CVarGetFloat("gSettings.ItemTracker.Scale", 1.0f);
 
+#ifdef COMBO_BUILD
+    // ComboShip: the seam's cell pad is the whole gap — zero the table's own CellPadding
+    // (locked in at BeginTable) so the grid pitch is exactly icon + IconSpacing.
+    ImGui::PushStyleVar(ImGuiStyleVar_CellPadding, ImVec2(0, 0));
+#endif
     if (ImGui::BeginTable(trackerGroup.name.c_str(), columns)) {
         ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
@@ -431,6 +450,9 @@ void DrawItemTrackerGroup(TrackerGroup& trackerGroup) {
         ImGui::PopStyleVar(2);
         ImGui::EndTable();
     }
+#ifdef COMBO_BUILD
+    ImGui::PopStyleVar();
+#endif
 }
 
 void ItemTrackerWindow::Draw() {

--- a/soh/soh/Enhancements/randomizer/SeedContext.cpp
+++ b/soh/soh/Enhancements/randomizer/SeedContext.cpp
@@ -25,6 +25,17 @@ extern "C" {
 #include <variables.h>
 }
 
+#ifdef COMBO_BUILD
+extern "C" PlayState* gPlayState;
+// ComboShip tripwire: a status wipe on the live context mid-game is the suspected cause of the
+// check tracker suddenly zeroing; log the path so a recurrence identifies its caller.
+static void ComboWarnIfLiveWipe(const char* who) {
+    if (gPlayState != nullptr && gSaveContext.fileNum != 0xFF) {
+        SPDLOG_WARN("{} while save {} is loaded - live check statuses wiped", who, gSaveContext.fileNum);
+    }
+}
+#endif
+
 namespace Rando {
 std::weak_ptr<Context> Context::mContext;
 
@@ -300,12 +311,18 @@ std::vector<RandomizerCheck> Context::GetLocations(const std::vector<RandomizerC
 }
 
 void Context::ClearItemLocations() {
+#ifdef COMBO_BUILD
+    ComboWarnIfLiveWipe("Context::ClearItemLocations");
+#endif
     for (size_t i = 0; i < itemLocationTable.size(); i++) {
         GetItemLocation(static_cast<RandomizerCheck>(i))->ResetVariables();
     }
 }
 
 void Context::ItemReset() {
+#ifdef COMBO_BUILD
+    ComboWarnIfLiveWipe("Context::ItemReset");
+#endif
     for (const RandomizerCheck il : allLocations) {
         GetItemLocation(il)->ResetVariables();
     }

--- a/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_check_tracker.cpp
@@ -600,6 +600,34 @@ void CheckTrackerHintRevealed(RandomizerHint hintKey) {
     }
 }
 
+#ifdef COMBO_BUILD
+// ComboShip: true when the loaded save's own flags prove this check was obtained. Conservative —
+// unmapped collection-check types return false so a genuine save-scum is never falsely promoted.
+static bool ComboCheckFlagObtained(const Rando::Location& loc) {
+    Rando::SpoilerCollectionCheck scc = loc.GetCollectionCheck();
+    switch (scc.type) {
+        case SPOILER_CHK_CHEST:
+            return (gSaveContext.sceneFlags[scc.scene].chest >> scc.flag) & 1;
+        case SPOILER_CHK_COLLECTABLE:
+            return (gSaveContext.sceneFlags[scc.scene].collect >> scc.flag) & 1;
+        case SPOILER_CHK_GOLD_SKULLTULA:
+            return (GET_GS_FLAGS(scc.scene) & scc.flag) != 0;
+        case SPOILER_CHK_EVENT_CHK_INF:
+            return Flags_GetEventChkInf(scc.flag) != 0;
+        case SPOILER_CHK_ITEM_GET_INF:
+            return Flags_GetItemGetInf(scc.flag) != 0;
+        case SPOILER_CHK_INF_TABLE:
+            return Flags_GetInfTable(scc.flag) != 0;
+        case SPOILER_CHK_RANDOMIZER_INF: {
+            RandomizerInf inf = OTRGlobals::Instance->gRandomizer->GetRandomizerInfFromCheck(loc.GetRandomizerCheck());
+            return inf != RAND_INF_MAX && Flags_GetRandomizerInf(inf);
+        }
+        default:
+            return false;
+    }
+}
+#endif
+
 void CheckTrackerLoadGame(int32_t fileNum) {
     if (IS_BOSS_RUSH) {
         return;
@@ -618,6 +646,16 @@ void CheckTrackerLoadGame(int32_t fileNum) {
 
         Rando::Location* entry2 = Rando::StaticData::GetLocation(rc);
         Rando::ItemLocation* loc = OTRGlobals::Instance->gRandoContext->GetItemLocation(rc);
+
+#ifdef COMBO_BUILD
+        // ComboShip: incremental tracker saves demote COLLECTED->SCUMMED on disk (upstream
+        // anti-save-scum) and a past save/load race could wipe statuses outright; when the loaded
+        // save's flags prove the check was obtained, promote to SAVED so counts stay truthful.
+        if (IS_RANDO && loc->GetCheckStatus() < RCSHOW_SAVED && !loc->GetIsSkipped() &&
+            OTRGlobals::Instance->gRandoContext->IsQuestOfLocationActive(rc) && ComboCheckFlagObtained(*entry2)) {
+            loc->SetCheckStatus(RCSHOW_SAVED);
+        }
+#endif
 
         checksByArea.find(entry2->GetArea())->second.push_back(entry2->GetRandomizerCheck());
         if (IsVisibleInCheckTracker(entry2->GetRandomizerCheck())) {
@@ -996,6 +1034,14 @@ void SaveTrackerData(SaveContext* saveContext, int sectionID, bool fullSave) {
             OTRGlobals::Instance->gRandoContext->GetItemLocation(i)->GetIsSkipped())
             checkCount.push_back(static_cast<RandomizerCheck>(i));
     }
+#ifdef COMBO_BUILD
+    // ComboShip tripwire: an all-UNCHECKED dump for a real rando file means some path wiped the
+    // live context before this (queued) save ran — it would persist an empty tracker section.
+    if (checkCount.empty() && saveContext->ship.quest.id == QUEST_RANDOMIZER) {
+        SPDLOG_WARN("SaveTrackerData: persisting EMPTY checkStatus for file {} (sectionID {}, fullSave {})",
+                    saveContext->fileNum, sectionID, fullSave);
+    }
+#endif
     SaveManager::Instance->SaveArray("checkStatus", checkCount.size(), [&](size_t i) {
         RandomizerCheck check = checkCount.at(i);
         RandomizerCheckStatus savedStatus =

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -3097,7 +3097,9 @@ extern "C" __declspec(dllexport) void SOH_MarkForeignObtained(const char* checkN
     CheckTracker::RecalculateAllAreaTotals();
     CheckTracker::RecalculateAvailableChecks();
     if (SaveManager::Instance && gSaveContext.fileNum != 0xFF) {
-        SaveManager::Instance->SaveSection(gSaveContext.fileNum, SECTION_ID_TRACKER_DATA, true);
+        // Full save (not SaveSection): incremental tracker saves demote COLLECTED->SCUMMED on
+        // disk, and no OOT flag exists for a foreign-collected check to promote it back from.
+        SaveManager::Instance->SaveFile(gSaveContext.fileNum);
     }
     SPDLOG_INFO("[ComboShip] SOH_MarkForeignObtained: marked OOT check '{}' collected", checkName);
 }

--- a/soh/soh/SaveManager.cpp
+++ b/soh/soh/SaveManager.cpp
@@ -2904,6 +2904,23 @@ extern "C" void Save_SaveGlobal(void) {
 }
 
 extern "C" void Save_LoadFile(void) {
+#ifdef COMBO_BUILD
+    // ComboShip (tracker wipe): drain queued threaded saves BEFORE recreating gRandoContext —
+    // SaveTrackerData reads the LIVE context from the pool thread, and reload paths (BetterSaveMenu
+    // Reset/Return-to-Spawn, portal return via title_setup.c) reach here before OnExitGame's
+    // ThreadPoolWait, so a queued save would persist an all-UNCHECKED "checkStatus".
+    SaveManager::Instance->ThreadPoolWait();
+    // Missing OOT block: LoadFile would return early AFTER the reset, leaving an all-unchecked
+    // context that the next save persists. Keep the current context instead.
+    if (gComboReadGameSave) {
+        const char* comboJson = gComboReadGameSave(ComboRando::GAME_OOT, gSaveContext.fileNum);
+        if (comboJson == nullptr || comboJson[0] == '\0') {
+            SPDLOG_ERROR("Save_LoadFile: no OOT save block for slot {} - keeping current rando context",
+                         gSaveContext.fileNum);
+            return;
+        }
+    }
+#endif
     // Handle vanilla context reset
     OTRGlobals::Instance->gRandoContext->GetLogic()->SetContext(nullptr);
     Rando::Settings::GetInstance()->ClearContext();


### PR DESCRIPTION
Three Item/Check Tracker fixes in one batch.

## 1. Trackers no longer spawn stacked; draggable by default
First-show placement fired while OOT''s AlwaysAutoResize window still had its sizing-placeholder rect, latching MM''s window inside OOT''s eventual frame (`gCombo.Tracker.MmPlaced`). Placement now waits for a settled OOT rect (a dormant OOT window under HideBackground keeps its last measured rect and places immediately). `Draggable` defaults on so first-time players can move both trackers right away. Existing configs that already latched a bad position are unaffected (fresh-config fix only).

## 2. Item tracker icon size/padding parity
Not the icon art - layout: both games draw icons at the bridged size (36px default), but OOT spaces them by `IconSpacing` (12px) while MM packed cells edge-to-edge (plus ImGui''s default table CellPadding). New canonical `gCombo.Tracker.IconSpacing` with a Shared-panel slider, mirrored to OOT''s native CVar and a `COMBO_BUILD` cell-padding seam in MM''s tracker (CellPadding zeroed), so both grids share the same icon+gap pitch. An existing OOT custom spacing is seeded, not clobbered.

## 3. OOT Check Tracker wholesale reset (0 checked, collected shown available, items intact)
Two confirmed causes fixed, both `COMBO_BUILD`-guarded:
- **Threaded-save race:** a queued trackerData save reads the LIVE `gRandoContext` from the pool thread; reload paths (Better Save Menu Reset/Return-to-Spawn, portal return) reach `Save_LoadFile` before `OnExitGame`''s drain, so the save ran against the freshly recreated all-UNCHECKED context and permanently persisted `"checkStatus": []`. `Save_LoadFile` now drains the pool first, and no longer resets the context when the combo container has no OOT block.
- **SCUMMED demotion:** incremental section saves write COLLECTED as SCUMMED on disk; only full saves promote to SAVED, and autosave is hard-blocked for the whole Ocarina-without-Song-of-Time stretch (hence the Song of Time correlation). On load, a persisted status is promoted to SAVED when the save''s own flags prove the check was obtained (quest-variant filtered; genuine save-scums keep SCUMMED since their flags are absent). This also **self-heals already-corrupted saves on next load**. Foreign-collected checks (no OOT flag exists) persist via a full `SaveFile` in `SOH_MarkForeignObtained`.

The reported mid-session zeroing moment is not fully root-caused; WARN tripwires (empty checkStatus dump for a rando file; `ItemReset`/`ClearItemLocations` with a save loaded) will name the path if it recurs.

Deviations documented in `docs/deviations/tracker.md`. Vendored delta ~90 lines, all guarded. Built Debug (comboui/soh/2ship) clean; unplaytested.

### Playtest notes
- Fresh config: enable Item Tracker -> MM window appears right of OOT with an 8px gap; both draggable.
- Icon parity: compare grids at defaults; move the shared Icon size/spacing sliders.
- Check tracker: load a previously-affected save -> counts should immediately reflect owned items. Anti-scum guard: collect a check, kill the process without saving, reload -> stays SCUMMED.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9057111893.zip)
<!--- section:artifacts:end -->