### PR TITLE
CMC: foreign checks render as the real item (#103)

### DIFF
--- a/combo/ComboRandoHeadless.cpp
+++ b/combo/ComboRandoHeadless.cpp
@@ -506,21 +506,12 @@ int main(int argc, char** argv) {
                                            { "placements", mmPl },
                                            { "prices", pricesOf(mmDump) } };
                     // ComboShip: enrich the foreign array exactly like RunComboFill (displayName game
-                    // suffix + oot checkArea) so the headless consolidated file matches the in-game one.
-                    std::unordered_map<std::string, std::string> ootCheckAreas;
-                    try {
-                        auto hd = nlohmann::json::parse(sohHintDump.empty() ? "{}" : sohHintDump);
-                        for (auto& c : hd.value("checks", nlohmann::json::array())) {
-                            std::string name = c.value("name", ""), area = c.value("area", "");
-                            if (!name.empty() && !area.empty())
-                                ootCheckAreas.emplace(std::move(name), std::move(area));
-                        }
-                    } catch (...) {}
+                    // suffix) so the headless consolidated file matches the in-game one.
                     auto foreignArr = fillSpoiler.value("foreign", nlohmann::json::array());
                     ComboRando::AssignTrapDisguises(foreignArr, fillSpoiler.value("oot", nlohmann::json::object()),
                                                     fillSpoiler.value("mm", nlohmann::json::object()), sohDump, mmDump,
                                                     masterSeed);
-                    consolidated["foreign"] = ComboRando::BuildForeignArray(foreignArr, ootCheckAreas);
+                    consolidated["foreign"] = ComboRando::BuildForeignArray(foreignArr);
                     // OOT entrance layout (parity with ComboShip.cpp's consolidated writer) — this is
                     // what --playthrough installs into the region graph before walking.
                     {

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -1125,12 +1125,11 @@ static void RunComboFill(std::string inputSeed, ComboRando::ComboGenProgress* pr
     nlohmann::json playthroughJson = nlohmann::json::array(); // structured sphere playthrough (combined-fill only)
     ComboRando::RequirednessResult pareDownResult;            // cross-hint Phase 3 WotH/foolish classification
     // ComboShip: checkName -> OOT area, computed once from sohHintDump right after the winning attempt's
-    // dump (below) — reused by the pare-down call and the foreign-array enrichment after the fill loop,
-    // instead of re-parsing sohHintDump twice for the same map.
+    // dump (below) for the pare-down call.
     std::unordered_map<std::string, std::string> ootCheckAreasCache;
 
-    // ComboShip: checkName -> area/region string, from each game's own dump. Shared by the pare-down
-    // (foolish-area rollup) and the foreign-array enrichment after the fill loop.
+    // ComboShip: checkName -> area/region string, from each game's own dump, for the pare-down
+    // (foolish-area rollup).
     auto buildOotCheckAreas = [](const std::string& hintDumpJson) {
         std::unordered_map<std::string, std::string> out;
         try {
@@ -1407,9 +1406,7 @@ static void RunComboFill(std::string inputSeed, ComboRando::ComboGenProgress* pr
         consolidated["mm"] = { { "settings", parseOrEmpty(MM_DumpRandoSettings) },
                                { "placements", mmSpoiler },
                                { "prices", pricesOf(mmDump) } };
-        // ComboShip: checkName -> OOT area name (cross-hint Phase 2 schema; consumed in Phase 3) — reuses
-        // the same parse done above, right after sohHintDump was produced, instead of re-parsing it here.
-        auto foreignEnriched = ComboRando::BuildForeignArray(foreignArr, ootCheckAreasCache);
+        auto foreignEnriched = ComboRando::BuildForeignArray(foreignArr);
         consolidated["foreign"] = foreignEnriched;
         consolidated["playthrough"] = ComboRando::PlaythroughLines(playthroughJson);
         // ComboShip (#90): OOT entrance layout — informational, reload re-derives it from masterSeed.

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -1042,7 +1042,8 @@ void PlandoSavePlay() {
     nlohmann::json ootPl = nlohmann::json::object();
     nlohmann::json mmPl = nlohmann::json::object();
     nlohmann::json foreignRaw = nlohmann::json::array();
-    // Trap disguises can't be recomputed here; carry them over for rows whose item is unchanged.
+    // Trap disguises and item categories can't be recomputed here; carry them over for rows whose
+    // item is unchanged.
     std::unordered_map<std::string, nlohmann::json> priorForeign;
     for (const auto& fm : j.value("foreign", nlohmann::json::array())) {
         priorForeign[fm.value("checkGame", "") + "|" + fm.value("checkName", "")] = fm;
@@ -1061,7 +1062,7 @@ void PlandoSavePlay() {
                                       { "advancement", r.advancement } };
             auto pf = priorForeign.find(cg + "|" + r.check);
             if (pf != priorForeign.end() && pf->second.value("itemName", "") == r.item) {
-                for (const char* k : { "fakeItemName", "fakeDisplayName", "fakeTrickName" })
+                for (const char* k : { "fakeItemName", "fakeDisplayName", "fakeTrickName", "category" })
                     if (pf->second.contains(k))
                         marker[k] = pf->second[k];
             }

--- a/combo/rando/CrossForeign.h
+++ b/combo/rando/CrossForeign.h
@@ -9,6 +9,7 @@
 // "foreign" array element:
 //   { "checkGame":"oot|mm", "checkName":"<friendly check name>", "itemGame":"oot|mm",
 //     "itemName":"<friendly item name>", "displayName":"<human name + (MM)/(OOT)>",
+//     optional: "advancement"/"trap" (only when true), "category" (native item category, drives CMC),
 //     optional trap disguise: "fakeItemName", "fakeDisplayName", "fakeTrickName" }
 //
 // Note: checkName/itemName are the friendly combo-spoiler names (bare, no suffix) — the home game
@@ -64,6 +65,9 @@ struct ForeignItem {
     std::string displayName;  // human string for the "sent"/"received" text
     bool advancement = false; // progression in its home game -> drives the held-up pickup animation
     bool trap = false;        // a trap in its home game -> fires on the FINDER, never cross-delivered
+    // Native item category name (junk/lesser/health/bossKey/smallKey/token/major/mask/strayFairy).
+    // Empty = absent (old seed or plando); consumers fall back to advancement.
+    std::string category;
     // Trap disguise (empty = none). The name/model shown until the check is collected; the GRANT
     // always uses itemName. fakeItemName lives in itemGame's namespace (feeds the draw producers).
     std::string fakeItemName;
@@ -218,11 +222,8 @@ inline void AssignTrapDisguises(nlohmann::json& foreignArr, const nlohmann::json
 
 // Tag a spoiler "foreign" array's displayNames with their home-game suffix for the consolidated file.
 // Every display surface (shops, hints, trackers, toasts) reads displayName, so tag once here.
-// ootCheckAreas (checkName -> OOT area name, from SOH_DumpRandoHintData's "checks" list) is optional;
-// when given, oot-side entries get a "checkArea" field for the combo hint layer's foolish-area logic.
-// MM-side entries omit it — MM's own dump carries its per-check "locationHints" (region names) instead.
-inline nlohmann::json BuildForeignArray(const nlohmann::json& foreignArray,
-                                        const std::unordered_map<std::string, std::string>& ootCheckAreas = {}) {
+// advancement/trap/category are emitted only when meaningful; every loader defaults them.
+inline nlohmann::json BuildForeignArray(const nlohmann::json& foreignArray) {
     nlohmann::json out = nlohmann::json::array();
     for (const auto& fm : foreignArray) {
         std::string checkGame = fm.value("checkGame", "");
@@ -240,21 +241,25 @@ inline nlohmann::json BuildForeignArray(const nlohmann::json& foreignArray,
             return s;
         };
         std::string displayName = tag(fm.value("displayName", itemName));
-        nlohmann::json entry = { { "checkGame", checkGame },         { "checkName", checkName },
-                                 { "itemGame", itemGame },           { "itemName", itemName },
-                                 { "displayName", displayName },     { "advancement", fm.value("advancement", false) },
-                                 { "trap", fm.value("trap", false) } };
+        nlohmann::json entry = { { "checkGame", checkGame },
+                                 { "checkName", checkName },
+                                 { "itemGame", itemGame },
+                                 { "itemName", itemName },
+                                 { "displayName", displayName } };
+        if (fm.value("advancement", false))
+            entry["advancement"] = true;
+        if (fm.value("trap", false))
+            entry["trap"] = true;
+        // Native item category: drives the container-matches-contents look at a foreign check.
+        std::string category = fm.value("category", "");
+        if (!category.empty())
+            entry["category"] = category;
         // Trap disguise: fakeItemName stays bare (it's a grant-namespace key); the shown names get tagged.
         std::string fakeItemName = fm.value("fakeItemName", "");
         if (!fakeItemName.empty()) {
             entry["fakeItemName"] = fakeItemName;
             entry["fakeDisplayName"] = tag(fm.value("fakeDisplayName", fakeItemName));
             entry["fakeTrickName"] = tag(fm.value("fakeTrickName", fm.value("fakeDisplayName", fakeItemName)));
-        }
-        if (checkGame == "oot") {
-            auto it = ootCheckAreas.find(checkName);
-            if (it != ootCheckAreas.end())
-                entry["checkArea"] = it->second;
         }
         out.push_back(std::move(entry));
     }
@@ -333,6 +338,8 @@ inline std::unordered_map<std::string, ForeignItem> LoadForeignForGame(int slot,
             fi.advancement = fm.value("advancement", false);
             // Absent in pre-trap-flag saves -> false -> the item cross-delivers as before.
             fi.trap = fm.value("trap", false);
+            // Absent in pre-category saves -> empty -> consumers fall back to advancement.
+            fi.category = fm.value("category", "");
             // Absent in pre-disguise saves -> empty -> every consumer falls back to the true name.
             fi.fakeItemName = fm.value("fakeItemName", "");
             fi.fakeDisplayName = fm.value("fakeDisplayName", "");

--- a/combo/rando/CrossHints.h
+++ b/combo/rando/CrossHints.h
@@ -294,7 +294,10 @@ inline nlohmann::json Generate(uint32_t masterSeed, const std::string& sohDumpJs
         if (fm.value("checkGame", "") != "oot" || fm.value("itemGame", "") != "mm")
             continue;
         std::string itemName = fm.value("itemName", "");
-        std::string area = fm.value("checkArea", fm.value("checkName", ""));
+        std::string checkName = fm.value("checkName", "");
+        // Area from the hint dump's own per-check table (foreign[] no longer persists checkArea).
+        auto ca = ootChecks.find(checkName);
+        std::string area = (ca != ootChecks.end() && !ca->second.area.empty()) ? ca->second.area : checkName;
         if (!itemName.empty())
             mmItemLocations[itemName] = "in " + area + " (OOT)";
     }

--- a/combo/rando/CrossWorldRando.h
+++ b/combo/rando/CrossWorldRando.h
@@ -1033,13 +1033,18 @@ inline CombinedFillResult CrossWorldCombinedFill(const std::string& sohDumpJson,
             mmPlacements[p.check.name] = p.item.name;
         }
         if (p.check.game != p.item.game) {
-            foreignMarkers.push_back({ { "checkGame", p.check.game == GAME_OOT ? "oot" : "mm" },
-                                       { "checkName", p.check.name },
-                                       { "itemGame", p.item.game == GAME_OOT ? "oot" : "mm" },
-                                       { "itemName", p.item.name },
-                                       // Propagate advancement so foreign checks holding an important item
-                                       // still play the held-up pickup animation (else defaulted to junk).
-                                       { "advancement", p.item.advancement } });
+            nlohmann::json marker = { { "checkGame", p.check.game == GAME_OOT ? "oot" : "mm" },
+                                      { "checkName", p.check.name },
+                                      { "itemGame", p.item.game == GAME_OOT ? "oot" : "mm" },
+                                      { "itemName", p.item.name },
+                                      // Propagate advancement so foreign checks holding an important item
+                                      // still play the held-up pickup animation (else defaulted to junk).
+                                      { "advancement", p.item.advancement } };
+            // Native item category, so CMC/CSMC can dress the container as the real item instead of
+            // the junk sentinel. UNKNOWN is omitted so consumers use the advancement fallback.
+            if (p.item.cat != CwCat::UNKNOWN)
+                marker["category"] = CwCatName(p.item.cat);
+            foreignMarkers.push_back(std::move(marker));
         }
     }
 

--- a/docs/deviations/rando.md
+++ b/docs/deviations/rando.md
@@ -1222,3 +1222,33 @@ kit); exposed by `gRando.StartingItems: []`, which shuffles the kit into the poo
 
 Fix: after the memset, re-init `inventory.items` (48 slots, items + masks) to `ITEM_NONE`, plus a
 one-time sweep asserting no inventory-slot item reads as owned on the empty context.
+
+## Container Matches Contents dresses foreign checks as the real item (issue #103, 2026-08-10)
+
+Both foreign sentinels are hard-typed junk (`itemTable[RG_COMBO_FOREIGN]` = `ITEM_CATEGORY_JUNK`,
+`RI_COMBO_FOREIGN` = `RITYPE_JUNK`), so every CMC surface — OOT chests + the Shuffle* containers, MM
+chests/grass/pots/barrels/crates — rendered every cross-game item as junk.
+
+**Seed schema:** `foreign[]` entries gain `category` — `CwCatName(p.item.cat)` stamped by the fill
+(the per-item `category` both dumps already emit in `pool[]`), carried by `BuildForeignArray` /
+`ForeignItem`. `CwCat::UNKNOWN` is omitted so consumers fall back to
+`advancement ? major : junk` (also the rule for pre-category seeds and plando imports, which cannot
+compute categories; the plando writer carries `category` over for unchanged rows like the disguise
+fields). Traps always classify **major** — OOT-native parity (`RG_ICE_TRAP` is MAJOR; a junk-looking
+container never gets opened, so the trap would never fire) — deliberately diverging from MM's native
+`RI_TRAP` = LESSER. `advancement`/`trap` are now emitted only when true (loaders already default
+false), and `checkArea` is no longer persisted: its only reader was `CrossHints.h::Generate`, which
+now derives the area from its own `ootChecks` table (same `sohHintDump` source, same
+empty-→checkName fallback, so hint text is unchanged).
+
+**OOT consumption:** `OOT_GetForeignCategory(rc)` (`hook_handlers.cpp`, per-rc cache invalidated by
+`g_ootForeignGen`); `GetFinalGIEntry` overrides `giEntry.getItemCategory` for the sentinel inside
+the existing `COMBO_BUILD` block — the table entry stays junk. MM-only `mask`/`strayFairy` map to
+MAJOR (no OOT textures). `Randomizer_AdjustItemCategory` early-returns for the sentinel so OOT's
+Skeleton Key cannot junk a foreign MM small key. The skip-animation classification in
+`RandomizerOnPlayerUpdateForRCQueueHandler` is intentionally untouched (animation gate ≠ container
+art).
+
+**MM consumption:** `Rando::GetItemTypeForCheck(itemId, checkId)` (`ConvertItem.cpp`) resolves the
+sentinel via `MM_LookupForeign` (category → `RITYPE_*`, same rules) and otherwise returns the old
+`Items[ConvertItem(...)].randoItemType`; the 8 CMC draw sites in `Rando/ActorBehavior/` now call it.

--- a/mm/2s2h/Rando/ActorBehavior/EnBox.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnBox.cpp
@@ -52,8 +52,8 @@ void func_80837C78_override(PlayState* play, Player* player) {
 void EnBox_RandoPostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot, Actor* actor, Gfx** gfx) {
     s32 pad;
     EnBox* enBox = (EnBox*)actor;
-    RandoItemId randoItemId = Rando::ConvertItem(RANDO_SAVE_CHECKS[ENBOX_RC].randoItemId, (RandoCheckId)ENBOX_RC);
-    RandoItemType randoItemType = Rando::StaticData::Items[randoItemId].randoItemType;
+    RandoItemType randoItemType =
+        Rando::GetItemTypeForCheck(RANDO_SAVE_CHECKS[ENBOX_RC].randoItemId, (RandoCheckId)ENBOX_RC);
     if (enBox->unk_1EC != 0 && actor->home.rot.z == 0) {
         actor->home.rot.z = randoItemType + 1;
     }

--- a/mm/2s2h/Rando/ActorBehavior/ObjGrass.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjGrass.cpp
@@ -342,8 +342,7 @@ Gfx* GetObjGrassDList(RandoCheckId randoCheckId) {
         return (Gfx*)gRandoBushDL;
     }
 
-    RandoItemId randoItemId = Rando::ConvertItem(RANDO_SAVE_CHECKS[randoCheckId].randoItemId, randoCheckId);
-    RandoItemType randoItemType = Rando::StaticData::Items[randoItemId].randoItemType;
+    RandoItemType randoItemType = Rando::GetItemTypeForCheck(RANDO_SAVE_CHECKS[randoCheckId].randoItemId, randoCheckId);
 
     switch (randoItemType) {
         case RITYPE_BOSS_KEY:
@@ -384,8 +383,7 @@ Gfx* GetObjGrassXluDList(RandoCheckId randoCheckId) {
         return (Gfx*)gRandoBushXluDL;
     }
 
-    RandoItemId randoItemId = Rando::ConvertItem(RANDO_SAVE_CHECKS[randoCheckId].randoItemId, randoCheckId);
-    RandoItemType randoItemType = Rando::StaticData::Items[randoItemId].randoItemType;
+    RandoItemType randoItemType = Rando::GetItemTypeForCheck(RANDO_SAVE_CHECKS[randoCheckId].randoItemId, randoCheckId);
 
     switch (randoItemType) {
         case RITYPE_BOSS_KEY:
@@ -427,8 +425,7 @@ Gfx* GetCuttableGrassDList(RandoCheckId randoCheckId) {
         return (Gfx*)gRandoCuttableGrassRandomDL;
     }
 
-    RandoItemId randoItemId = Rando::ConvertItem(RANDO_SAVE_CHECKS[randoCheckId].randoItemId, randoCheckId);
-    RandoItemType randoItemType = Rando::StaticData::Items[randoItemId].randoItemType;
+    RandoItemType randoItemType = Rando::GetItemTypeForCheck(RANDO_SAVE_CHECKS[randoCheckId].randoItemId, randoCheckId);
 
     switch (randoItemType) {
         case RITYPE_BOSS_KEY:

--- a/mm/2s2h/Rando/ActorBehavior/ObjKibako.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjKibako.cpp
@@ -151,8 +151,7 @@ void ObjKibako_RandoDraw(Actor* actor, PlayState* play) {
     }
 
     RandoCheckId randoCheckId = Rando::ActorBehavior::GetObjectRandoCheckId(actor);
-    RandoItemId randoItemId = Rando::ConvertItem(RANDO_SAVE_CHECKS[randoCheckId].randoItemId, randoCheckId);
-    RandoItemType randoItemType = Rando::StaticData::Items[randoItemId].randoItemType;
+    RandoItemType randoItemType = Rando::GetItemTypeForCheck(RANDO_SAVE_CHECKS[randoCheckId].randoItemId, randoCheckId);
 
     switch (randoItemType) {
         case RITYPE_BOSS_KEY:
@@ -192,8 +191,7 @@ void ObjKibako2_RandoDraw(Actor* actor, PlayState* play) {
     }
 
     RandoCheckId randoCheckId = Rando::ActorBehavior::GetObjectRandoCheckId(actor);
-    RandoItemId randoItemId = Rando::ConvertItem(RANDO_SAVE_CHECKS[randoCheckId].randoItemId, randoCheckId);
-    RandoItemType randoItemType = Rando::StaticData::Items[randoItemId].randoItemType;
+    RandoItemType randoItemType = Rando::GetItemTypeForCheck(RANDO_SAVE_CHECKS[randoCheckId].randoItemId, randoCheckId);
 
     switch (randoItemType) {
         case RITYPE_BOSS_KEY:

--- a/mm/2s2h/Rando/ActorBehavior/ObjTaru.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjTaru.cpp
@@ -66,8 +66,7 @@ void ObjTaru_RandoDraw(Actor* actor, PlayState* play) {
     }
 
     RandoCheckId randoCheckId = Rando::ActorBehavior::GetObjectRandoCheckId(actor);
-    RandoItemId randoItemId = Rando::ConvertItem(RANDO_SAVE_CHECKS[randoCheckId].randoItemId, randoCheckId);
-    RandoItemType randoItemType = Rando::StaticData::Items[randoItemId].randoItemType;
+    RandoItemType randoItemType = Rando::GetItemTypeForCheck(RANDO_SAVE_CHECKS[randoCheckId].randoItemId, randoCheckId);
 
     switch (randoItemType) {
         case RITYPE_BOSS_KEY:

--- a/mm/2s2h/Rando/ActorBehavior/ObjTsubo.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjTsubo.cpp
@@ -340,8 +340,7 @@ void ObjTsubo_RandoDraw(Actor* actor, PlayState* play) {
     }
 
     RandoCheckId randoCheckId = Rando::ActorBehavior::GetObjectRandoCheckId(actor);
-    RandoItemId randoItemId = Rando::ConvertItem(RANDO_SAVE_CHECKS[randoCheckId].randoItemId, randoCheckId);
-    RandoItemType randoItemType = Rando::StaticData::Items[randoItemId].randoItemType;
+    RandoItemType randoItemType = Rando::GetItemTypeForCheck(RANDO_SAVE_CHECKS[randoCheckId].randoItemId, randoCheckId);
 
     switch (randoItemType) {
         case RITYPE_BOSS_KEY:

--- a/mm/2s2h/Rando/ConvertItem.cpp
+++ b/mm/2s2h/Rando/ConvertItem.cpp
@@ -4,6 +4,9 @@
 #include "2s2h/ShipUtils.h"
 #include "2s2h/ShipInit.hpp"
 #include <cassert>
+#ifdef COMBO_BUILD
+#include "Rando/MiscBehavior/MiscBehavior.h" // ComboShip: MM_LookupForeign for foreign container art
+#endif
 
 // Copied from z_player.c, we could instead move this to a header file, idk
 typedef struct GetItemEntry {
@@ -799,4 +802,57 @@ RandoItemId Rando::ConvertItem(RandoItemId randoItemId, RandoCheckId randoCheckI
 
         return RI_JUNK;
     }
+}
+
+#ifdef COMBO_BUILD
+// ComboShip: foreign[].category -> MM container-art type. Unknown maps to RITYPE_MAJOR —
+// over-promising beats dressing a major item as junk.
+static RandoItemType ForeignTypeFromCategory(const std::string& category) {
+    if (category == "junk") {
+        return RITYPE_JUNK;
+    }
+    if (category == "lesser") {
+        return RITYPE_LESSER;
+    }
+    if (category == "health") {
+        return RITYPE_HEALTH;
+    }
+    if (category == "bossKey") {
+        return RITYPE_BOSS_KEY;
+    }
+    if (category == "smallKey") {
+        return RITYPE_SMALL_KEY;
+    }
+    if (category == "token") {
+        return RITYPE_SKULLTULA_TOKEN;
+    }
+    if (category == "mask") {
+        return RITYPE_MASK;
+    }
+    if (category == "strayFairy") {
+        return RITYPE_STRAY_FAIRY;
+    }
+    return RITYPE_MAJOR;
+}
+#endif
+
+RandoItemType Rando::GetItemTypeForCheck(RandoItemId randoItemId, RandoCheckId randoCheckId) {
+#ifdef COMBO_BUILD
+    // A foreign check's saved item is the hard-typed junk sentinel, so read the real item's category.
+    if (randoCheckId != RC_UNKNOWN && RANDO_SAVE_CHECKS[randoCheckId].randoItemId == RI_COMBO_FOREIGN) {
+        const ComboRando::ForeignItem* fi = Rando::MiscBehavior::MM_LookupForeign(randoCheckId);
+        if (fi != nullptr) {
+            // Foreign traps deliberately read MAJOR (junk/lesser containers get skipped, so the trap
+            // would never fire) even though native RI_TRAP is LESSER. Absent category -> importance.
+            if (fi->trap) {
+                return RITYPE_MAJOR;
+            }
+            if (fi->category.empty()) {
+                return fi->advancement ? RITYPE_MAJOR : RITYPE_JUNK;
+            }
+            return ForeignTypeFromCategory(fi->category);
+        }
+    }
+#endif
+    return Rando::StaticData::Items[Rando::ConvertItem(randoItemId, randoCheckId)].randoItemType;
 }

--- a/mm/2s2h/Rando/Rando.h
+++ b/mm/2s2h/Rando/Rando.h
@@ -24,6 +24,9 @@ RandoItemId CurrentJunkItem(RandoCheckId randoCheckId = RC_UNKNOWN);
 RandoItemId CurrentTrapItem(RandoCheckId randoCheckId = RC_UNKNOWN);
 bool IsItemObtainable(RandoItemId randoItemId, RandoCheckId randoCheckId = RC_UNKNOWN);
 RandoItemId ConvertItem(RandoItemId randoItemId, RandoCheckId randoCheckId = RC_UNKNOWN);
+// Container-matches-contents type for a check. Same as Items[ConvertItem(...)].randoItemType, except a
+// ComboShip foreign check resolves the real cross-game item's category behind the junk sentinel.
+RandoItemType GetItemTypeForCheck(RandoItemId randoItemId, RandoCheckId randoCheckId = RC_UNKNOWN);
 RandoCheckId FindItemPlacement(RandoItemId randoItemId);
 // Like GetLocationNameForHint(FindItemPlacement(id)); on ComboShip builds, falls back to the combo
 // foreign map when the item was cross-placed into OOT instead of an MM check.

--- a/soh/soh/Enhancements/randomizer/SeedContext.cpp
+++ b/soh/soh/Enhancements/randomizer/SeedContext.cpp
@@ -26,6 +26,7 @@ extern "C" {
 }
 
 #ifdef COMBO_BUILD
+#include "soh/Enhancements/randomizer/hook_handlers.h" // ComboShip: OOT_GetForeignCategory
 extern "C" PlayState* gPlayState;
 // ComboShip tripwire: a status wipe on the live context mid-game is the suspected cause of the
 // check tracker suddenly zeroing; log the path so a recurrence identifies its caller.
@@ -409,6 +410,11 @@ GetItemEntry Context::GetFinalGIEntry(const RandomizerCheck rc, const bool check
     }
 #ifdef COMBO_BUILD
     giEntry.comboForeignCheck = rc; // ComboShip: see ItemTableTypes.h
+    // ComboShip: the sentinel is hard-typed junk; re-type it from the foreign item's own category so
+    // Container Matches Contents doesn't advertise every foreign check as junk.
+    if (itemLoc->GetPlacedRandomizerGet() == RG_COMBO_FOREIGN) {
+        giEntry.getItemCategory = OOT_GetForeignCategory(rc);
+    }
 #endif
     return giEntry;
 }

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -432,6 +432,67 @@ const ComboRando::ForeignItem* OOT_LookupForeign(int slot, const std::string& ch
     return it == g_ootForeignMap.end() ? nullptr : &it->second;
 }
 
+// ComboShip: foreign[].category -> OOT container-art category. Unknown and MM-only (mask,
+// strayFairy) map to MAJOR — over-promising beats dressing a major item as junk.
+static GetItemCategory ForeignCategoryFromName(const std::string& name) {
+    if (name == "junk") {
+        return ITEM_CATEGORY_JUNK;
+    }
+    if (name == "lesser") {
+        return ITEM_CATEGORY_LESSER;
+    }
+    if (name == "health") {
+        return ITEM_CATEGORY_HEALTH;
+    }
+    if (name == "bossKey") {
+        return ITEM_CATEGORY_BOSS_KEY;
+    }
+    if (name == "smallKey") {
+        return ITEM_CATEGORY_SMALL_KEY;
+    }
+    if (name == "token") {
+        return ITEM_CATEGORY_SKULLTULA_TOKEN;
+    }
+    return ITEM_CATEGORY_MAJOR;
+}
+
+// ComboShip: category the foreign item would have at home, so Container Matches Contents dresses the
+// chest/pot/crate as the real item instead of the hard-typed junk sentinel. Cached per check.
+GetItemCategory OOT_GetForeignCategory(RandomizerCheck rc) {
+    static std::unordered_map<RandomizerCheck, GetItemCategory> cache;
+    static uint64_t cachedGen = (uint64_t)-1;
+    if (cachedGen != g_ootForeignGen) {
+        cache.clear();
+        cachedGen = g_ootForeignGen;
+    }
+    auto cached = cache.find(rc);
+    if (cached != cache.end())
+        return cached->second;
+
+    const ComboRando::ForeignItem* fi =
+        OOT_LookupForeign(gSaveContext.fileNum, Rando::StaticData::GetLocation(rc)->GetName());
+    // The lookup may have built the map (bumping the generation); adopt it so this entry survives.
+    if (cachedGen != g_ootForeignGen) {
+        cache.clear();
+        cachedGen = g_ootForeignGen;
+    }
+
+    // Traps are MAJOR for native parity (OOT ice traps are, disguised or not). An absent category
+    // (pre-category seed or plando import) falls back to importance.
+    GetItemCategory category = ITEM_CATEGORY_JUNK; // no entry -> the sentinel's own junk typing
+    if (fi != nullptr) {
+        if (fi->trap) {
+            category = ITEM_CATEGORY_MAJOR;
+        } else if (fi->category.empty()) {
+            category = fi->advancement ? ITEM_CATEGORY_MAJOR : ITEM_CATEGORY_JUNK;
+        } else {
+            category = ForeignCategoryFromName(fi->category);
+        }
+    }
+    cache.emplace(rc, category);
+    return category;
+}
+
 // ComboShip: expose the currently-queued check so Randomizer_DrawComboForeign (draw.cpp) can
 // identify the check behind a get-item draw. Foreign checks are diverted to the mailbox BEFORE
 // queueing, so this is a defensive fallback; player-visible foreign draws (shop shelves) identify

--- a/soh/soh/Enhancements/randomizer/hook_handlers.h
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.h
@@ -7,8 +7,12 @@
 #include <cstdint>
 #include "rando/CrossForeign.h"
 #include "soh/Enhancements/randomizer/randomizerTypes.h"
+#include "soh/Enhancements/item-tables/ItemTableTypes.h"
 // ComboShip: per-slot foreign-item lookup (defined in hook_handlers.cpp).
 const ComboRando::ForeignItem* OOT_LookupForeign(int slot, const std::string& checkName);
+// ComboShip: the foreign item's home-game container category, so Container Matches Contents doesn't
+// render every foreign check as the junk sentinel. Defined in hook_handlers.cpp.
+GetItemCategory OOT_GetForeignCategory(RandomizerCheck rc);
 // ComboShip: generation of the foreign map; bumped on every rebuild so draw caches can invalidate.
 uint64_t OOT_ForeignMapGen();
 // ComboShip: currently-queued get-item check (RC_UNKNOWN_CHECK if none) — fallback identity for

--- a/soh/soh/Enhancements/randomizer/item_category_adj.cpp
+++ b/soh/soh/Enhancements/randomizer/item_category_adj.cpp
@@ -7,6 +7,12 @@
 GetItemCategory Randomizer_AdjustItemCategory(GetItemEntry item) {
     GetItemCategory category = item.getItemCategory;
 
+    // ComboShip: a foreign check's category already describes the OTHER game's item, so none of the
+    // local-inventory downgrades below apply (they'd junk a foreign small key on our skeleton key).
+    if (item.modIndex == MOD_RANDOMIZER && item.getItemId == RG_COMBO_FOREIGN) {
+        return category;
+    }
+
     // Downgrade bombchus to lesser if the player already has bombchus
     if (INV_CONTENT(ITEM_BOMBCHU) == ITEM_BOMBCHU &&
         ((item.modIndex == MOD_RANDOMIZER && item.getItemId == RG_PROGRESSIVE_BOMBCHU_BAG) ||


### PR DESCRIPTION
Fixes #103.

Container Matches Contents rendered every cross-game check as junk: foreign checks hold a junk-typed sentinel (`RG_COMBO_FOREIGN` / `RI_COMBO_FOREIGN`) and CMC classified by it.

- `foreign[]` entries now carry `category` (the per-item category both dumps already emit; `CwCat::UNKNOWN` omitted).
- OOT: `GetFinalGIEntry` overrides the sentinel entry's category via `OOT_GetForeignCategory` (gen-counter cached); `Randomizer_AdjustItemCategory` skips the sentinel so Skeleton Key can't junk a foreign MM small key. MM-only `mask`/`strayFairy` render major.
- MM: `Rando::GetItemTypeForCheck` resolves the sentinel at the 8 CMC draw sites (chests, grass, pots, barrels, crates).
- Traps always read MAJOR (OOT-native parity; a junk-looking container never gets opened).
- Old seeds/plando: no category -> advancement ? major : junk. No regen forced, no version bump (schema tolerant both ways).
- foreign[] slimming: `checkArea` no longer persisted (only reader was hint gen, now fed in-memory from the same dump); `advancement`/`trap` emitted only when true.

Verified: soh/2ship/ComboShip/comborando Debug builds clean; headless seed CMC103 — 222/222 foreign entries categorized, no checkArea, no false flags, hint areas resolve, byte-identical regeneration. Unplaytested.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9064587343.zip)
<!--- section:artifacts:end -->