### PR TITLE
fix(tracker): dormant trackers respect "only show when paused" (#127)

### DIFF
--- a/combo/gui/ComboTrackerSwap.cpp
+++ b/combo/gui/ComboTrackerSwap.cpp
@@ -1,6 +1,7 @@
 // combo/gui/ComboTrackerSwap.cpp — see ComboTrackerSwap.h for rationale.
 #include "ComboTrackerSwap.h"
 #include "ComboTrackerCommon.h"
+#include "ComboTrackerBridge.h" // canonical window-type defaults
 #include "ComboForeground.h"
 #include <libultraship/libultraship.h>
 #include <ship/resource/CrossRMRegistry.h>
@@ -70,6 +71,49 @@ void EnsureMmSaveLoadedForDormantDraw() {
 #endif
 }
 
+// Each game's own "only show while paused" setting, per tracker kind. OOT's is a no-op unless the
+// window type is floating (0) — upstream nests it that way; MM's is VisibilityMode 1.
+struct PausedOnly {
+    const char* ootCvar;
+    const char* ootWindowTypeCvar; // canonical combo CVar (the bridge mirrors it into OOT's)
+    int ootWindowTypeDefault;
+    const char* mmCvar;
+};
+constexpr PausedOnly kPausedOnly[ComboTracker::kSwapCount] = {
+    { "gTrackers.ItemTracker.ShowOnlyPaused", "gCombo.Tracker.WindowType", ComboTracker::kDefaultWindowType,
+      "gSettings.ItemTracker.VisibilityMode" },
+    { "gTrackers.CheckTracker.ShowOnlyPaused", "gCombo.CheckTracker.WindowType", ComboTracker::kDefaultCheckWindowType,
+      "gRando.CheckTracker.VisibilityMode" },
+};
+
+// True when the dormant game's tracker of this kind is set to only show while its game is paused.
+bool DormantPausedOnly(int kindIdx, int bg) {
+    const PausedOnly& p = kPausedOnly[kindIdx];
+    if (bg == 0) {
+        return CVarGetInteger(p.ootCvar, 0) != 0 && CVarGetInteger(p.ootWindowTypeCvar, p.ootWindowTypeDefault) == 0;
+    }
+    return CVarGetInteger(p.mmCvar, 0) == 1; // MM's button modes (2/3) stay always-show while dormant
+}
+
+// The foreground game's pause state, from its DLL (the dormant game's own is stale). Fails open
+// (paused) so a missing module/export degrades to the previous always-show behavior.
+bool ForegroundPaused(int fg) {
+#ifdef _WIN32
+    static int (*sFn[2])(void) = {};
+    static bool sTried[2] = {};
+    if (!sTried[fg]) {
+        sTried[fg] = true;
+        if (HMODULE h = GetModuleHandleA(fg == 0 ? "soh.dll" : "2ship.dll")) {
+            sFn[fg] = (int (*)(void))GetProcAddress(h, fg == 0 ? "SOH_IsPausedForCombo" : "MM_IsPausedForCombo");
+        }
+    }
+    if (sFn[fg]) {
+        return sFn[fg]() != 0;
+    }
+#endif
+    return true;
+}
+
 // Write the derived visibility only on change (SetTracker writes the CVar and Show/Hides the
 // GuiWindow; doing that unconditionally every frame would fight the games' own Draw gating).
 void ApplyDerived(const ComboTracker::Win& w, bool visible) {
@@ -130,7 +174,10 @@ void Reconcile(int kindIdx) {
     const bool hideBg = CVarGetInteger(kind.hideBgCvar, 0) != 0;
 
     bool wantFg = master;
-    bool wantBg = master && (!hideBg || sPeeks[kindIdx].held);
+    // A dormant tracker set to "only while paused" follows the FOREGROUND game's pause state (its
+    // own is stale); peek-hold still overrides.
+    const bool onlyPaused = DormantPausedOnly(kindIdx, bg);
+    bool wantBg = master && ((!hideBg && (!onlyPaused || ForegroundPaused(fg))) || sPeeks[kindIdx].held);
     // A dormant game's tracker needs its ResourceManager registered (icons) and, for dormant MM,
     // an active OOT save whose MM counterpart it can show — not the title/file-select screens.
     if (wantBg && !Ship::CrossRMRegistry::Get(bg == 0 ? "oot" : "mm")) {

--- a/docs/deviations/tracker.md
+++ b/docs/deviations/tracker.md
@@ -142,6 +142,11 @@ on boot.
   settings content are hidden in combo builds (`gWindows.ItemTracker`/`.CheckTracker` are derived
   from the combo master toggle every frame; the buttons would fight it).
 
+**Dormant "only while paused" (#127, 2026-08-12):** the in-tracker dormant bypasses stay (stale
+pause state); instead `Reconcile` hides a dormant tracker whose game is set to only-while-paused
+unless the FOREGROUND game is paused, via new `SOH_IsPausedForCombo` / `MM_IsPausedForCombo`
+exports (fail open = paused). Peek-hold still overrides.
+
 **On future merges:** if upstream renames the tracker ImGui windows or the settings windows,
 update `combo/gui/ComboTrackerCommon.h` (`kKinds[].imguiWin`) and the inline-widget window names.
 

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -4162,6 +4162,12 @@ bool Combo_MmIsForeground(void) {
     return sFn ? (sFn() == 1) : true;
 }
 
+// ComboShip (#127): MM's pause state, read by comboui's dormant-tracker gate (see
+// SOH_IsPausedForCombo) — the dormant game's own pause state is stale.
+extern "C" __declspec(dllexport) int MM_IsPausedForCombo(void) {
+    return gPlayState != nullptr && gPlayState->pauseCtx.state > 0;
+}
+
 extern "C" __declspec(dllexport) int32_t MM_MenuEvalDisabled(int32_t i, const char** outReason) {
     ComboMenuContext::UseSharedImGuiContext();
     Ship::ResourceManagerScope rmScope(Ship::CrossRMRegistry::Get("mm"));

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -3243,6 +3243,12 @@ bool Combo_OotIsForeground(void) {
     return sFn ? (sFn() == 0) : true;
 }
 
+// ComboShip (#127): OOT's pause state, read by comboui's dormant-tracker gate (a dormant game's own
+// pause state is stale, so the foreground game's is queried across the DLL boundary).
+extern "C" __declspec(dllexport) int SOH_IsPausedForCombo(void) {
+    return gPlayState != nullptr && gPlayState->pauseCtx.state > 0;
+}
+
 // ComboShip: Ctrl+R reset. Set when a reset should return the whole session to first-boot; read by
 // SOH_ResumeGame so OOT boots to the title sequence instead of resuming the dormant save.
 static bool sComboResetPending = false;


### PR DESCRIPTION
Fixes #127.

The dormant game's Item/Check tracker previously drew unconditionally: its own `gPlayState` is null while dormant, so the in-tracker pause gates are bypassed. Those bypasses stay; instead comboui's per-frame `Reconcile` now hides a dormant tracker whose game has the paused-only setting enabled unless the **foreground** game is paused.

- Foreground pause state comes from new `SOH_IsPausedForCombo` / `MM_IsPausedForCombo` exports, resolved via `GetProcAddress` and failing open (missing export = previous always-show behavior).
- Per-game settings govern each game's own tracker: OOT `ShowOnlyPaused` (still a no-op for windowed type, matching upstream), MM `VisibilityMode == Only on Pause Menu` (button modes unchanged).
- Peek-hold and "Only show the active game's tracker" behave as before; a hidden paused-only dormant MM tracker no longer forces a save load.

Built comboui/soh/2ship Debug clean; exports verified via dumpbin. Not playtested yet.

Playtest checklist:
- [ ] OOT foreground, MM trackers on "Only on Pause Menu": hidden in gameplay, appear on pause, gone on unpause; peek-hold shows regardless
- [ ] MM foreground, OOT floating trackers with "Only Enable While Paused": symmetric
- [ ] OOT windowed type + ShowOnlyPaused: dormant tracker still always shows (upstream no-op)
- [ ] Option off / HideBackground on: identical to today

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9155824958.zip)
<!--- section:artifacts:end -->