### PR TITLE
fix(rando): ice traps never disguise as the Triforce (#131)

### DIFF
--- a/combo/ComboRandoHeadless.cpp
+++ b/combo/ComboRandoHeadless.cpp
@@ -486,6 +486,10 @@ int main(int argc, char** argv) {
                     auto pricesOf = [](const std::string& dump) {
                         return nlohmann::json::parse(dump).value("prices", nlohmann::json::object());
                     };
+                    // OOT's curated ice-trap disguise set (parity with RunComboFill's writer).
+                    auto iceTrapModelsOf = [](const std::string& dump) {
+                        return nlohmann::json::parse(dump).value("iceTrapModels", nlohmann::json::array());
+                    };
                     nlohmann::json consolidated;
                     consolidated["fileType"] = "ComboShipRandomizer";
                     consolidated["seed"] = seed;
@@ -501,7 +505,8 @@ int main(int argc, char** argv) {
                                                                    ? nlohmann::json::parse(SOH_DumpEnabledTricks())
                                                                    : nlohmann::json::array() },
                                             { "placements", ootPl },
-                                            { "prices", pricesOf(sohDump) } };
+                                            { "prices", pricesOf(sohDump) },
+                                            { "iceTrapModels", iceTrapModelsOf(sohDump) } };
                     consolidated["mm"] = { { "settings", nlohmann::json::parse(MM_DumpSettings()) },
                                            { "placements", mmPl },
                                            { "prices", pricesOf(mmDump) } };

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -1307,6 +1307,13 @@ static void RunComboFill(std::string inputSeed, ComboRando::ComboGenProgress* pr
         std::unordered_map<std::string, bool> ootAdv, mmAdv;
         auto ootNames = buildNameMap(sohDump, ootAdv);
         auto mmNames = buildNameMap(mmDump, mmAdv);
+
+        // ComboShip: OOT's curated ice-trap disguise set — carried into the apply payload (below) and
+        // the consolidated spoiler so a reload restores it instead of deriving one from placements.
+        nlohmann::json ootIceTrapModels = nlohmann::json::array();
+        try {
+            ootIceTrapModels = nlohmann::json::parse(sohDump).value("iceTrapModels", nlohmann::json::array());
+        } catch (...) {}
         for (auto& fm : foreignArr) {
             std::string itemGame = fm.value("itemGame", "");
             std::string itemName = fm.value("itemName", "");
@@ -1350,6 +1357,8 @@ static void RunComboFill(std::string inputSeed, ComboRando::ComboGenProgress* pr
                 mmSpoiler[cn] = dn;
             }
         }
+        // Reserved apply-only key (ootSpoiler was copied above, so it stays a pure placement map).
+        ootApply["__iceTrapModels"] = ootIceTrapModels;
 
         // ComboShip: the gSaveContext-mutating apply (SOH_ApplyRandoPlacements) and the seed-hash set
         // MUST run on the main thread — the worker only computes. Stash their inputs for
@@ -1402,7 +1411,8 @@ static void RunComboFill(std::string inputSeed, ComboRando::ComboGenProgress* pr
         consolidated["oot"] = { { "settings", parseOrEmpty(SOH_DumpRandoSettings) },
                                 { "enabledTricks", parseOrEmpty(SOH_DumpEnabledTricks) },
                                 { "placements", ootSpoiler },
-                                { "prices", pricesOf(sohDump) } };
+                                { "prices", pricesOf(sohDump) },
+                                { "iceTrapModels", ootIceTrapModels } };
         consolidated["mm"] = { { "settings", parseOrEmpty(MM_DumpRandoSettings) },
                                { "placements", mmSpoiler },
                                { "prices", pricesOf(mmDump) } };

--- a/combo/rando/CrossForeign.h
+++ b/combo/rando/CrossForeign.h
@@ -56,6 +56,14 @@ inline nlohmann::json ApplyPayloadFromConsolidated(const nlohmann::json& consoli
             apply[checkName] = sentinel;
         }
     }
+    // OOT's curated ice-trap disguise set rides along as a reserved key (absent on old spoilers, where
+    // the apply falls back to deriving one).
+    if (game == GAME_OOT) {
+        const nlohmann::json oot = consolidated.value("oot", nlohmann::json::object());
+        if (oot.contains("iceTrapModels")) {
+            apply["__iceTrapModels"] = oot["iceTrapModels"];
+        }
+    }
     return apply;
 }
 
@@ -160,6 +168,24 @@ inline std::unordered_map<std::string, ForeignItemMeta> ParseItemMeta(const std:
     return m;
 }
 
+// OOT's curated ice-trap disguise names from its dump ("iceTrapModels"). `present` = a usable (non-empty)
+// list; a stale dump (no field) or a failed prep (empty field) both fall back to the caller's own filter.
+inline std::set<std::string> ParseIceTrapModels(const std::string& dump, bool& present) {
+    std::set<std::string> out;
+    try {
+        auto d = nlohmann::json::parse(dump);
+        auto it = d.find("iceTrapModels");
+        if (it != d.end() && it->is_array()) {
+            for (const auto& n : *it) {
+                if (n.is_string())
+                    out.insert(n.get<std::string>());
+            }
+        }
+    } catch (...) {}
+    present = !out.empty();
+    return out;
+}
+
 // Give every foreign TRAP a disguise: a plausible progression item OF THE TRAP'S OWN GAME that this
 // seed actually placed (mirrors OOT's possibleIceTrapModels), plus a typo'd name for shop/hint text.
 // Deterministic: a dedicated LCG stream off masterSeed, sorted candidate sets, array order.
@@ -170,6 +196,11 @@ inline void AssignTrapDisguises(nlohmann::json& foreignArr, const nlohmann::json
     const auto ootMeta = ParseItemMeta(sohDump), mmMeta = ParseItemMeta(mmDump);
     if (ootMeta.empty() && mmMeta.empty())
         return;
+    // OOT candidates follow SoH's curated disguise list (issue #131: never a Triforce piece). The list
+    // holds representative names (Empty Bottle, ...) that no concrete placement matches, so those drop
+    // out of foreign candidacy too — a strict subset of native semantics, intended.
+    bool curatedPresent = false;
+    const std::set<std::string> curated = ParseIceTrapModels(sohDump, curatedPresent);
     std::set<std::string> ootCand, mmCand;
     auto scan = [&](const nlohmann::json& pl) {
         if (!pl.is_object())
@@ -178,8 +209,9 @@ inline void AssignTrapDisguises(nlohmann::json& foreignArr, const nlohmann::json
             if (!it.value().is_string())
                 continue;
             const std::string n = it.value().get<std::string>();
+            const bool ootOk = curatedPresent ? curated.count(n) != 0 : (n != "Triforce" && n != "Triforce Piece");
             auto o = ootMeta.find(n);
-            if (o != ootMeta.end() && o->second.advancement && !o->second.trap)
+            if (ootOk && o != ootMeta.end() && o->second.advancement && !o->second.trap)
                 ootCand.insert(n);
             auto m = mmMeta.find(n);
             if (m != mmMeta.end() && m->second.advancement && !m->second.trap)

--- a/soh/soh/Enhancements/randomizer/Traps.h
+++ b/soh/soh/Enhancements/randomizer/Traps.h
@@ -11,8 +11,8 @@ namespace Rando {
 namespace Traps {
 Text GetTrapName(uint16_t id, uint64_t* state = nullptr);
 RandomizerGet GetTrapTrickModel(uint64_t* state = nullptr);
-// ComboShip: true if an item id has a fake ice-trap name (i.e. is a valid disguise). Combo builds
-// possibleIceTrapModels from placed items, so it must exclude unnamed junk that GetTrapName can't name.
+// ComboShip: true if an item id has a fake ice-trap name (i.e. is a valid disguise) — guards the dump
+// export, curated-set restore, and old-seed placed-item fallback, since GetTrapName asserts on unnamed items.
 bool CanBeTrapModel(uint16_t id);
 bool ShouldJunkItemBeTrap();
 void BuildIceTrapMessage(CustomMessage& msg, GetItemEntry getItemEntry);

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -3862,6 +3862,9 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoStaticData(void) {
     nlohmann::json fixed = nlohmann::json::array();
     nlohmann::json items = nlohmann::json::array();
     nlohmann::json prices = nlohmann::json::object();
+    // ComboShip: SoH's curated ice-trap disguise set (native possibleIceTrapModels) — combo skips
+    // GenerateItemPool's fill, so the apply restores this instead of re-deriving from placed items.
+    nlohmann::json iceTrapModels = nlohmann::json::array();
     // ComboShip: OOT accessibility settings the combo fill honors per-game. Defaults = ALL_REACHABLE
     // (safe: unchanged fill behavior) if the prep throws before these are read.
     nlohmann::json accessibility = { { "noLogic", false },
@@ -3992,6 +3995,15 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoStaticData(void) {
                 prices[loc->GetName()] = ctx->GetItemLocation(rc)->GetPrice();
         }
 
+        // ComboShip: ComboFillConfined ran GenerateItemPool, so possibleIceTrapModels now holds the
+        // native curated disguise set — export it (minus entries GetTrapName can't name, e.g. Chest
+        // Game keys, which would assert) so the apply gets native parity.
+        for (RandomizerGet rg : ctx->possibleIceTrapModels) {
+            const std::string& mn = Rando::StaticData::RetrieveItem(rg).GetName().GetEnglish();
+            if (!mn.empty() && Rando::Traps::CanBeTrapModel(rg))
+                iceTrapModels.push_back(mn);
+        }
+
         // ComboShip: accessibility settings the combo fill maps to an OotAccess mode (per-game relax).
         accessibility["noLogic"] = ctx->GetOption(RSK_LOGIC_RULES).Is(RO_LOGIC_NO_LOGIC);
         accessibility["allLocationsReachable"] = static_cast<bool>(ctx->GetOption(RSK_ALL_LOCATIONS_REACHABLE));
@@ -4071,8 +4083,13 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoStaticData(void) {
     }
 
     cached = nlohmann::json{
-        { "checks", std::move(checks) }, { "pool", std::move(pool) },     { "fixed", std::move(fixed) },
-        { "items", std::move(items) },   { "prices", std::move(prices) }, { "accessibility", std::move(accessibility) }
+        { "checks", std::move(checks) },
+        { "pool", std::move(pool) },
+        { "fixed", std::move(fixed) },
+        { "items", std::move(items) },
+        { "prices", std::move(prices) },
+        { "iceTrapModels", std::move(iceTrapModels) },
+        { "accessibility", std::move(accessibility) }
     }.dump();
     return cached.c_str();
 }
@@ -4486,8 +4503,8 @@ extern "C" __declspec(dllexport) void SOH_ApplyRandoPlacements(const char* json)
         ctx->ItemReset();
 #ifdef COMBO_BUILD
         // Combo skips GenerateItemPool (OOT's own fill), which is what normally fills the ice-trap
-        // disguise pool. Rebuild it from the items we actually place below, else every ice trap falls
-        // back to a bottle (empty-set draw).
+        // disguise pool. The payload carries the dump's curated set ("__iceTrapModels"); old seeds
+        // without it fall back to deriving one from the items we place below.
         ctx->possibleIceTrapModels.clear();
         // Combo also skips native Fill()'s HintReset() call — without it, a same-session regenerate
         // would see the PREVIOUS seed's hints still marked enabled and skip re-populating them.
@@ -4517,6 +4534,28 @@ extern "C" __declspec(dllexport) void SOH_ApplyRandoPlacements(const char* json)
 #endif
 
         nlohmann::json placements = nlohmann::json::parse(json);
+#ifdef COMBO_BUILD
+        // ComboShip: reserved key carrying the dump's curated ice-trap disguise set (native parity —
+        // e.g. Triforce pieces are never a disguise). Erased so the placement loop never sees it.
+        if (auto modelsIt = placements.find("__iceTrapModels"); modelsIt != placements.end()) {
+            if (modelsIt->is_array()) {
+                for (const auto& mv : *modelsIt) {
+                    if (!mv.is_string())
+                        continue;
+                    const std::string mn = mv.get<std::string>();
+                    auto mIt = Rando::StaticData::itemNameToEnum.find(mn);
+                    if (mIt == Rando::StaticData::itemNameToEnum.end() || !Rando::Traps::CanBeTrapModel(mIt->second)) {
+                        SPDLOG_WARN("[ComboShip] SOH_ApplyRandoPlacements: invalid ice-trap model '{}'", mn);
+                        continue;
+                    }
+                    ctx->possibleIceTrapModels.insert(mIt->second);
+                }
+            }
+            placements.erase("__iceTrapModels");
+        }
+        // Empty result (empty/garbled list, e.g. a failed dump prep) falls back to deriving a pool below.
+        const bool haveCuratedModels = !ctx->possibleIceTrapModels.empty();
+#endif
         int placed = 0, skipped = 0;
         // ComboShip: cross-game name collisions are suffixed "(OOT)" in the consolidated spoiler; strip
         // our own suffix before resolving native OOT location/item names.
@@ -4552,7 +4591,10 @@ extern "C" __declspec(dllexport) void SOH_ApplyRandoPlacements(const char* json)
             ctx->PlaceItemInLocation(rc, rg, false, false);
             ++placed;
 #ifdef COMBO_BUILD
-            if (rg != RG_ICE_TRAP && rg != RG_COMBO_FOREIGN && rg != RG_NONE && Rando::Traps::CanBeTrapModel(rg)) {
+            // Old seeds only (no curated set in the payload): derive a disguise pool from placed items.
+            // Triforce is excluded here — native never disguises a trap as one (issue #131).
+            if (!haveCuratedModels && rg != RG_ICE_TRAP && rg != RG_COMBO_FOREIGN && rg != RG_NONE &&
+                rg != RG_TRIFORCE && rg != RG_TRIFORCE_PIECE && Rando::Traps::CanBeTrapModel(rg)) {
                 ctx->possibleIceTrapModels.insert(rg); // candidate ice-trap disguise (only named items)
             }
 #endif


### PR DESCRIPTION
Fixes #131.

Combo seeds skip OOT's native fill and rebuilt the ice-trap disguise pool from placed items with only a has-trick-name filter, dropping native curation. Every defeat-Ganon seed places Triforce at Ganon, so traps could show as a Triforce piece with Triforce Hunt off (and both Triforce RGs draw the shard model).

- Export the native curated `possibleIceTrapModels` set (built by the confined fill's `GenerateItemPool`) as `iceTrapModels` in the OOT dump, filtered through `CanBeTrapModel` so unnamed entries (Chest Game keys) can't reach `GetTrapName`'s assert.
- Carry it into the apply payload (reserved `__iceTrapModels` key, erased before the placement loop) and the consolidated spoiler; restore it in `SOH_ApplyRandoPlacements` instead of re-deriving. Old seeds fall back to derivation, now minus `RG_TRIFORCE`/`RG_TRIFORCE_PIECE`.
- Foreign-trap disguises (`AssignTrapDisguises`) intersect OOT candidates with the curated list (same fallback for stale dumps). Empty/absent lists are treated as "no curation" everywhere, so a failed dump prep can't silence disguises.

Matches native SoH semantics: Triforce pieces are never a disguise, even with Triforce Hunt on; `Triforce` itself remains eligible only under wincon Anywhere (native behavior).

Verified headless (Debug): `iceTrapModels` present with no Triforce entries while `Ganon: Triforce` is placed; all foreign OOT trap disguises within the curated set; same seed twice is byte-identical; `--playthrough` PASS. Not playtested in-game.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9184836166.zip)
<!--- section:artifacts:end -->