### PR TITLE
fix(rando): Ganon-first warp sends Adult to Temple of Time

### DIFF
--- a/docs/deviations/rando.md
+++ b/docs/deviations/rando.md
@@ -578,14 +578,17 @@ quit/resume and MM's Song-of-Time cycles. Registered into both DLLs via the new 
 
 **Vendored boss seams (`COMBO_BUILD`-guarded — preserve on merges, ~13 lines each):**
 - `soh/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c` — death cutscene `case 20`: if not both
-  dead, warp to `ENTR_MARKET_DAY_OUTSIDE_HAPPY_MASK_SHOP` (child, no cutscene) instead of the Chamber
-  of the Sages credits. Reuses the existing MM→OOT portal arrival point (see title_setup.c).
+  dead, warp to `ENTR_TEMPLE_OF_TIME_WARP_PAD` (adult, no cutscene) instead of the Chamber of the
+  Sages credits. The pedestal is the guaranteed route to Child (the Master Sword is in hand after
+  Ganon) and from there to the Mask Shop portal.
 - `mm/src/overlays/actors/ovl_Boss_07/z_boss_07.c` — Majora's Wrath death: if not both dead, warp to
   `ENTRANCE(SOUTH_CLOCK_TOWN, 0)` (no cutscene) instead of the Termina Field `0xFFF7` credits.
 
-**Deviation from plan:** the OOT first-kill warp targets the Happy Mask Shop area (not Temple of Time)
-because the OOT→MM portal is the Happy Mask Shop, only reachable as child in the Market — adult Link at
-Temple of Time couldn't reach it.
+**Revised (2026-08-13, issue #137):** the first-kill warp originally targeted
+`ENTR_MARKET_DAY_OUTSIDE_HAPPY_MASK_SHOP` with `linkAgeOnLoad = 0` — but 0 is `LINK_AGE_ADULT`, so
+Link stayed adult and the adult scene layer (+2) landed him in Market Ruins with the Mask Shop
+boarded up. Now warps to the Temple of Time adult spawn instead of forcing child: the player must
+travel to Child via the pedestal anyway to reach the portal.
 
 **Playtest-pending:** both orders (Ganon-first and Majora-first); portal reachable after each warp;
 resume-after-first-kill keeps the flag; finale plays on the second kill.

--- a/soh/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
+++ b/soh/src/overlays/actors/ovl_Boss_Ganon2/z_boss_ganon2.c
@@ -1882,13 +1882,14 @@ void func_8090120C(BossGanon2* this, PlayState* play) {
         case 20:
 #ifdef COMBO_BUILD
             // ComboShip: gate the ending on both bosses. If Majora isn't dead yet, skip OOT's credits
-            // and warp Link (as child) to the Happy Mask Shop portal to go finish MM.
+            // and warp Adult to the Temple of Time adult spawn — the pedestal is the route to Child
+            // and the Mask Shop portal to go finish MM.
             if (gComboFinalBossDefeated == NULL || !gComboFinalBossDefeated(0, gSaveContext.fileNum)) {
-                play->nextEntranceIndex = ENTR_MARKET_DAY_OUTSIDE_HAPPY_MASK_SHOP;
+                play->nextEntranceIndex = ENTR_TEMPLE_OF_TIME_WARP_PAD;
                 gSaveContext.nextCutsceneIndex = 0xFFEF;
                 play->transitionTrigger = TRANS_TRIGGER_START;
                 play->transitionType = TRANS_TYPE_FADE_WHITE;
-                play->linkAgeOnLoad = 0;
+                play->linkAgeOnLoad = LINK_AGE_ADULT;
                 break;
             }
 #endif


### PR DESCRIPTION
Fixes #137.

Beating Ganon before Majora intended to warp child Link to the Market outside the Happy Mask Shop, but set `linkAgeOnLoad = 0`, which is `LINK_AGE_ADULT` — Link stayed adult and the adult scene layer (+2) resolved the Market Day entrance to Market Ruins, stranding Adult Link at the boarded-up Mask Shop.

Now the warp targets `ENTR_TEMPLE_OF_TIME_WARP_PAD` (the adult savewarp/rando adult spawn) and keeps Link adult: the pedestal is the guaranteed route to Child (Master Sword is in hand after Ganon) and from there to the Mask Shop portal to finish MM. All four layer rows of that entrance point at ToT spawn 7, so the layer offset can't misroute again.

Majora-first (South Clock Town) is unaffected; the finale still plays in whichever game finishes second.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9198186083.zip)
<!--- section:artifacts:end -->