### PR TITLE
fix(anchor): MM team-state merge no longer wipes randoInf flags or trade slots

### DIFF
--- a/mm/2s2h/Network/Anchor/MMAnchor.cpp
+++ b/mm/2s2h/Network/Anchor/MMAnchor.cpp
@@ -825,6 +825,13 @@ void MMAnchor::HandlePacket_UpdateTeamState(nlohmann::json& payload) {
     // Bug 5: saveInfo replace clobbers permanentSceneFlags[120] — snapshot to OR back after the assign.
     PermanentSceneFlags localPermSceneFlags[120];
     memcpy(localPermSceneFlags, gSaveContext.save.saveInfo.permanentSceneFlags, sizeof(localPermSceneFlags));
+    // Issue #130: randoInf (obtained trade items/souls/purchases) is monotonic — snapshot to OR back.
+    u16 localRandoInf[ARRAY_COUNT(gSaveContext.save.shipSaveInfo.rando.randoInf)];
+    memcpy(localRandoInf, gSaveContext.save.shipSaveInfo.rando.randoInf, sizeof(localRandoInf));
+    // Issue #130: trade slots hold the locally-selected deed/key/letter — a stale snapshot must not empty them.
+    u8 localTradeItems[3] = { gSaveContext.save.saveInfo.inventory.items[SLOT_TRADE_DEED],
+                              gSaveContext.save.saveInfo.inventory.items[SLOT_TRADE_KEY_MAMA],
+                              gSaveContext.save.saveInfo.inventory.items[SLOT_TRADE_COUPLE] };
 
     // Restore bottle contents (unless Deku Princess).
     for (int i = 0; i < 6; i++) {
@@ -874,9 +881,18 @@ void MMAnchor::HandlePacket_UpdateTeamState(nlohmann::json& payload) {
     for (int i = 0; i < 100; i++) {
         gSaveContext.save.saveInfo.weekEventReg[i] |= localWeekEventReg[i];
     }
+    for (int i = 0; i < ARRAY_COUNT(gSaveContext.save.shipSaveInfo.rando.randoInf); i++) {
+        gSaveContext.save.shipSaveInfo.rando.randoInf[i] |= localRandoInf[i];
+    }
     for (int i = 0; i < 24; i++) {
         if (localMasks[i] != ITEM_NONE) {
             gSaveContext.save.saveInfo.inventory.items[24 + i] = localMasks[i];
+        }
+    }
+    const u8 tradeSlots[3] = { SLOT_TRADE_DEED, SLOT_TRADE_KEY_MAMA, SLOT_TRADE_COUPLE };
+    for (int i = 0; i < 3; i++) {
+        if (localTradeItems[i] != ITEM_NONE) {
+            gSaveContext.save.saveInfo.inventory.items[tradeSlots[i]] = localTradeItems[i];
         }
     }
     gSaveContext.save.saveInfo.inventory.questItems |= localQuestItems;


### PR DESCRIPTION
Fixes #130.

MM's Anchor `HandlePacket_UpdateTeamState` wholesale-replaces `saveInfo`/`shipSaveInfo` from the teammate snapshot and OR-restores weekEventReg/masks/questItems/upgrades/scene flags afterward — but never OR-merged `shipSaveInfo.rando.randoInf[]` (obtained trade items, souls, swim, purchases, ocarina buttons) and never preserved the three shared trade slots. A stale teammate snapshot could clear locally-obtained flags, or empty a trade slot while its flag survived — producing #130''s "trade item obtained but not in the primary slot, unselectable until a second item of the group arrives".

Fix (receive-side only; covers both live and dormant applies):
- Snapshot `randoInf` before the wholesale assigns and OR it back after, mirroring OOT''s `randomizerInf` OR-merge in soh''s UpdateTeamState.
- Preserve the three trade slot bytes when locally non-empty, mirroring the existing masks pattern (and OOT''s keep-local-slot loop). Safe because `randoInf` is monotonic in play — trade flags mean "ever obtained" and are never cleared on hand-over, so the OR cannot resurrect a given-away item.

Every solo give path was audited and writes flag+slot atomically; the merge was the only live producer of the corrupted state. Not playtested; co-op repro steps: two clients on one seed with item sync on, client A collects a trade item, then trigger a team resync from a client with a stale save — A must keep flag+slot, B must receive both. Deliberately out of scope (by decision): merge-time reconcile for already-corrupted saves, `foundDungeonKeys`/`foundTriforcePieces` max-merge, and the Kaleido single-item select gate.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9239134680.zip)
<!--- section:artifacts:end -->