### PR TITLE
fix(combo): portal return must not arrive on a cutscene layer (#135)

### DIFF
--- a/soh/src/code/title_setup.c
+++ b/soh/src/code/title_setup.c
@@ -33,6 +33,9 @@ void TitleSetup_InitImpl(GameState* gameState) {
         // Must follow OnLoadGame: the rando handler's Entrance_SetSavewarpEntrance() recomputes from
         // savedSceneNum (never set by the portal handoff) and would clobber this with Link's House.
         gSaveContext.entranceIndex = Entrance_OverrideNextIndex(ENTR_MARKET_DAY_OUTSIDE_HAPPY_MASK_SHOP);
+        // A portal return is never a cutscene arrival: a never-played MM-start save still holds the
+        // pending intro (0xFFF1), which would shift Play_Init's entrance lookup onto a garbage layer.
+        gSaveContext.cutsceneIndex = 0;
         gComboReturnFileNum = -1;
         gameState->running = false;
         SET_NEXT_GAMESTATE(gameState, Play_Init, PlayState);


### PR DESCRIPTION
Starting Game = MM, first Clock Tower return into OOT spawned Link out of bounds in the night Market (void loop).

Root cause: a never-played MM-start OOT save still holds the pending intro `cutsceneIndex` (0xFFF1) — only an adult rando start clears it, and OOT's Play never ran to consume it. On the portal return, `Play_Init` sees `cutsceneIndex >= 0xFFF0` and picks scene layer 5, shifting the entrance lookup from `ENTR_MARKET_DAY_OUTSIDE_HAPPY_MASK_SHOP` (0x1D1) to 0x1D6 (`SCENE_MARKET_NIGHT`, spawn 10) with a cutscene header the scene lacks.

Fix: clear `cutsceneIndex` in the TitleSetup combo return block — a portal return is never a cutscene arrival. Played saves already carry 0, so OOT-start round trips are unchanged.

Untested in-game yet (playtest pending); Debug build verified.