### PR TITLE
Triforce Hunt: cross-game completion fix + combined pool total

### DIFF
--- a/combo/ComboRandoHeadless.cpp
+++ b/combo/ComboRandoHeadless.cpp
@@ -101,12 +101,16 @@ int main(int argc, char** argv) {
     uint32_t masterSeedArg = 0;
     // #136: combined goal. Absent => read the menu CVars (matches in-game); 0 => force bosses.
     int triforceRequiredArg = -1;
+    // #136: combined pool total. Absent (-1) => the menu CVar, or `required` when that is overridden.
+    int triforceTotalArg = -1;
     // #135: starting game. Absent (-1) => read the menu CVar, same as in-game.
     int startingGameArg = -1;
     for (int i = 1; i < argc; ++i) {
         std::string a = argv[i];
         if (a == "--triforce-required" && i + 1 < argc)
             triforceRequiredArg = std::atoi(argv[++i]);
+        else if (a == "--triforce-total" && i + 1 < argc)
+            triforceTotalArg = std::atoi(argv[++i]);
         else if (a == "--starting-game" && i + 1 < argc) {
             std::string v = argv[++i];
             startingGameArg = v == "oot" ? 0 : v == "mm" ? 1 : v == "random" ? 2 : -2;
@@ -159,9 +163,9 @@ int main(int argc, char** argv) {
     auto SOH_SetCheckPrices = Sym<FnTakeStr>(soh, "SOH_SetCheckPrices");
     auto MM_SetCheckPrices = Sym<FnTakeStr>(mm, "MM_SetCheckPrices");
     // #136: combined goal — must be pushed before every dump (it shapes both games' pools).
-    auto SOH_SetComboGoal = Sym<void (*)(int, int)>(soh, "SOH_SetComboGoal");
-    auto MM_SetComboGoal = Sym<void (*)(int, int)>(mm, "MM_SetComboGoal");
-    auto SOH_ReadComboGoalCVars = Sym<int (*)(int*)>(soh, "SOH_ReadComboGoalCVars");
+    auto SOH_SetComboGoal = Sym<void (*)(int, int, int)>(soh, "SOH_SetComboGoal");
+    auto MM_SetComboGoal = Sym<void (*)(int, int, int)>(mm, "MM_SetComboGoal");
+    auto SOH_ReadComboGoalCVars = Sym<int (*)(int*, int*)>(soh, "SOH_ReadComboGoalCVars");
     // #135: starting game — also pushed before every dump (it forces OOT's age/forest/exclusions).
     auto SOH_SetComboStartingGame = Sym<void (*)(int)>(soh, "SOH_SetComboStartingGame");
     auto SOH_ReadComboStartingGameCVar = Sym<int (*)(void)>(soh, "SOH_ReadComboStartingGameCVar");
@@ -214,6 +218,7 @@ int main(int argc, char** argv) {
             auto g = spoiler.value("goal", nlohmann::json::object());
             goal.hunt = g.value("type", std::string("bosses")) == "triforceHunt";
             goal.required = goal.hunt ? g.value("requiredPieces", 0) : 0;
+            goal.total = g.value("totalPieces", -1); // absent on seeds made before the combined total
         }
         // #135: the seed's starting game. Absent on old spoilers, which all started in OOT.
         const bool mmStart = spoiler.value("startingGame", std::string("OOT")) == "MM";
@@ -257,9 +262,9 @@ int main(int argc, char** argv) {
             if (MM_SetSeed)
                 MM_SetSeed(masterSeed);
             if (SOH_SetComboGoal)
-                SOH_SetComboGoal(goal.hunt ? 1 : 0, goal.required);
+                SOH_SetComboGoal(goal.hunt ? 1 : 0, goal.required, ComboRando::CwOotPieces(goal.total));
             if (MM_SetComboGoal)
-                MM_SetComboGoal(goal.hunt ? 1 : 0, goal.required);
+                MM_SetComboGoal(goal.hunt ? 1 : 0, goal.required, ComboRando::CwMmPieces(goal.total));
             if (SOH_SetComboStartingGame)
                 SOH_SetComboStartingGame(mmStart ? 1 : 0);
             // A real in-game save's placement map lists only SHUFFLED checks; non-shuffled items the
@@ -468,19 +473,25 @@ int main(int argc, char** argv) {
     ComboRando::CwGoal goal;
     if (triforceRequiredArg >= 0) {
         goal.hunt = triforceRequiredArg > 0;
-        goal.required = triforceRequiredArg;
+        goal.required = std::min(triforceRequiredArg, ComboRando::kMaxComboTriforcePieces);
+        // --triforce-total wins; else default the pool to exactly what the goal needs.
+        goal.total = std::max(triforceTotalArg, goal.required);
     } else if (SOH_ReadComboGoalCVars) {
-        int required = 0;
-        goal.hunt = SOH_ReadComboGoalCVars(&required) != 0;
+        int required = 0, total = -1;
+        goal.hunt = SOH_ReadComboGoalCVars(&required, &total) != 0;
         goal.required = goal.hunt ? required : 0;
+        goal.total = triforceTotalArg > 0 ? std::max(triforceTotalArg, goal.required) : total;
     }
+    // Same cap the DLLs apply per game, so the recorded totalPieces can't disagree with the pools.
+    goal.total = std::clamp(goal.total, goal.required, ComboRando::kMaxComboTriforcePieces);
     // #135: same fallback order — the flag wins, else the menu CVar.
     const int startCfg = startingGameArg >= 0            ? startingGameArg
                          : SOH_ReadComboStartingGameCVar ? SOH_ReadComboStartingGameCVar()
                                                          : 0;
     std::cout << "[comborando] validating " << count << " seed(s) from "
               << (haveMasterSeed ? "masterSeed " + std::to_string(masterSeedArg) : "'" + seed + "'")
-              << (goal.hunt ? " (Triforce Hunt, " + std::to_string(goal.required) + " required)"
+              << (goal.hunt ? " (Triforce Hunt, " + std::to_string(goal.required) + " of " +
+                                  std::to_string(goal.total) + " pieces)"
                             : std::string(" (both bosses)"))
               << (startCfg == 1   ? ", starting game MM"
                   : startCfg == 2 ? ", starting game random"
@@ -508,9 +519,9 @@ int main(int argc, char** argv) {
                 MM_SetSeed(masterSeed);
             // Before the dumps: the goal shapes OOT's wincon placement and MM's hunt pool.
             if (SOH_SetComboGoal)
-                SOH_SetComboGoal(goal.hunt ? 1 : 0, goal.required);
+                SOH_SetComboGoal(goal.hunt ? 1 : 0, goal.required, ComboRando::CwOotPieces(goal.total));
             if (MM_SetComboGoal)
-                MM_SetComboGoal(goal.hunt ? 1 : 0, goal.required);
+                MM_SetComboGoal(goal.hunt ? 1 : 0, goal.required, ComboRando::CwMmPieces(goal.total));
             // Same reason (#135): an MM start forces OOT's age/forest/exclusions.
             if (SOH_SetComboStartingGame)
                 SOH_SetComboStartingGame(mmStart ? 1 : 0);
@@ -520,7 +531,7 @@ int main(int argc, char** argv) {
                 const int pieces = ComboRando::CountPoolTriforcePieces(sohDump, mmDump);
                 if (pieces < goal.required) {
                     std::cerr << "[comborando] Triforce Hunt needs " << goal.required << " pieces but only " << pieces
-                              << " are in the combined pool — raise the OOT/MM piece sliders\n";
+                              << " are in the combined pool — raise --triforce-total / the Combo pool total\n";
                     return 2;
                 }
             }
@@ -603,7 +614,8 @@ int main(int argc, char** argv) {
                     consolidated["seed"] = seed;
                     consolidated["masterSeed"] = masterSeed;
                     consolidated["goal"] = { { "type", goal.hunt ? "triforceHunt" : "bosses" },
-                                             { "requiredPieces", goal.required } };
+                                             { "requiredPieces", goal.required },
+                                             { "totalPieces", goal.total } };
                     consolidated["startingGame"] = resolvedMmStart ? "MM" : "OOT"; // #135
                     // ComboShip: suffix cross-game item-name collisions in the placements (parity with
                     // RunComboFill's consolidated writer) so the headless spoiler shows "(OOT)"/"(MM)".

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -625,8 +625,8 @@ static int g_comboCompletionSlot = -1;
 
 // ComboShip (#136): Triforce Hunt is ONE combined goal — the launcher pushes it into both DLLs, sums
 // both counters on every piece grant/merge, and dispatches the ending itself.
-typedef void (*FnSetComboGoal)(int hunt, int required);
-typedef int (*FnReadComboGoalCVars)(int* required);
+typedef void (*FnSetComboGoal)(int hunt, int required, int pieces);
+typedef int (*FnReadComboGoalCVars)(int* required, int* total);
 typedef int (*FnGetTriforceCount)(void);
 typedef void (*FnTriggerTriforceCredits)(int dormant);
 typedef void (*FnSetTriforceProgressCb)(void (*)(int, int));
@@ -645,6 +645,7 @@ static FnSetOtherTriforceCountCb MM_SetOtherTriforceCountCb = nullptr;
 // Active goal for the loaded slot (0 required = the both-bosses goal) + the one-shot completion latch.
 static bool g_goalHunt = false;
 static int g_goalRequired = 0;
+static int g_goalTotal = -1; // combined pieces the seed places; -1 = seed predates the combo-owned total
 static bool g_comboTriforceDone = false;
 
 // ComboShip (#135): starting game. The menu CVar may say Random; the launcher resolves it per seed and
@@ -988,6 +989,9 @@ static void ResetCrossItemDedupForSeed(uint32_t seed) {
     }
 }
 
+// ComboShip (#136): defined below; the cross-grant re-evaluates the combined goal (see DeliverCrossItem).
+static void Combo_OnTriforceProgress(int game, int fileNum);
+
 static void DeliverCrossItem(int targetGame, const char* itemName, const char* srcCheckName) {
     if (srcCheckName && srcCheckName[0] != '\0') {
         std::lock_guard<std::mutex> lock(sAppliedCrossChecksMutex);
@@ -1001,6 +1005,13 @@ static void DeliverCrossItem(int targetGame, const char* itemName, const char* s
     } else {
         if (SOH_GrantCrossItem)
             SOH_GrantCrossItem(itemName);
+    }
+    // ComboShip (#136): the grant's own poke carries the TARGET game's fileNum, which is unbound (0xFF)
+    // whenever that game is dormant, so it gets dropped. Re-poke here — the single choke point every
+    // cross-grant (local collection in either game, Anchor receive, resync backfill) passes through —
+    // with the launcher's loaded slot. Latched in Combo_OnTriforceProgress, so extra pokes are free.
+    if (itemName && ComboRando::CwIsTriforcePiece((ComboRando::GameId)targetGame, itemName)) {
+        Combo_OnTriforceProgress(targetGame, g_comboCompletionSlot);
     }
 }
 
@@ -1044,6 +1055,7 @@ static void LoadComboCompletion(int slot) {
     g_comboTriforceDone = false;
     g_goalHunt = false;
     g_goalRequired = 0;
+    g_goalTotal = -1;
     g_startingGameMM = false;
     {
         std::lock_guard<std::mutex> lk(g_containerMutex);
@@ -1058,14 +1070,15 @@ static void LoadComboCompletion(int slot) {
         auto goal = rando.value("goal", nlohmann::json::object());
         g_goalHunt = goal.value("type", std::string("bosses")) == "triforceHunt";
         g_goalRequired = g_goalHunt ? goal.value("requiredPieces", 0) : 0;
+        g_goalTotal = goal.value("totalPieces", -1); // absent on seeds made before the combined total
         // Same for the starting game (#135) — old seeds have no field and started in OOT.
         g_startingGameMM = rando.value("startingGame", std::string("OOT")) == "MM";
     }
     // Push outside the container lock — the DLL setters must never re-enter the sidecar.
     if (SOH_SetComboGoal)
-        SOH_SetComboGoal(g_goalHunt ? 1 : 0, g_goalRequired);
+        SOH_SetComboGoal(g_goalHunt ? 1 : 0, g_goalRequired, ComboRando::CwOotPieces(g_goalTotal));
     if (MM_SetComboGoal)
-        MM_SetComboGoal(g_goalHunt ? 1 : 0, g_goalRequired);
+        MM_SetComboGoal(g_goalHunt ? 1 : 0, g_goalRequired, ComboRando::CwMmPieces(g_goalTotal));
     if (SOH_SetComboStartingGame)
         SOH_SetComboStartingGame(g_startingGameMM ? 1 : 0);
 }
@@ -1076,9 +1089,9 @@ static void RestoreLoadedSlotGoal() {
     if (g_comboCompletionSlot < 0)
         return;
     if (SOH_SetComboGoal)
-        SOH_SetComboGoal(g_goalHunt ? 1 : 0, g_goalRequired);
+        SOH_SetComboGoal(g_goalHunt ? 1 : 0, g_goalRequired, ComboRando::CwOotPieces(g_goalTotal));
     if (MM_SetComboGoal)
-        MM_SetComboGoal(g_goalHunt ? 1 : 0, g_goalRequired);
+        MM_SetComboGoal(g_goalHunt ? 1 : 0, g_goalRequired, ComboRando::CwMmPieces(g_goalTotal));
     if (SOH_SetComboStartingGame)
         SOH_SetComboStartingGame(g_startingGameMM ? 1 : 0);
 }
@@ -1243,9 +1256,10 @@ static void RunComboFill(std::string inputSeed, ComboRando::ComboGenProgress* pr
     // ComboShip (#136): the combo-owned goal. Read via soh.dll — the launcher has no CVar access.
     ComboRando::CwGoal goal;
     if (SOH_ReadComboGoalCVars) {
-        int required = 0;
-        goal.hunt = SOH_ReadComboGoalCVars(&required) != 0;
+        int required = 0, total = -1;
+        goal.hunt = SOH_ReadComboGoalCVars(&required, &total) != 0;
         goal.required = goal.hunt ? required : 0;
+        goal.total = total; // kept even for bosses, so each game's own piece slider is forced to 0
     }
     if (goal.hunt && goal.required < 1) {
         fail("Triforce Hunt needs at least 1 required piece");
@@ -1320,9 +1334,9 @@ static void RunComboFill(std::string inputSeed, ComboRando::ComboGenProgress* pr
         // Must precede the dumps: OOT's FinalizeSettings and MM's GeneratePools shape their pools
         // (wincon, Majora soul removal, piece count) from the goal.
         if (SOH_SetComboGoal)
-            SOH_SetComboGoal(goal.hunt ? 1 : 0, goal.required);
+            SOH_SetComboGoal(goal.hunt ? 1 : 0, goal.required, ComboRando::CwOotPieces(goal.total));
         if (MM_SetComboGoal)
-            MM_SetComboGoal(goal.hunt ? 1 : 0, goal.required);
+            MM_SetComboGoal(goal.hunt ? 1 : 0, goal.required, ComboRando::CwMmPieces(goal.total));
         // Same reason (#135): an MM start forces OOT's age/forest/exclusions, which shape its pool.
         if (SOH_SetComboStartingGame)
             SOH_SetComboStartingGame(mmStart ? 1 : 0);
@@ -1338,7 +1352,7 @@ static void RunComboFill(std::string inputSeed, ComboRando::ComboGenProgress* pr
             const int pieces = ComboRando::CountPoolTriforcePieces(sohDump, mmDump);
             if (pieces < goal.required) {
                 fail((std::string("Triforce Hunt needs ") + std::to_string(goal.required) + " pieces but only " +
-                      std::to_string(pieces) + " are in the combined pool — raise the OOT/MM piece sliders")
+                      std::to_string(pieces) + " are in the combined pool — raise the Combo menu's pool total")
                          .c_str());
                 return;
             }
@@ -1597,7 +1611,8 @@ static void RunComboFill(std::string inputSeed, ComboRando::ComboGenProgress* pr
         // ComboShip (#136): the goal is seed-bound — the runtime latch reads it back from the slot's
         // baked combo.rando, never from the live menu CVars.
         consolidated["goal"] = { { "type", goal.hunt ? "triforceHunt" : "bosses" },
-                                 { "requiredPieces", goal.required } };
+                                 { "requiredPieces", goal.required },
+                                 { "totalPieces", goal.total } };
         // ComboShip (#135): the resolved starting game — seed-bound like the goal, never re-rolled.
         consolidated["startingGame"] = resolvedMmStart ? "MM" : "OOT";
         // ComboShip (#90): OOT entrance layout — informational, reload re-derives it from masterSeed.
@@ -1956,10 +1971,12 @@ static int Combo_OnReloadRequest(const char* path) {
             auto g = j.value("goal", nlohmann::json::object());
             const int hunt = g.value("type", std::string("bosses")) == "triforceHunt" ? 1 : 0;
             const int required = hunt ? g.value("requiredPieces", 0) : 0;
+            // Absent on seeds made before the combined total — -1 leaves each game's own slider alone.
+            const int total = g.value("totalPieces", -1);
             if (SOH_SetComboGoal)
-                SOH_SetComboGoal(hunt, required);
+                SOH_SetComboGoal(hunt, required, ComboRando::CwOotPieces(total));
             if (MM_SetComboGoal)
-                MM_SetComboGoal(hunt, required);
+                MM_SetComboGoal(hunt, required, ComboRando::CwMmPieces(total));
             // Log-only sanity check: a hand-edited/plandomized spoiler could ask for more pieces than it
             // actually places, which is unwinnable. Loud, but the load still proceeds (the file is the
             // player's own artifact and the rest of it may be perfectly fine).

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -1614,14 +1614,25 @@ void ComboMenu::DrawComboPanel() {
     }
     ComboRando::ComboMenu_PopCheckbox();
     if (hunt) {
-        int required = CVarGetInteger("gCombo.Rando.TriforceRequired", 15);
-        ImGui::SetNextItemWidth(260.0f);
+        const int kMaxPieces = ComboRando::kMaxComboTriforcePieces;
+        int required = std::clamp(CVarGetInteger("gCombo.Rando.TriforceRequired", 15), 1, kMaxPieces);
+        int total = std::clamp(CVarGetInteger("gCombo.Rando.TriforceTotal", 15), required, kMaxPieces);
         ComboRando::ComboMenu_PushInput(goalTheme);
+        ImGui::SetNextItemWidth(260.0f);
         if (ImGui::InputInt("Required pieces (both games)", &required)) {
-            CVarSetInteger("gCombo.Rando.TriforceRequired", required < 1 ? 1 : required);
+            required = std::clamp(required, 1, kMaxPieces);
+            CVarSetInteger("gCombo.Rando.TriforceRequired", required);
+            if (total < required) {
+                CVarSetInteger("gCombo.Rando.TriforceTotal", required); // total can never sit below required
+            }
+        }
+        ImGui::SetNextItemWidth(260.0f);
+        if (ImGui::InputInt("Pieces in the pool (both games)", &total)) {
+            CVarSetInteger("gCombo.Rando.TriforceTotal", std::clamp(total, required, kMaxPieces));
         }
         ComboRando::ComboMenu_PopInput();
         ImGui::TextDisabled("Collect this many pieces across OOT and MM to finish; bosses are optional.");
+        ImGui::TextDisabled("The pool total is split evenly between the two games (OOT takes the odd one).");
         // The combined count is invisible to both games' own trackers, so combo draws its own line.
         bool line = CVarGetInteger("gCombo.Tracker.TriforceLine", 1) != 0;
         ComboRando::ComboMenu_PushCheckbox(goalTheme);

--- a/combo/rando/CrossWorldRando.h
+++ b/combo/rando/CrossWorldRando.h
@@ -87,7 +87,20 @@ inline constexpr const char* kMmTriforcePiece = "Piece of the Triforce";
 struct CwGoal {
     bool hunt = false;
     int required = 0;
+    int total = -1; // combined pieces placed; -1 = unset (seed predates the combo-owned total)
 };
+
+// Even split of the combined total across the two pools; OOT takes the odd piece. -1 passes through
+// so each game keeps its own slider (old seeds).
+inline int CwOotPieces(int total) {
+    return total < 0 ? -1 : total - total / 2;
+}
+inline int CwMmPieces(int total) {
+    return total < 0 ? -1 : total / 2;
+}
+// Ceiling on the combined total. OOT's pool can't absorb its half much past this (100/100 trips
+// item_pool.cpp's itemPool <= locCount assert); 50/50 is verified to generate.
+inline constexpr int kMaxComboTriforcePieces = 100;
 
 inline bool CwIsTriforcePiece(GameId itemGame, const std::string& itemName) {
     return itemName == (itemGame == GAME_OOT ? kOotTriforcePiece : kMmTriforcePiece);

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -2753,6 +2753,7 @@ static void Combo_MM_ApplyCheckPrices();
 // Triforce options from these — combo owns the goal and MM's own CVars are hidden in combo builds.
 extern "C" int gMMComboGoalHunt;
 extern "C" int gMMComboGoalRequired;
+extern "C" int gMMComboGoalPieces;
 
 // Combo master seed for MM's RNG, mirroring OOT's SOH_SetComboRandoSeed so confined placement
 // (PreplaceConfinedItems, via Ship_Random) is reproducible per seed.
@@ -2826,6 +2827,10 @@ extern "C" __declspec(dllexport) int MM_InitRandoSaveFile(int fileNum, const cha
             (uint32_t)(gMMComboGoalHunt ? RO_GENERIC_YES : RO_GENERIC_NO);
         if (gMMComboGoalHunt) {
             options[Rando::StaticData::Options[RO_TRIFORCE_PIECES_REQUIRED].name] = (uint32_t)gMMComboGoalRequired;
+            // #136: MM's half of the combined total; -1 = old seed, keep the CVar.
+            if (gMMComboGoalPieces >= 0) {
+                options[Rando::StaticData::Options[RO_TRIFORCE_PIECES_MAX].name] = (uint32_t)gMMComboGoalPieces;
+            }
         }
         spoiler["options"] = options;
         spoiler["startingItems"] = nlohmann::json::array();
@@ -3812,6 +3817,11 @@ extern "C" __declspec(dllexport) void Combo_MM_Rando_Reset(void) {
     if (gMMComboGoalHunt) {
         gSaveContext.save.shipSaveInfo.rando.randoSaveOptions[RO_TRIFORCE_PIECES_REQUIRED] =
             (uint32_t)gMMComboGoalRequired;
+        // #136: MM's half of the combined total; -1 = old seed, keep the CVar.
+        if (gMMComboGoalPieces >= 0) {
+            gSaveContext.save.shipSaveInfo.rando.randoSaveOptions[RO_TRIFORCE_PIECES_MAX] =
+                (uint32_t)gMMComboGoalPieces;
+        }
     }
 
     // ComboShip: grant the seed's STARTING ITEMS into the oracle inventory. These aren't in the
@@ -4013,9 +4023,13 @@ extern "C" __declspec(dllexport) void MM_SetFinalBossDefeatedCb(int (*cb)(int, i
 // hunt=0 means the normal both-bosses goal; required is the combined piece count.
 extern "C" int gMMComboGoalHunt = 0;
 extern "C" int gMMComboGoalRequired = 0;
-extern "C" __declspec(dllexport) void MM_SetComboGoal(int hunt, int required) {
+// This game's share of the combined piece total, forced at every save-option build site.
+// -1 = unset (old seed), so MM's own slider decides.
+extern "C" int gMMComboGoalPieces = -1;
+extern "C" __declspec(dllexport) void MM_SetComboGoal(int hunt, int required, int pieces) {
     gMMComboGoalHunt = hunt ? 1 : 0;
     gMMComboGoalRequired = gMMComboGoalHunt ? required : 0;
+    gMMComboGoalPieces = pieces < 0 ? -1 : (pieces > 100 ? 100 : pieces); // same 0..100 cap as OOT's
 }
 extern "C" __declspec(dllexport) int MM_GetTriforcePieceCount(void) {
     return gSaveContext.save.shipSaveInfo.rando.foundTriforcePieces;

--- a/mm/2s2h/Rando/Logic/GeneratePools.cpp
+++ b/mm/2s2h/Rando/Logic/GeneratePools.cpp
@@ -10,6 +10,7 @@ extern "C" {
 #ifdef COMBO_BUILD
 extern "C" int gMMComboGoalHunt;
 extern "C" int gMMComboGoalRequired;
+extern "C" int gMMComboGoalPieces;
 #endif
 
 namespace Rando {
@@ -23,6 +24,10 @@ void GeneratePools(RandoSaveInfo& saveInfo, std::vector<RandoCheckId>& checkPool
     saveInfo.randoSaveOptions[RO_SHUFFLE_TRIFORCE_PIECES] = gMMComboGoalHunt ? RO_GENERIC_YES : RO_GENERIC_NO;
     if (gMMComboGoalHunt) {
         saveInfo.randoSaveOptions[RO_TRIFORCE_PIECES_REQUIRED] = (uint32_t)gMMComboGoalRequired;
+        // #136: MM's half of the combined total; -1 = old seed, keep the CVar.
+        if (gMMComboGoalPieces >= 0) {
+            saveInfo.randoSaveOptions[RO_TRIFORCE_PIECES_MAX] = (uint32_t)gMMComboGoalPieces;
+        }
     }
 #endif
     std::vector<RandoItemId> startingItems = Rando::GetStartingItemsFromSave(saveInfo);

--- a/mm/2s2h/Rando/Menu.cpp
+++ b/mm/2s2h/Rando/Menu.cpp
@@ -585,7 +585,7 @@ static void DrawShufflesTab() {
                 CVarGetInteger(Rando::StaticData::Options[RO_STRAY_FAIRIES_MAX].cvar, STRAY_FAIRY_SCATTERED_TOTAL));
         }
     }
-#ifndef COMBO_BUILD // ComboShip (#136): combo owns the hunt toggle and the (combined) required count.
+#ifndef COMBO_BUILD // ComboShip (#136): combo owns the hunt toggle plus the combined required/total counts.
     CVarCheckbox("Triforce Hunt", Rando::StaticData::Options[RO_SHUFFLE_TRIFORCE_PIECES].cvar);
     ImGui::BeginDisabled(!CVarGetInteger(Rando::StaticData::Options[RO_SHUFFLE_TRIFORCE_PIECES].cvar, RO_GENERIC_OFF));
     CVarSliderInt(
@@ -596,7 +596,6 @@ static void DrawShufflesTab() {
             .Min(1)
             .Max(CVarGetInteger(Rando::StaticData::Options[RO_TRIFORCE_PIECES_MAX].cvar, DEFAULT_TRIFORCE_PIECES_MAX))
             .DefaultValue(DEFAULT_TRIFORCE_PIECES_MAX));
-#endif
     if (CVarSliderInt(
             "Shuffled Triforce Pieces", Rando::StaticData::Options[RO_TRIFORCE_PIECES_MAX].cvar,
             IntSliderOptions()
@@ -614,10 +613,9 @@ static void DrawShufflesTab() {
                 CVarGetInteger(Rando::StaticData::Options[RO_TRIFORCE_PIECES_MAX].cvar, DEFAULT_TRIFORCE_PIECES_MAX));
         }
     }
-
-#ifndef COMBO_BUILD
     ImGui::EndDisabled();
 #endif
+
     ImGui::EndChild();
     ImGui::SameLine();
     ImGui::BeginChild("randoShufflesColumn2", ImVec2(columnWidth, halfHeight));

--- a/soh/soh/Enhancements/kaleido.cpp
+++ b/soh/soh/Enhancements/kaleido.cpp
@@ -147,7 +147,7 @@ Kaleido::Kaleido() {
     if (ctx->GetOption(RSK_TRIFORCE_HUNT_PIECES_TOTAL).Get() > 0) {
         mEntries.push_back(std::make_shared<KaleidoEntryIconCountRequired>(
             gTriforcePieceTex, G_IM_FMT_RGBA, G_IM_SIZ_32b, 32, 32, Color_RGBA8{ 255, 255, 255, 255 },
-            reinterpret_cast<int*>(&gSaveContext.ship.quest.data.randomizer.triforcePiecesCollected),
+            &gSaveContext.ship.quest.data.randomizer.triforcePiecesCollected,
             ctx->GetOption(RSK_WINCON_TRIFORCE_COUNT).Get(), ctx->GetOption(RSK_TRIFORCE_HUNT_PIECES_TOTAL).Get()));
     }
     if (ctx->GetOption(RSK_SKELETON_KEY)) {
@@ -392,7 +392,7 @@ void KaleidoEntryIconFlag::Update(PlayState* play) {
 
 KaleidoEntryIconCountRequired::KaleidoEntryIconCountRequired(const char* iconResourceName, int iconFormat, int iconSize,
                                                              int iconWidth, int iconHeight, Color_RGBA8 iconColor,
-                                                             int* watch, int required, int total)
+                                                             const u8* watch, int required, int total)
     : KaleidoEntryIcon(iconResourceName, iconFormat, iconSize, iconWidth, iconHeight, iconColor), mWatch(watch),
       mRequired(required), mTotal(total) {
     mCount = *mWatch;

--- a/soh/soh/Enhancements/kaleido.h
+++ b/soh/soh/Enhancements/kaleido.h
@@ -123,17 +123,18 @@ class KaleidoEntryIconCountRequired final : public KaleidoEntryIcon {
      * @param flag flag to check for. An integer can be provided but enum values should be preferred
      * @param x x coordinate of the location to draw this relative to the parent matrix's origin.
      * @param y y coordinate of the location to draw this relative to the parent matrix's origin.
-     * @param watch a pointer to an integer value to watch. Update will check this value to update
+     * @param watch a pointer to the u8 counter to watch. Update will check this value to update
      * a local count variable.
      * @param required The amount of this collectible required to beat the seed. Set to 0 to not render.
      * @param total The amount of this collectible available in the seed. Set to 0 to not render.
      */
     KaleidoEntryIconCountRequired(const char* iconResourceName, int iconFormat, int iconSize, int iconWidth,
-                                  int iconHeight, Color_RGBA8 iconColor, int* watch, int required = 0, int total = 0);
+                                  int iconHeight, Color_RGBA8 iconColor, const u8* watch, int required = 0,
+                                  int total = 0);
     void Update(PlayState* play) override;
 
   private:
-    int* mWatch;
+    const u8* mWatch;
     int mRequired;
     int mTotal;
     int mCount;

--- a/soh/soh/Enhancements/randomizer/hint.cpp
+++ b/soh/soh/Enhancements/randomizer/hint.cpp
@@ -4,9 +4,6 @@
 #include <spdlog/spdlog.h>
 #include "static_data.h"
 #include "rng.h"
-#ifdef COMBO_BUILD
-extern "C" int gComboGoalRequired;
-#endif
 
 namespace Rando {
 Hint::Hint() {
@@ -669,13 +666,8 @@ CustomMessage Hint::GetWinconText() {
         winconMessage.InsertNumber(ctx->GetOption(RSK_WINCON_TOKEN_COUNT).Get());
     } else if (ctx->GetOption(RSK_WINCON).Is(RO_WINCON_TRIFORCE_PIECES)) {
         winconMessage = StaticData::hintTextTable[RHT_WINCON_TRIFORCE_PIECES_HINT].GetHintMessage();
-#ifdef COMBO_BUILD
-        // ComboShip (#136): the goal spans both games; the native option only holds OOT's count.
-        winconMessage.InsertNumber(gComboGoalRequired > 0 ? gComboGoalRequired
-                                                          : ctx->GetOption(RSK_WINCON_TRIFORCE_COUNT).Get());
-#else
+        // ComboShip (#136): combo forces this option to the COMBINED required count (settings.cpp).
         winconMessage.InsertNumber(ctx->GetOption(RSK_WINCON_TRIFORCE_COUNT).Get());
-#endif
     }
     return winconMessage;
 }

--- a/soh/soh/Enhancements/randomizer/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/settings.cpp
@@ -2715,8 +2715,8 @@ void Context::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocation
         mOptions[RSK_TRIFORCE_HUNT_PIECES_TOTAL].Set(ootPieces);
         // The forced total bypasses RSK_TRIFORCE_HUNT_PIECES_TOTAL's callback, so mirror its clamp:
         // these triggers count OOT-LOCAL pieces, and asking for more than OOT's pool holds is unwinnable.
-        for (const RandomizerSettingKey key : { RSK_RAINBOW_BRIDGE_TRIFORCE_COUNT, RSK_GBK_TRIFORCE_COUNT,
-                                                RSK_GANONS_SOUL_TRIFORCE_COUNT }) {
+        for (const RandomizerSettingKey key :
+             { RSK_RAINBOW_BRIDGE_TRIFORCE_COUNT, RSK_GBK_TRIFORCE_COUNT, RSK_GANONS_SOUL_TRIFORCE_COUNT }) {
             if (mOptions[key].Get() > ootPieces) {
                 mOptions[key].Set(ootPieces);
             }

--- a/soh/soh/Enhancements/randomizer/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/settings.cpp
@@ -15,11 +15,28 @@
 // ComboShip (#136): combo owns the win condition (combined Triforce goal), forced in FinalizeSettings.
 // A plain constant, not an #ifdef inside the OPT_CALLBACK macro arguments.
 extern "C" int gComboGoalHunt;
+// ComboShip (#136): the combined required count, and this game's share of the combo-owned piece
+// total (-1 = unset, i.e. a seed generated before combo owned it).
+extern "C" int gComboGoalRequired;
+extern "C" int gComboGoalPieces;
 // ComboShip (#135): 1 when the resolved starting game is MM, which forces age/forest/exclusions below.
 extern "C" int gComboStartingGameMM;
 static constexpr bool kComboOwnsWincon = true;
+// ComboShip (#136): OOT's half of the combo-owned pool, for the menu-side dependent-count ranges.
+// Mirrors CwOotPieces in combo/rando/CrossWorldRando.h — the two splits must stay identical.
+static uint8_t ComboOotTriforceTotal() {
+    if (CVarGetInteger("gCombo.Rando.TriforceHunt", 0) == 0) {
+        return 0;
+    }
+    int total = CVarGetInteger("gCombo.Rando.TriforceTotal", 15);
+    total = total < 1 ? 1 : (total > 100 ? 100 : total); // 100 = kMaxComboTriforcePieces
+    return static_cast<uint8_t>(total - total / 2);      // OOT takes the odd piece
+}
 #else
 static constexpr bool kComboOwnsWincon = false;
+static uint8_t ComboOotTriforceTotal() {
+    return 0; // never reached (kComboOwnsWincon is false), but the call site is a runtime if
+}
 #endif
 
 namespace Rando {
@@ -456,12 +473,18 @@ void Settings::CreateOptions() {
     // positive value adds that many Triforce Pieces to the pool and unlocks the pieces-location option.
     OPT_U8(RSK_TRIFORCE_HUNT_PIECES_TOTAL, "Triforce Hunt Total Pieces", {NumOpts(0, 100)}, OptionCategory::Setting, CVAR_RANDOMIZER_SETTING("TriforceHuntTotalPieces"), mOptionDescriptions[RSK_TRIFORCE_HUNT_PIECES_TOTAL], WIDGET_CVAR_SLIDER_INT, 0, false, nullptr, IMFLAG_NONE);
     OPT_CALLBACK(RSK_TRIFORCE_HUNT_PIECES_TOTAL, {
-        const uint8_t triforceTotal = CVarGetInteger(CVAR_RANDOMIZER_SETTING("TriforceHuntTotalPieces"), 0);
+        uint8_t triforceTotal = CVarGetInteger(CVAR_RANDOMIZER_SETTING("TriforceHuntTotalPieces"), 0);
         // ComboShip: the cross-world fill can't honor a dungeon/overworld restriction — forced Anywhere.
         if (triforceTotal == 0 || kComboOwnsWincon) {
             mOptions[RSK_TRIFORCE_HUNT_PIECES_LOCATION].Hide();
         } else {
             mOptions[RSK_TRIFORCE_HUNT_PIECES_LOCATION].Unhide();
+        }
+        // ComboShip (#136): the combo menu owns the total, so hide this slider and range the dependent
+        // counts below against OOT's forced share instead of this (now dead) CVar.
+        if (kComboOwnsWincon) {
+            mOptions[RSK_TRIFORCE_HUNT_PIECES_TOTAL].Hide();
+            triforceTotal = ComboOotTriforceTotal();
         }
         if (mOptions[RSK_RAINBOW_BRIDGE_TRIFORCE_COUNT].GetOptionCount() != triforceTotal + 1) {
             mOptions[RSK_RAINBOW_BRIDGE_TRIFORCE_COUNT].ChangeOptions(NumOpts(0, triforceTotal));
@@ -2680,6 +2703,25 @@ void Context::FinalizeSettings(const std::set<RandomizerCheck>& excludedLocation
     // Ganon-skip and parks RG_TRIFORCE on the dump-excluded RC_WINCON); pieces must go anywhere.
     mOptions[RSK_WINCON].Set(gComboGoalHunt ? RO_WINCON_TRIFORCE_PIECES : RO_WINCON_DEFEAT_GANON);
     mOptions[RSK_TRIFORCE_HUNT_PIECES_LOCATION].Set(RO_TRIFORCE_HUNT_LOCATION_ANYWHERE);
+    // ComboShip (#136): the goal is combined, so the per-game triforce UI (kaleido, item tracker,
+    // altar hint) must show the COMBINED required count, not OOT's share. Safe to force: the native
+    // win trigger is COMBO_BUILD'd out (hook_handlers.cpp) and this only otherwise gates RC_WINCON,
+    // which the combo dump excludes.
+    mOptions[RSK_WINCON_TRIFORCE_COUNT].Set((uint8_t)gComboGoalRequired);
+    // OOT's half of the combined total (0 when the hunt is off, so a stale slider value can't leak
+    // pieces into a both-bosses pool). -1 = old seed, leave the slider alone.
+    if (gComboGoalPieces >= 0) {
+        const uint8_t ootPieces = gComboGoalHunt ? (uint8_t)gComboGoalPieces : (uint8_t)0;
+        mOptions[RSK_TRIFORCE_HUNT_PIECES_TOTAL].Set(ootPieces);
+        // The forced total bypasses RSK_TRIFORCE_HUNT_PIECES_TOTAL's callback, so mirror its clamp:
+        // these triggers count OOT-LOCAL pieces, and asking for more than OOT's pool holds is unwinnable.
+        for (const RandomizerSettingKey key : { RSK_RAINBOW_BRIDGE_TRIFORCE_COUNT, RSK_GBK_TRIFORCE_COUNT,
+                                                RSK_GANONS_SOUL_TRIFORCE_COUNT }) {
+            if (mOptions[key].Get() > ootPieces) {
+                mOptions[key].Set(ootPieces);
+            }
+        }
+    }
     // ComboShip (#135): an MM start must leave OOT enterable from nothing — the Clock Tower door lands
     // an itemless child outside the Mask Shop, and an itemless child must be able to leave the forest.
     if (gComboStartingGameMM) {

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -3126,9 +3126,13 @@ extern "C" __declspec(dllexport) void SOH_SetFinalBossDefeatedCb(int (*cb)(int, 
 // pushes it here. hunt=0 means the normal both-bosses goal; required is the combined piece count.
 extern "C" int gComboGoalHunt = 0;
 extern "C" int gComboGoalRequired = 0;
-extern "C" __declspec(dllexport) void SOH_SetComboGoal(int hunt, int required) {
+// This game's share of the combined piece total, forced in FinalizeSettings. -1 = unset (old seed),
+// so OOT's own slider decides. Clamped to the option's 0..100 range.
+extern "C" int gComboGoalPieces = -1;
+extern "C" __declspec(dllexport) void SOH_SetComboGoal(int hunt, int required, int pieces) {
     gComboGoalHunt = hunt ? 1 : 0;
     gComboGoalRequired = gComboGoalHunt ? required : 0;
+    gComboGoalPieces = pieces < 0 ? -1 : (pieces > 100 ? 100 : pieces);
 }
 // The goal currently in force (comboui reads it for the combined-progress readout). Returns hunt on/off.
 extern "C" __declspec(dllexport) int SOH_GetComboGoal(int* required) {
@@ -3138,10 +3142,18 @@ extern "C" __declspec(dllexport) int SOH_GetComboGoal(int* required) {
     return gComboGoalHunt;
 }
 // Menu-authored goal CVars, read here because the launcher has no CVar access. Returns hunt on/off.
-extern "C" __declspec(dllexport) int SOH_ReadComboGoalCVars(int* required) {
+extern "C" __declspec(dllexport) int SOH_ReadComboGoalCVars(int* required, int* total) {
     const int hunt = CVarGetInteger("gCombo.Rando.TriforceHunt", 0) != 0 ? 1 : 0;
+    int req = CVarGetInteger("gCombo.Rando.TriforceRequired", 15);
+    int tot = CVarGetInteger("gCombo.Rando.TriforceTotal", 15);
+    // 100 = CrossWorldRando.h kMaxComboTriforcePieces (past that OOT's half overflows its item pool).
+    req = std::clamp(req, 1, 100);
+    tot = std::clamp(tot, req, 100);
     if (required != NULL) {
-        *required = hunt ? CVarGetInteger("gCombo.Rando.TriforceRequired", 15) : 0;
+        *required = hunt ? req : 0;
+    }
+    if (total != NULL) {
+        *total = tot; // the hunt-off force to 0 pieces happens game-side, so report the raw total
     }
     return hunt;
 }
@@ -4360,16 +4372,8 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoHintData(void) {
                 return { "RHT_WINCON_DUNGEONS_HINT", ctx->GetOption(RSK_WINCON_DUNGEON_COUNT).Get() };
             if (o.Is(RO_WINCON_TOKENS))
                 return { "RHT_WINCON_TOKENS_HINT", ctx->GetOption(RSK_WINCON_TOKEN_COUNT).Get() };
-            if (o.Is(RO_WINCON_TRIFORCE_PIECES)) {
-#ifdef COMBO_BUILD
-                // ComboShip (#136): the goal spans both games; the native option only holds OOT's count.
-                return { "RHT_WINCON_TRIFORCE_PIECES_HINT",
-                         gComboGoalRequired > 0 ? gComboGoalRequired
-                                                : (int)ctx->GetOption(RSK_WINCON_TRIFORCE_COUNT).Get() };
-#else
+            if (o.Is(RO_WINCON_TRIFORCE_PIECES))
                 return { "RHT_WINCON_TRIFORCE_PIECES_HINT", ctx->GetOption(RSK_WINCON_TRIFORCE_COUNT).Get() };
-#endif
-            }
             return { "", 0 };
         }();
         const char* doorOfTimeKey =


### PR DESCRIPTION
Playtest follow-ups to #155 (issue #136).

**Bug: hunt didn't complete when the final piece was an MM-world piece picked up in OOT.** The combined goal check was only poked from the owning game's increment hook with the dormant game's fileNum, which can be unbound (0xFF) — silently dropped. The poke now fires from the launcher's `DeliverCrossItem` choke point with the launcher's known slot, covering local collection in both games, both Anchor cross-item receives, and the resync backfill.

**Combo-owned pool total.** The OOT/MM 'Triforce Pieces' sliders are replaced by a single 'Pieces in the pool (both games)' input in the Combo menu next to Required. The total is split evenly between the two game pools (OOT takes the odd piece) and forced into each game's options at generation; the per-game sliders are hidden in combo builds. Persisted as `goal.totalPieces` in the spoiler (older spoilers fall back to per-game options).

Also:
- `RSK_WINCON_TRIFORCE_COUNT` forced to the combined required count, so kaleido / item tracker / altar hint show the real goal (deletes two prior workarounds); dependent OOT-local counts (bridge/GBK/Ganon's soul) re-ranged and clamped to OOT's share
- Piece cap 100 — past that OOT's half overflows its item pool (hard assert in `item_pool.cpp`)
- Kaleido piece counter read a `u8` through `reinterpret_cast<int*>` (count jumped by 256 once the neighboring byte was set)
- `comborando --triforce-total N` flag; clamps mirrored headless/GUI so recorded totals always match the pools

Headless-verified: even/odd splits, playthrough beatable, byte-identical determinism, bosses regression, clamp abuse (500/500). UNPLAYTESTED in-game.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9313402321.zip)
<!--- section:artifacts:end -->