### PR TITLE
Seed auto-load recovery at file select + Finalizing generation phase

### DIFF
--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -1197,8 +1197,13 @@ static std::filesystem::path WriteComboSpoiler(const nlohmann::json& fileHash, c
 // ComboShip: mark a spoiler as the one a restart reloads. MAIN THREAD ONLY — this writes a CVar and
 // saves the config, and libultraship's ConsoleVariable map is unlocked (same race as the apply below).
 static void RememberComboSpoiler(const std::filesystem::path& path) {
-    if (SOH_SetComboSpoilerPath && !path.empty())
-        SOH_SetComboSpoilerPath(path.string().c_str());
+    if (!SOH_SetComboSpoilerPath || path.empty())
+        return;
+    // Absolute: WriteComboSpoiler returns a CWD-relative path, which stops resolving if the game is
+    // ever launched from another directory (shortcut, launcher, debugger).
+    std::error_code ec;
+    auto abs = std::filesystem::absolute(path, ec);
+    SOH_SetComboSpoilerPath((ec ? path : abs).string().c_str());
 }
 
 // ComboShip: a silent auto-reload must not let the pending seed's settings overwrite the user's
@@ -1411,7 +1416,7 @@ static void RunComboFill(std::string inputSeed, ComboRando::ComboGenProgress* pr
                                                     goal.hunt ? ComboRando::MakeTriforceHuntGoal(goal.required)
                                                     : noLogic ? ComboRando::MmOnlyMajoraGoal
                                                               : ComboRando::DefaultGanonMajoraGoal,
-                                                    !noLogic, mmStart);
+                                                    !noLogic, mmStart, progress);
             } else {
                 std::cout << "[ComboShip] RunComboFill: pare-down skipped (no enabled hint surface needs "
                              "requiredness)\n";
@@ -1917,6 +1922,68 @@ static int Combo_PollFinalize() {
     return (g_ComboProgress.done.load() && !g_GenerateBusy.load()) ? 1 : 0;
 }
 
+// ComboShip: read a candidate consolidated seed file. True only if it opens, parses and is ours.
+static bool TryLoadComboSeedFile(const std::filesystem::path& p, nlohmann::json& out) {
+    std::ifstream in(p);
+    if (!in.is_open())
+        return false;
+    try {
+        nlohmann::json j;
+        in >> j;
+        if (j.value("fileType", std::string()) != "ComboShipRandomizer") {
+            std::cerr << "[ComboShip] reload: " << p.string() << " is not a ComboShip seed file\n";
+            return false;
+        }
+        out = std::move(j);
+        return true;
+    } catch (const std::exception& e) {
+        std::cerr << "[ComboShip] reload: could not parse " << p.string() << ": " << e.what() << "\n";
+        return false;
+    }
+}
+
+// ComboShip: a stored-relative path (or one from a different CWD) also gets tried next to the exe.
+static std::filesystem::path ResolveComboSeedPath(const std::string& file) {
+    std::filesystem::path p(file);
+    std::error_code ec;
+    if (std::filesystem::exists(p, ec))
+        return p;
+#ifdef _WIN32
+    // Wide API: the ANSI variant mangles non-ASCII install paths (e.g. accented user names) to '?'.
+    wchar_t exe[MAX_PATH] = { 0 };
+    if (GetModuleFileNameW(nullptr, exe, MAX_PATH)) {
+        const auto dir = std::filesystem::path(exe).parent_path();
+        // A relative path re-rooted at the exe; a moved absolute one by name under the seed dir.
+        for (const auto& alt : { dir / p.relative_path(), dir / ComboRando::ConsolidatedDir() / p.filename() })
+            if (std::filesystem::exists(alt, ec))
+                return alt;
+    }
+#endif
+    return p;
+}
+
+// ComboShip: newest readable combo seed in the Randomizer dir — recovers an auto-load when the
+// remembered path is lost (e.g. a wiped CVar) while the seed files are still there.
+static std::filesystem::path FindNewestComboSeed(nlohmann::json& out) {
+    std::error_code ec;
+    std::vector<std::pair<std::filesystem::file_time_type, std::filesystem::path>> found;
+    for (const auto& dir :
+         { ComboRando::ConsolidatedDir(), ResolveComboSeedPath(ComboRando::ConsolidatedDir().string()) }) {
+        for (std::filesystem::directory_iterator it(dir, ec), end; !ec && it != end; it.increment(ec)) {
+            if (!it->is_regular_file(ec) || it->path().extension() != ".json")
+                continue;
+            found.emplace_back(std::filesystem::last_write_time(it->path(), ec), it->path());
+        }
+        if (!found.empty())
+            break;
+    }
+    std::sort(found.begin(), found.end(), [](const auto& a, const auto& b) { return a.first > b.first; });
+    for (const auto& [t, p] : found)
+        if (TryLoadComboSeedFile(p, out))
+            return p;
+    return {};
+}
+
 // ComboShip: reload a consolidated seed file (the remembered pending file when path is null/empty, or
 // a dropped file) and make it playable WITHOUT regenerating. Runs synchronously on the MAIN thread
 // (called from the file-select), so the gSaveContext-mutating apply is safe. Restores both games'
@@ -1924,29 +1991,59 @@ static int Combo_PollFinalize() {
 // placements, and keeps the consolidated JSON in memory so "Start Randomizer" writes the per-slot
 // file. Returns 1 on success. The hash string is recomputed from displaySeed for the per-slot name.
 static int Combo_OnReloadRequest(const char* path) {
-    if (g_GenerateBusy.load() || g_ComboPendingFinalize.load())
+    if (g_GenerateBusy.load() || g_ComboPendingFinalize.load()) {
+        std::cerr << "[ComboShip] reload: skipped — a generation is in flight\n";
         return 0; // a generation is in flight — don't race it
+    }
     // A null/empty path is the silent first-frame auto-reload; a non-empty path is an explicit drop
     // (a deliberate seed switch, so its settings are allowed to become the new persisted baseline).
     bool isSilentAutoLoad = !(path && path[0]);
     std::string file;
-    if (!isSilentAutoLoad) {
-        file = path;
-    } else if (SOH_GetComboSpoilerPath) {
-        const char* remembered = SOH_GetComboSpoilerPath();
-        if (remembered)
-            file = remembered;
-    }
-    if (file.empty())
-        return 0; // nothing generated yet on this install
-    std::ifstream in(file);
-    if (!in.is_open())
-        return 0;
+    nlohmann::json j;
+    // The resolve/scan below touches the filesystem and may throw (path conversion, bad_alloc); this
+    // runs under a C-ABI callback, so nothing may unwind past it.
     try {
-        nlohmann::json j;
-        in >> j;
-        if (j.value("fileType", std::string()) != "ComboShipRandomizer")
-            return 0;
+        if (!isSilentAutoLoad) {
+            // An explicit drop never falls back to another seed: a failed drop is a real error.
+            auto dropped = ResolveComboSeedPath(path);
+            if (!TryLoadComboSeedFile(dropped, j)) {
+                std::cerr << "[ComboShip] reload: dropped file '" << path << "' could not be loaded\n";
+                return 0;
+            }
+            file = dropped.string();
+        } else {
+            std::string remembered = SOH_GetComboSpoilerPath ? SOH_GetComboSpoilerPath() : "";
+            if (remembered.empty()) {
+                std::cerr << "[ComboShip] reload: no remembered seed path — scanning "
+                          << ComboRando::ConsolidatedDir().string() << "\n";
+            } else {
+                auto resolved = ResolveComboSeedPath(remembered);
+                if (TryLoadComboSeedFile(resolved, j))
+                    file = resolved.string();
+                else
+                    std::cerr << "[ComboShip] reload: remembered seed '" << remembered
+                              << "' is missing or unreadable — scanning " << ComboRando::ConsolidatedDir().string()
+                              << "\n";
+            }
+            if (file.empty()) {
+                auto recovered = FindNewestComboSeed(j);
+                if (recovered.empty()) {
+                    std::cerr << "[ComboShip] reload: no combo seed found to auto-load\n";
+                    return 0;
+                }
+                file = recovered.string();
+                std::cout << "[ComboShip] reload: recovered newest seed " << file << "\n";
+                RememberComboSpoiler(recovered); // repair the lost/stale remembered path
+            }
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "[ComboShip] reload: seed lookup failed: " << e.what() << "\n";
+        return 0;
+    } catch (...) {
+        std::cerr << "[ComboShip] reload: seed lookup failed: non-std exception\n";
+        return 0;
+    }
+    try {
         uint32_t masterSeed = j.value("masterSeed", 0u);
         ResetCrossItemDedupForSeed(masterSeed);
         uint32_t displaySeed = j.value("displaySeed", 0u);
@@ -2087,6 +2184,9 @@ static int Combo_OnReloadRequest(const char* path) {
         return 1;
     } catch (const std::exception& e) {
         std::cerr << "[ComboShip] reload failed: " << e.what() << "\n";
+        return 0;
+    } catch (...) {
+        std::cerr << "[ComboShip] reload failed: non-std exception\n";
         return 0;
     }
 }

--- a/combo/rando/ComboPlaythrough.h
+++ b/combo/rando/ComboPlaythrough.h
@@ -232,13 +232,15 @@ struct RequirednessResult {
 // goal => NOT required (foolish), else required (WotH). Tested individually (no monotonicity assumed),
 // restricted to the winning playthrough's checks. mmRestore resets the MM oracle snapshot afterward.
 // ootCheckAreas/mmCheckAreas (checkName -> area) roll results up into per-area classification.
+// progress (optional) is write-only reporting for the UI; it never influences the result.
 inline RequirednessResult PareDownPlaythrough(const std::string& spoilerJson, const OracleFns& ootOracle,
                                               const OracleFns& mmOracle, void (*mmRestore)(),
                                               const std::string& sohDumpJson = "", const std::string& mmDumpJson = "",
                                               const std::unordered_map<std::string, std::string>& ootCheckAreas = {},
                                               const std::unordered_map<std::string, std::string>& mmCheckAreas = {},
                                               GoalPredicate goalReached = DefaultGanonMajoraGoal,
-                                              bool portalGated = true, bool mmStart = false) {
+                                              bool portalGated = true, bool mmStart = false,
+                                              ComboGenProgress* progress = nullptr) {
     RequirednessResult result;
     auto placements = ParseSpoilerPlacements(spoilerJson, sohDumpJson, mmDumpJson);
 
@@ -325,6 +327,11 @@ inline RequirednessResult PareDownPlaythrough(const std::string& spoilerJson, co
             classified[i] = 1;
     }
     result.candidateCount = static_cast<int>(cand.size());
+    // The pare-down owns the "Finalizing" bar: restart placed/total over the candidate replays.
+    if (progress) {
+        progress->total.store(result.candidateCount);
+        progress->placed.store(0);
+    }
 
     // Per-item WotH (native IsBeatableWithout): blank exactly one candidate check and replay from
     // empty. Still wins -> not required; loses -> required. Definitionally correct, no monotonicity
@@ -332,6 +339,8 @@ inline RequirednessResult PareDownPlaythrough(const std::string& spoilerJson, co
     for (size_t i : cand) {
         ++result.replayedCount;
         classified[i] = winsWithout({ i }, nullptr) ? 0 : 1;
+        if (progress)
+            progress->placed.fetch_add(1);
     }
 
     for (size_t pi : candAll) {

--- a/combo/rando/CrossWorldRando.h
+++ b/combo/rando/CrossWorldRando.h
@@ -1082,8 +1082,10 @@ inline CombinedFillResult CrossWorldCombinedFill(
     }
 
     if (progress) {
-        progress->placed.store(progress->total.load()); // all placed
-        progress->phase.store(3);                       // Finalizing
+        progress->phase.store(3); // Finalizing
+        // Zero the bar: post-fill work (the pare-down) re-stores its own placed/total.
+        progress->placed.store(0);
+        progress->total.store(0);
     }
 
     // --- Build spoiler (same shape as the no-logic generator) ---

--- a/soh/soh/Enhancements/FileSelectEnhancements.cpp
+++ b/soh/soh/Enhancements/FileSelectEnhancements.cpp
@@ -62,6 +62,17 @@ std::array<std::string, LANGUAGE_MAX> RandomizerSettingsMenuText[RSM_MAX] = {
       "\nou glissez un spoilerlog sur la fenêtre du jeu."
 #endif
     },
+#ifdef COMBO_BUILD
+    // ComboShip: post-fill phase of a combo generation (its own 0-100%).
+    {
+        // English
+        "Finalizing...",
+        // German
+        "Abschließen...",
+        // French
+        "Finalisation...",
+    },
+#endif
 };
 
 const char* SohFileSelect_GetSettingText(uint8_t optionIndex, uint8_t language) {

--- a/soh/soh/Enhancements/FileSelectEnhancements.h
+++ b/soh/soh/Enhancements/FileSelectEnhancements.h
@@ -18,6 +18,9 @@ typedef enum {
     RSM_OPEN_RANDOMIZER_SETTINGS,
     RSM_GENERATING,
     RSM_NO_RANDOMIZER_GENERATED,
+#ifdef COMBO_BUILD
+    RSM_FINALIZING, // ComboShip: post-fill generation phase (see SOH_GetComboGenPhase)
+#endif
     RSM_MAX,
 } RandomizerSettingsMenuEnums;
 

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -4794,6 +4794,12 @@ extern "C" __declspec(dllexport) int SOH_GetComboGenPercent(void) {
     return total > 0 ? static_cast<int>((100LL * placed) / total) : 0;
 }
 
+// Current generation phase (ComboGenProgress: 0 Idle, 1 Preparing, 2 Placing, 3 Finalizing), so the
+// C file-select can label the post-fill work instead of showing "Generating..." forever.
+extern "C" __declspec(dllexport) int SOH_GetComboGenPhase(void) {
+    return gComboProgressPtr ? gComboProgressPtr->phase.load() : 0;
+}
+
 extern "C" __declspec(dllexport) void SOH_SetOnComboFinalizeCallback(int (*cb)()) {
     gComboFinalizeCallback = cb;
 }

--- a/soh/soh/OTRGlobals.h
+++ b/soh/soh/OTRGlobals.h
@@ -134,6 +134,7 @@ void Randomizer_ShowRandomizerMenu();
 void SOH_TriggerComboGenerate(void);
 int SOH_PollComboFinalize(void);
 int SOH_GetComboGenPercent(void);
+int SOH_GetComboGenPhase(void);
 uint8_t SOH_IsOnFileSelect(void);
 // Open the combo menu on the Randomizer tab (file-select "Open Randomizer Settings").
 void SOH_OpenComboRandoSettings(void);

--- a/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/soh/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -365,6 +365,11 @@ void DrawSeedHashSprites(FileChooseContext* this) {
 u8 generating;
 int retries = 0;
 bool fileSelectSpoilerFileLoaded = false;
+#ifdef COMBO_BUILD
+// ComboShip: one combo seed auto-reload attempt per file-select entry (file IO, so never per frame);
+// FileChoose_Init clears it so a failure or a save-load context reset gets another try on re-entry.
+static u8 sComboReloadTried = 0;
+#endif
 
 void FileChoose_UpdateRandomizer() {
     if (CVarGetInteger(CVAR_GENERAL("RandoGenerating"), 0) != 0 && generating == 0) {
@@ -397,13 +402,14 @@ void FileChoose_UpdateRandomizer() {
     // regenerating. A dropped combo spoiler (flagged by Rando_HandleSpoilerDrop) takes priority and
     // overrides the remembered pending seed; otherwise, on the first frame with nothing loaded, reload
     // the remembered pending seed (no-op if none).
-    static u8 sComboReloadTried = 0;
     const char* comboDrop = CVarGetString(CVAR_GENERAL("ComboDroppedFile"), "");
     if (!Ship_IsCStringEmpty(comboDrop)) {
         Sfx_PlaySfxCentered(SOH_RequestComboReload(comboDrop) ? NA_SE_SY_CORRECT_CHIME : NA_SE_SY_ERROR);
         CVarSetString(CVAR_GENERAL("ComboDroppedFile"), "");
         sComboReloadTried = 1;
     } else if (!sComboReloadTried && !Randomizer_IsSeedGenerated() && !Randomizer_IsSpoilerLoaded()) {
+        // Latch before the call so a failure can't retry every frame; a success needs no latch of its
+        // own — the seed-generated check above stops re-entry from reloading what's already loaded.
         sComboReloadTried = 1;
         SOH_RequestComboReload(NULL);
     }
@@ -1884,7 +1890,12 @@ void FileChoose_DrawWindowContents(GameState* thisx) {
 
         // Show text to indicate randomizer is being generated.
         if (generating) {
-            Interface_DrawTextLine(this->state.gfxCtx, SohFileSelect_GetSettingText(RSM_GENERATING, language), 70,
+            u8 comboLabel = RSM_GENERATING;
+#ifdef COMBO_BUILD
+            // ComboShip: phase 3 (post-fill work) gets its own label and percent.
+            comboLabel = (SOH_GetComboGenPhase() == 3) ? RSM_FINALIZING : RSM_GENERATING;
+#endif
+            Interface_DrawTextLine(this->state.gfxCtx, SohFileSelect_GetSettingText(comboLabel, language), 70,
                                    (80 + 64), 255, 255, 255, textAlpha, 0.8f, true);
 #ifdef COMBO_BUILD
             // ComboShip: live combo-generation progress (worker thread keeps the main loop running).
@@ -3162,6 +3173,9 @@ void FileChoose_Init(GameState* thisx) {
     this->questType[1] = MIN_QUEST;
     this->questType[2] = MIN_QUEST;
     fileSelectSpoilerFileLoaded = false;
+#ifdef COMBO_BUILD
+    sComboReloadTried = 0; // ComboShip: one combo auto-reload attempt per entry (see the flag's comment)
+#endif
     CVarSetInteger(CVAR_GENERAL("OnFileSelectNameEntry"), 0);
 
     SREG(30) = 1;


### PR DESCRIPTION
Playtest follow-ups.

**Bug: "No randomizer seed loaded" despite previously generated seeds.** The silent auto-reload was a one-shot per process, latched before knowing whether it worked, with seven silent failure paths — and the remembered spoiler path was CWD-relative, so a different launch directory (or a lost CVar key) left seeds on disk unloadable. Now:
- the reload retries once per file-select entry (a save-load resetting the rando context gets another attempt on return; never per-frame IO)
- the remembered path is stored absolute and re-resolved against the exe directory (wide-char, non-ASCII installs included)
- when the remembered path is lost or stale, the newest `fileType == ComboShipRandomizer` JSON in `Randomizer/` is loaded and the CVar repaired; explicit drops never fall back
- every failure path logs one `[ComboShip] reload:` line

**Suggestion: "Finalizing..." with its own 0-100%.** The bar used to sit at 100% while the playthrough pare-down ran (the dominant post-fill cost). `PareDownPlaythrough` now reports progress through the existing `ComboGenProgress` phase machinery, and OOT's file select switches to a `Finalizing...` label with a percent that restarts at 0. The comboui progress panel already rendered phase labels and benefits automatically. MM hosts no generation UI (verified) — no MM changes.

Headless-verified: determinism byte-identical across the progress plumbing, playthrough PASS; path-resolution helpers exercised against foreign CWDs and a moved install via a scratch harness. UNPLAYTESTED in-game.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9310202683.zip)
<!--- section:artifacts:end -->