### PR TITLE
Item tracker: settings reachability, OOT/MM icon parity, shared paused-only toggle

### DIFF
--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -600,7 +600,7 @@ void DrawTrackerSharedPanel() {
         bool appearanceChanged = false;
         int px = CVarGetInteger("gCombo.Tracker.IconSize", ComboTracker::kDefaultIconSize);
         ComboRando::ComboMenu_PushSlider(theme);
-        if (ImGui::SliderInt("Icon size (px)", &px, 16, 64)) {
+        if (ImGui::SliderInt("Icon size (px)", &px, 16, 128)) {
             CVarSetInteger("gCombo.Tracker.IconSize", px);
             appearanceChanged = true;
         }
@@ -632,7 +632,15 @@ void DrawTrackerSharedPanel() {
             CVarSetInteger("gCombo.Tracker.Draggable", dragB ? 1 : 0);
             appearanceChanged = true;
         }
+        bool pausedB = CVarGetInteger("gCombo.Tracker.OnlyPaused", ComboTracker::kDefaultOnlyPaused) != 0;
+        if (ImGui::Checkbox("Only enable while paused", &pausedB)) {
+            CVarSetInteger("gCombo.Tracker.OnlyPaused", pausedB ? 1 : 0);
+            appearanceChanged = true;
+        }
         ComboRando::ComboMenu_PopCheckbox();
+        if (pausedB && wt != 0) {
+            ImGui::TextDisabled("Ocarina of Time only honors this with the floating tracker.");
+        }
         if (appearanceChanged) {
             ComboTracker::SyncAppearance();
             changed = true;

--- a/combo/gui/ComboTrackerBridge.cpp
+++ b/combo/gui/ComboTrackerBridge.cpp
@@ -51,6 +51,18 @@ void ComboTracker::SyncAppearance() {
     CVarSetInteger("gTrackers.ItemTracker.Draggable", drag);
     CVarSetInteger("gSettings.ItemTracker.Draggable", drag);
 
+    // Only while paused: OOT has a bool (effective in floating mode only, upstream); MM expresses it
+    // as VisibilityMode 1 — its button modes (2/3) aren't reachable from the shared toggle.
+    // Arrived after the first-run seed — latch separately, adopting OOT's bool (MM's 2/3 don't map).
+    if (!CVarGetInteger("gCombo.Tracker.OnlyPausedSeeded", 0)) {
+        CVarSetInteger("gCombo.Tracker.OnlyPausedSeeded", 1);
+        CVarSetInteger("gCombo.Tracker.OnlyPaused",
+                       CVarGetInteger("gTrackers.ItemTracker.ShowOnlyPaused", kDefaultOnlyPaused));
+    }
+    int onlyPaused = CVarGetInteger("gCombo.Tracker.OnlyPaused", kDefaultOnlyPaused) != 0 ? 1 : 0;
+    CVarSetInteger("gTrackers.ItemTracker.ShowOnlyPaused", onlyPaused);
+    CVarSetInteger("gSettings.ItemTracker.VisibilityMode", onlyPaused);
+
     // Check Tracker window type (0 = floating overlay, 1 = window): OOT native; MM's tracker has
     // no native window-type CVar — its COMBO_BUILD seam reads the canonical CVar directly.
     if (!CVarGetInteger("gCombo.CheckTracker.Seeded", 0)) {

--- a/combo/gui/ComboTrackerBridge.h
+++ b/combo/gui/ComboTrackerBridge.h
@@ -19,6 +19,7 @@ inline constexpr int kDefaultIconSpacing = 12;
 inline constexpr float kDefaultOpacity = 0.0f;
 inline constexpr int kDefaultWindowType = 0;
 inline constexpr int kDefaultDraggable = 1;
+inline constexpr int kDefaultOnlyPaused = 0;
 inline constexpr int kDefaultCheckWindowType = 1; // TRACKER_WINDOW_WINDOW — OOT's check tracker default
 
 // Push all canonical gCombo.Tracker.* values into both games' CVars (seeding them from OOT on

--- a/docs/deviations/tracker.md
+++ b/docs/deviations/tracker.md
@@ -179,3 +179,51 @@ adds canonical `gCombo.Tracker.IconSpacing` (separately seeded) and flips Dragga
   check has no OOT flag to promote it back from SCUMMED).
 - `soh/.../SeedContext.cpp` — WARN tripwires in `ItemReset`/`ClearItemLocations` when called with
   a save loaded (suspected mid-session wipe path; not yet root-caused).
+
+## Item Tracker settings: flat layout, icon-size parity, shared paused-only (2026-08-18)
+
+**Why:** (1) MM's `ItemTrackerSettingsWindow::DrawElement` wrapped everything in auto-sized
+`BeginChild`s. Embedded inline in the combo Settings hub the outer child only gets the parent's
+leftover height, so the group Available/Active lists (and the reorder chevrons / per-group options)
+were unreachable even though the hub scrolls. (2) Both games still exposed their own icon
+size/spacing editors, which the bridge silently overwrites at the next `SyncAppearance`. (3) MM's
+split-window-group mode used the per-group `scale` *instead of* the global one, so MM icons jumped
+to their 46px base while OOT sat at the shared 36px.
+
+**Combo-owned:** `ComboMenu.cpp` — shared "Icon size" max widened 64 → 128 (covers OOT's old
+range), new "Only enable while paused" checkbox + a hint when the window type is Window.
+`ComboTrackerBridge.{h,cpp}` — canonical `gCombo.Tracker.OnlyPaused` (default 0) mirrored into
+`gTrackers.ItemTracker.ShowOnlyPaused` and `gSettings.ItemTracker.VisibilityMode` (0/1).
+
+**Vendored — guard-free (equivalent-or-better standalone):**
+- `mm/.../ItemTrackerSettings.cpp` — `DrawElement` / `DrawTrackerAvailableGroups` /
+  `DrawTrackerActiveGroups` lay out flat, like SoH's item-tracker settings: the outer, per-column
+  and per-list `BeginChild`s are gone, so content extends the parent and the *window* scrolls when
+  popped out. The two lists regained ID scoping via `PushID` (they were previously separated by
+  their child windows, and ImGui table cells do not scope IDs). The right-aligned group buttons
+  now use a cursor-relative helper — `SameLine(absolute_x)` is cell-relative while
+  `GetContentRegionMax()` is window-relative, so the old form would have flown off-screen in the
+  second table column. The dead `SetNextWindowSize` before the removed outer child went with it
+  (`BeginChildEx` always overrides it; the popout's size comes from its `GuiWindow` registration).
+- `mm/.../ItemTracker.cpp` — `DrawItemCounts` restores `SetWindowFontScale(1.0f)`; it is
+  window-wide state and leaked into every widget drawn after a counted icon.
+
+**Vendored (`COMBO_BUILD`-guarded):**
+- `mm/.../ItemTracker.cpp` — new `GetItemTrackerGroupScale()`; in combo the effective scale is
+  `global × group.scale`, making the per-group scale a relative multiplier (1.0 = parity with OOT).
+  Standalone keeps the either/or.
+- `mm/.../ItemTrackerSettings.cpp` — global `Scale` slider and `Visibility` combobox hidden (combo
+  owns both); per-group scale slider relabelled "Group scale (x global)" with a 0.05 step (0.5
+  steps would snap the bridge-derived 0.7826 to 0.5/1.0); the Available/Active preview grids draw
+  at `min(effective scale, 1.0)` instead of a hardcoded 1.0.
+- `soh/.../randomizer_item_tracker.cpp` — "Icon size"/"Icon margins" sliders and the "Only Enable
+  While Paused" checkbox hidden (all three are bridge-derived).
+
+**Residuals (accepted):**
+- MM's Button Toggle / Button Hold visibility modes (2/3) are unreachable in combo builds — the
+  shared toggle only expresses Always (0) and Only-on-pause (1), and `SyncAppearance` forces one of
+  those every sync.
+- OOT's `ShowOnlyPaused` is a no-op when the tracker window type is Window rather than Floating
+  (pre-existing upstream nesting); MM honors paused-only in both. The shared panel says so inline.
+- The per-group scale is still MM-only; OOT has no equivalent, so a non-1.0 group scale breaks
+  cross-game icon parity by design.

--- a/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.cpp
@@ -308,6 +308,7 @@ void DrawItemCounts(TrackerItemType itemType, u32 itemId, ImVec2 textureSize, fl
     ImGui::SetCursorPos(textPos);
     ImGui::SetWindowFontScale(scale);
     ImGui::Text("%s", itemCount.c_str());
+    ImGui::SetWindowFontScale(1.0f); // ComboShip: window-wide state — don't leak it to later widgets.
 }
 
 bool DrawItemTrackerSlot(TrackerItemType itemType, u32 itemId, float scale, bool clickable) {
@@ -424,15 +425,25 @@ bool DrawItemTrackerSlot(TrackerItemType itemType, u32 itemId, float scale, bool
     return clicked;
 }
 
+// Effective icon scale for a group. In combo builds the global Scale is combo-owned (mirrored by
+// ComboTrackerBridge) and a group's own scale is a relative multiplier instead of a replacement.
+float GetItemTrackerGroupScale(const TrackerGroup& trackerGroup) {
+    float global = CVarGetFloat("gSettings.ItemTracker.Scale", 1.0f);
+    bool split = CVarGetInteger("gSettings.ItemTracker.WindowGroup", 0) != 0;
+#ifdef COMBO_BUILD
+    return split ? global * trackerGroup.scale : global;
+#else
+    return split ? trackerGroup.scale : global;
+#endif
+}
+
 void DrawItemTrackerGroup(TrackerGroup& trackerGroup) {
     int columns = trackerGroup.columns;
     if (trackerGroup.items.size() < trackerGroup.columns) {
         columns = trackerGroup.items.size();
     }
 
-    float scale = CVarGetInteger("gSettings.ItemTracker.WindowGroup", 0)
-                      ? trackerGroup.scale
-                      : CVarGetFloat("gSettings.ItemTracker.Scale", 1.0f);
+    float scale = GetItemTrackerGroupScale(trackerGroup);
 
 #ifdef COMBO_BUILD
     // ComboShip: the seam's cell pad is the whole gap — zero the table's own CellPadding

--- a/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.h
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.h
@@ -36,6 +36,7 @@ typedef struct {
 extern std::vector<TrackerGroup> itemTrackerGroups;
 extern bool DrawItemTrackerSlot(TrackerItemType itemType, u32 itemId, float scale, bool clickable);
 extern std::string GetItemTrackerItemName(TrackerItemType itemType, u32 itemId);
+extern float GetItemTrackerGroupScale(const TrackerGroup& trackerGroup);
 
 class ItemTrackerWindow : public Ship::GuiWindow {
   public:

--- a/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTrackerSettings.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTrackerSettings.cpp
@@ -113,6 +113,13 @@ struct DragDropPayload {
 void DrawItemTrackerGroupPreview(TrackerGroup& group, bool addMode, int groupIndex) {
     static std::pair<TrackerItemType, u32> selectedItem = { TRACKER_ITEM_RANDO, 0 };
 
+    float previewScale = 1.0f;
+#ifdef COMBO_BUILD
+    // ComboShip: preview at the tracker's real icon size (combo's is below MM's 46px base), capped
+    // so a large group scale can't bloat the settings block.
+    previewScale = std::min(GetItemTrackerGroupScale(group), 1.0f);
+#endif
+
     if (ImGui::BeginChild(group.name.c_str(), ImVec2(0, 0),
                           ImGuiChildFlags_AlwaysAutoResize | ImGuiChildFlags_AutoResizeX |
                               ImGuiChildFlags_AutoResizeY)) {
@@ -125,7 +132,7 @@ void DrawItemTrackerGroupPreview(TrackerGroup& group, bool addMode, int groupInd
                 auto& [itemType, itemId] = group.items[itemIndex];
                 ImGui::TableNextColumn();
                 ImGui::PushID((int)itemIndex);
-                if (DrawItemTrackerSlot(itemType, itemId, 1.0f, true)) {
+                if (DrawItemTrackerSlot(itemType, itemId, previewScale, true)) {
                     if (addMode) {
                         selectedItem = { itemType, itemId };
                         ImGui::OpenPopup("AddToGroup");
@@ -148,7 +155,7 @@ void DrawItemTrackerGroupPreview(TrackerGroup& group, bool addMode, int groupInd
                     ImGui::SetDragDropPayload("TRACKER_ITEM", &payload, sizeof(DragDropPayload));
 
                     // Display preview while dragging
-                    DrawItemTrackerSlot(itemType, itemId, 0.5f, true);
+                    DrawItemTrackerSlot(itemType, itemId, previewScale * 0.5f, true);
                     ImGui::EndDragDropSource();
                 }
 
@@ -246,14 +253,23 @@ bool DrawTrackerWindowOptions(int32_t windowIndex, TrackerGroup& group) {
         SaveItemTrackerLayout();
     }
     if (CVarGetInteger("gSettings.ItemTracker.WindowGroup", 0)) {
+#ifdef COMBO_BUILD
+        // ComboShip: combo owns the global scale, so this one is a multiplier on top of it — finer
+        // step, since 0.5 steps would be a huge jump relative to the shared icon size.
+        const char* scaleFormat = "Group scale (x global): %.2f";
+        const float scaleStep = 0.05f;
+#else
+        const char* scaleFormat = "Scale: %.1f";
+        const float scaleStep = 0.5f;
+#endif
         if (UIWidgets::SliderFloat("Scale", &scale,
                                    UIWidgets::FloatSliderOptions()
                                        .Min(0.2f)
                                        .Max(3.0f)
                                        .DefaultValue(1.0f)
                                        .LabelPosition(UIWidgets::LabelPosition::None)
-                                       .Format("Scale: %.1f")
-                                       .Step(0.5f)
+                                       .Format(scaleFormat)
+                                       .Step(scaleStep)
                                        .Color(WIDGET_COLOR))) {
             group.scale = scale;
             SaveItemTrackerLayout();
@@ -533,11 +549,14 @@ void DrawTrackerOptions() {
                                 UIWidgets::ComboboxOptions()
                                     .ComponentAlignment(UIWidgets::ComponentAlignment::Right)
                                     .LabelPosition(UIWidgets::LabelPosition::Far));
+#ifndef COMBO_BUILD
+        // ComboShip: visibility is derived from the shared "Only enable while paused" toggle.
         UIWidgets::CVarCombobox("Visibility", CVAR_NAME_VISIBILITY_MODE, &sItemTrackerVisibilityModes,
                                 UIWidgets::ComboboxOptions()
                                     .DefaultIndex(ITEM_TRACKER_VISIBILITY_MODE_ALWAYS)
                                     .ComponentAlignment(UIWidgets::ComponentAlignment::Right)
                                     .LabelPosition(UIWidgets::LabelPosition::Far));
+#endif
         if (CVAR_VISIBILITY_MODE == ITEM_TRACKER_VISIBILITY_MODE_BUTTON_TOGGLE ||
             CVAR_VISIBILITY_MODE == ITEM_TRACKER_VISIBILITY_MODE_BUTTON_HOLD) {
             UIWidgets::CVarBtnSelector("Button Combination:", CVAR_NAME_VISIBILITY_BTN,
@@ -551,6 +570,8 @@ void DrawTrackerOptions() {
             SaveItemTrackerLayout();
         }
 
+#ifndef COMBO_BUILD
+        // ComboShip: the global scale is derived from the shared "Icon size" slider — hide this editor.
         if (!CVarGetInteger("gSettings.ItemTracker.WindowGroup", 0)) {
             UIWidgets::CVarSliderFloat("Scale", "gSettings.ItemTracker.Scale",
                                        UIWidgets::FloatSliderOptions()
@@ -562,6 +583,7 @@ void DrawTrackerOptions() {
                                            .Step(0.5f)
                                            .Color(WIDGET_COLOR));
         }
+#endif
 
         UIWidgets::CVarSliderFloat("Opacity", "gSettings.ItemTracker.Opacity",
                                    UIWidgets::FloatSliderOptions()
@@ -594,102 +616,101 @@ void DrawTrackerOptions() {
     }
 }
 
+// Right-align the next widget on the line just ended, given that line's start-of-line right edge.
+// (Cell-safe: SameLine(absolute_x) is relative to the cell, GetContentRegionMax() is not.)
+static void TrackerGroupRowAlignRight(float rowRightX, float widgetWidth) {
+    ImGui::SameLine();
+    ImGui::SetCursorPosX(rowRightX - widgetWidth);
+}
+
 void DrawTrackerAvailableGroups() {
-    if (ImGui::BeginChild("Available Groups")) {
-        int groupIndex = 0;
-        for (auto& group : itemTrackerGroupsAvailable) {
-            ImGui::PushID(groupIndex);
-            ImGui::SeparatorText(group.name.c_str());
-            ImGui::SameLine(ImGui::GetContentRegionMax().x - (ImGui::CalcTextSize("aaa").x * 1.5f));
-            if (UIWidgets::Button(ICON_FA_PLUS, { .size = ImVec2(0, 0), .color = UIWidgets::Colors::Green })) {
-                itemTrackerGroups.push_back(group);
-                SaveItemTrackerLayout();
-            }
-            DrawItemTrackerGroupPreview(group, true, groupIndex);
-            ImGui::PopID();
-            groupIndex++;
+    ImGui::PushID("AvailableGroups"); // was a BeginChild; keeps this list's IDs distinct
+    int groupIndex = 0;
+    for (auto& group : itemTrackerGroupsAvailable) {
+        ImGui::PushID(groupIndex);
+        float rowRightX = ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x;
+        ImGui::SeparatorText(group.name.c_str());
+        TrackerGroupRowAlignRight(rowRightX, ImGui::CalcTextSize("aaa").x * 1.5f);
+        if (UIWidgets::Button(ICON_FA_PLUS, { .size = ImVec2(0, 0), .color = UIWidgets::Colors::Green })) {
+            itemTrackerGroups.push_back(group);
+            SaveItemTrackerLayout();
         }
+        DrawItemTrackerGroupPreview(group, true, groupIndex);
+        ImGui::PopID();
+        groupIndex++;
     }
-    ImGui::EndChild();
+    ImGui::PopID();
 }
 
 void DrawTrackerActiveGroups() {
-    if (ImGui::BeginChild("Active Groups")) {
-        int groupIndex = 0;
-        for (auto& group : itemTrackerGroups) {
-            ImGui::PushID(groupIndex);
-            ImGui::SeparatorText(group.name.c_str());
+    ImGui::PushID("ActiveGroups"); // was a BeginChild; keeps this list's IDs distinct
+    int groupIndex = 0;
+    for (auto& group : itemTrackerGroups) {
+        ImGui::PushID(groupIndex);
+        float rowRightX = ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x;
+        ImGui::SeparatorText(group.name.c_str());
 
-            ImGui::SameLine(ImGui::GetContentRegionMax().x - (ImGui::CalcTextSize("aaaaaaaaa").x * 1.5f));
-            if (UIWidgets::Button(ICON_FA_CHEVRON_UP, { .size = ImVec2(0, 0), .color = WIDGET_COLOR })) {
-                if (groupIndex > 0) {
-                    std::swap(itemTrackerGroups[groupIndex], itemTrackerGroups[groupIndex - 1]);
-                    SaveItemTrackerLayout();
-                }
+        TrackerGroupRowAlignRight(rowRightX, ImGui::CalcTextSize("aaaaaaaaa").x * 1.5f);
+        if (UIWidgets::Button(ICON_FA_CHEVRON_UP, { .size = ImVec2(0, 0), .color = WIDGET_COLOR })) {
+            if (groupIndex > 0) {
+                std::swap(itemTrackerGroups[groupIndex], itemTrackerGroups[groupIndex - 1]);
+                SaveItemTrackerLayout();
             }
-            ImGui::SameLine();
-            if (UIWidgets::Button(ICON_FA_CHEVRON_DOWN, { .size = ImVec2(0, 0), .color = WIDGET_COLOR })) {
-                if (groupIndex < static_cast<int>(itemTrackerGroups.size()) - 1) {
-                    std::swap(itemTrackerGroups[groupIndex], itemTrackerGroups[groupIndex + 1]);
-                    SaveItemTrackerLayout();
-                }
-            }
-            ImGui::SameLine();
-            if (UIWidgets::Button(ICON_FA_ELLIPSIS_H, { .size = ImVec2(0, 0), .color = UIWidgets::Colors::Gray })) {
-                ImGui::OpenPopup("GroupOptions");
-            }
-            ImGui::SetNextWindowSize(ImVec2(400, 0), ImGuiCond_Always);
-            ImGui::SetNextWindowPos(ImVec2(ImGui::GetItemRectMin().x - 400, ImGui::GetItemRectMin().y),
-                                    ImGuiCond_Always);
-            if (ImGui::BeginPopup("GroupOptions")) {
-                if (DrawTrackerWindowOptions(groupIndex, group)) {
-                    ImGui::CloseCurrentPopup();
-                }
-                ImGui::EndPopup();
-            }
-            DrawItemTrackerGroupPreview(group, false, groupIndex);
-            ImGui::PopID();
-            groupIndex++;
         }
+        ImGui::SameLine();
+        if (UIWidgets::Button(ICON_FA_CHEVRON_DOWN, { .size = ImVec2(0, 0), .color = WIDGET_COLOR })) {
+            if (groupIndex < static_cast<int>(itemTrackerGroups.size()) - 1) {
+                std::swap(itemTrackerGroups[groupIndex], itemTrackerGroups[groupIndex + 1]);
+                SaveItemTrackerLayout();
+            }
+        }
+        ImGui::SameLine();
+        if (UIWidgets::Button(ICON_FA_ELLIPSIS_H, { .size = ImVec2(0, 0), .color = UIWidgets::Colors::Gray })) {
+            ImGui::OpenPopup("GroupOptions");
+        }
+        ImGui::SetNextWindowSize(ImVec2(400, 0), ImGuiCond_Always);
+        ImGui::SetNextWindowPos(ImVec2(ImGui::GetItemRectMin().x - 400, ImGui::GetItemRectMin().y), ImGuiCond_Always);
+        if (ImGui::BeginPopup("GroupOptions")) {
+            if (DrawTrackerWindowOptions(groupIndex, group)) {
+                ImGui::CloseCurrentPopup();
+            }
+            ImGui::EndPopup();
+        }
+        DrawItemTrackerGroupPreview(group, false, groupIndex);
+        ImGui::PopID();
+        groupIndex++;
     }
-    ImGui::EndChild();
+    ImGui::PopID();
 }
 
+// Laid out flat (no auto-sized BeginChild wrappers, matching SoH's item-tracker settings): an
+// auto-sized child only gets the parent's leftover height, which hid the group lists when the
+// combo Settings hub embeds this inline. Popped out, the window itself scrolls.
 void ItemTrackerSettingsWindow::DrawElement() {
-    ImGui::SetNextWindowSize(ImVec2(733, 472), ImGuiCond_FirstUseEver);
-    if (ImGui::BeginChild("Item Tracker Settings")) {
-        DrawTrackerOptions();
+    DrawTrackerOptions();
 
-        UIWidgets::PushStyleTabs(WIDGET_COLOR);
-        if (ImGui::BeginTable("TrackerTabs", 2)) {
-            ImGui::TableNextColumn();
-            if (ImGui::BeginChild("TrackerChild")) {
-                if (ImGui::BeginTabBar("TrackerTabs")) {
-                    if (ImGui::BeginTabItem("Available Groups")) {
-                        DrawTrackerAvailableGroups();
-                        ImGui::EndTabItem();
-                    }
-                    ImGui::EndTabBar();
-                }
+    UIWidgets::PushStyleTabs(WIDGET_COLOR);
+    if (ImGui::BeginTable("TrackerTabs", 2)) {
+        ImGui::TableNextColumn();
+        if (ImGui::BeginTabBar("TrackerTabBar")) {
+            if (ImGui::BeginTabItem("Available Groups")) {
+                DrawTrackerAvailableGroups();
+                ImGui::EndTabItem();
             }
-            ImGui::EndChild();
-
-            ImGui::TableNextColumn();
-            if (ImGui::BeginChild("WindowChild")) {
-                if (ImGui::BeginTabBar("WindowTab")) {
-                    if (ImGui::BeginTabItem("Active Groups")) {
-                        DrawTrackerActiveGroups();
-                        ImGui::EndTabItem();
-                    }
-                    ImGui::EndTabBar();
-                }
-            }
-            ImGui::EndChild();
-            ImGui::EndTable();
+            ImGui::EndTabBar();
         }
-        UIWidgets::PopStyleTabs();
+
+        ImGui::TableNextColumn();
+        if (ImGui::BeginTabBar("WindowTab")) {
+            if (ImGui::BeginTabItem("Active Groups")) {
+                DrawTrackerActiveGroups();
+                ImGui::EndTabItem();
+            }
+            ImGui::EndTabBar();
+        }
+        ImGui::EndTable();
     }
-    ImGui::EndChild();
+    UIWidgets::PopStyleTabs();
 }
 
 void ItemTrackerSettingsWindow::InitElement() {

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -2107,10 +2107,13 @@ void ItemTrackerSettingsWindow::DrawElement() {
             if (CVarCheckbox("Enable Dragging", CVAR_TRACKER_ITEM("Draggable"), CheckboxOptions().Color(THEME_COLOR))) {
                 shouldUpdateVectors = true;
             }
+#ifndef COMBO_BUILD
+            // ComboShip: derived from the shared "Only enable while paused" toggle — hide this editor.
             if (CVarCheckbox("Only Enable While Paused", CVAR_TRACKER_ITEM("ShowOnlyPaused"),
                              CheckboxOptions().Color(THEME_COLOR))) {
                 shouldUpdateVectors = true;
             }
+#endif
             if (CVarCombobox("Display Mode", CVAR_TRACKER_ITEM("DisplayType.Main"), showMode,
                              ComboboxOptions()
                                  .DefaultIndex(TRACKER_DISPLAY_ALWAYS)
@@ -2140,10 +2143,13 @@ void ItemTrackerSettingsWindow::DrawElement() {
             }
         }
         ImGui::Separator();
+#ifndef COMBO_BUILD
+        // ComboShip: both are derived from the shared icon size/spacing sliders — hide these editors.
         CVarSliderInt("Icon size : %dpx", CVAR_TRACKER_ITEM("IconSize"),
                       IntSliderOptions().Min(25).Max(128).DefaultValue(36).Color(THEME_COLOR));
         CVarSliderInt("Icon margins : %dpx", CVAR_TRACKER_ITEM("IconSpacing"),
                       IntSliderOptions().Min(-5).Max(50).DefaultValue(12).Color(THEME_COLOR));
+#endif
         CVarSliderInt("Text size : %dpx", CVAR_TRACKER_ITEM("TextSize"),
                       IntSliderOptions().Min(1).Max(30).DefaultValue(13).Color(THEME_COLOR));
 


### PR DESCRIPTION
Playtest follow-ups to #145/#148.

**Bug: Settings → Item Tracker cut off at the bottom.** MM's settings drew inside five nested auto-sized `BeginChild`s, which can't grow inside the combo hub's scroll panel — the group-reordering UI was unreachable. The layout is now flat like OOT's (the hub scrollbar reaches everything; the popout window scrolls itself). Flattening required explicit `PushID` scoping for the two group lists and a table-cell-safe right-align helper for the row buttons.

**Bug: icon size/spacing parity.** OOT's own Icon size / Icon margins sliders were a second, one-way editor of the bridge-owned CVars (silently overwritten on every sync) — hidden in combo builds; the shared Icon size slider now spans 16–128. MM's split-group mode bypassed the global scale entirely (per-group default 1.0 → 46px vs OOT's 36px) — per-group scale is now a relative multiplier of the shared global scale. MM's own Scale slider (0.5-step quantizer) and Visibility combobox are hidden in combo builds; settings preview grids use the effective scale; a window-font-scale leak is fixed.

**Shared "Only enable while paused".** New combo toggle mirrored with full authority into OOT's `ShowOnlyPaused` and MM's `VisibilityMode` (0/1), seeded from an existing OOT setting on first run so upgrades don't reset it. The dormant-visibility gate from #148 honors it unchanged. Residuals (MM button-toggle/hold modes unselectable in combo builds; OOT's toggle is floating-mode-only upstream) documented in docs/deviations/tracker.md.

Code-walked both draw paths (inline hub + popout) and the scale math at defaults (36px both games, split on/off). UI change — UNPLAYTESTED; key things to check in-game: MM group reordering reachable in the hub, right-aligned row buttons in both table columns, icon parity with split groups on, paused-only gating both trackers incl. dormant.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9311057903.zip)
<!--- section:artifacts:end -->