### PR TITLE
Item tracker: MM group boundaries drift vs OOT grid

### DIFF
--- a/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.cpp
@@ -591,6 +591,13 @@ comboSkipVisibilityGates:;
 #endif
     }
 
+#ifdef COMBO_BUILD
+    // ComboShip: padded cells own the whole grid pitch — the window's ItemSpacing between group
+    // tables would add a per-group vertical drift vs OOT's continuous grid.
+    if (!shouldWindowSplit) {
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
+    }
+#endif
     uint32_t index = 0;
     for (auto& group : itemTrackerGroups) {
         if (group.items.empty()) {
@@ -624,6 +631,11 @@ comboSkipVisibilityGates:;
 
         index++;
     }
+#ifdef COMBO_BUILD
+    if (!shouldWindowSplit) {
+        ImGui::PopStyleVar();
+    }
+#endif
     if (!shouldWindowSplit) {
         ImGui::PopStyleColor(1);
         ImGui::End();


### PR DESCRIPTION
Playtest finding on #160: with the two trackers side by side, each MM group boundary sits slightly lower than OOT's grid, and the offset accumulates the more groups are shown.

Cause: OOT positions its whole tracker as one continuous grid (pitch = icon + spacing everywhere). MM draws one table per group and only zeroes `ItemSpacing` inside each table, so ImGui inserts the window `ItemSpacing.y` between tables - once per group boundary.

Fix: in single-window mode, zero `ItemSpacing` around the whole group loop so the padded cells own the entire pitch. Boundary gap becomes exactly IconSpacing, matching the within-group pitch and OOT. Split-window mode is unaffected.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9398853491.zip)
<!--- section:artifacts:end -->