### PR TITLE
fix(soh): embed Hint Tracker settings inline in combo menu

### DIFF
--- a/soh/soh/SohGui/SohMenuRandomizer.cpp
+++ b/soh/soh/SohGui/SohMenuRandomizer.cpp
@@ -974,6 +974,22 @@ void SohMenu::AddMenuRandomizer() {
         .WindowName("Hint Tracker Settings")
         .HideInSearch(true)
         .Options(WindowButtonOptions().Tooltip("Enables the separate Hint Tracker Settings Window."));
+#ifdef COMBO_BUILD
+    // ComboShip: embed the settings inline (see "Plandomizer Inline"); skipped while popped out.
+    AddWidget(path, "Hint Tracker Settings Inline", WIDGET_CUSTOM)
+        .RaceDisable(false)
+        .HideInSearch(true)
+        .CustomFunction([](WidgetInfo&) {
+            auto ctx = Ship::Context::GetRawInstance();
+            if (!ctx || !ctx->GetWindow() || !ctx->GetWindow()->GetGui())
+                return;
+            auto win = ctx->GetWindow()->GetGui()->GetGuiWindow("Hint Tracker Settings");
+            if (!win || win->IsVisible())
+                return;
+            win->Update();
+            win->DrawElement();
+        });
+#endif
 }
 
 } // namespace SohGui


### PR DESCRIPTION
Fixes #162.

In combo builds, comboui renders window buttons itself and never performs upstream's inline embed, so the Hint Tracker Settings section showed only the popout button. The Hint Tracker arrived in the 2026-07-13 upstream merge, after the inline shim was added to the other trackers, making it the only tracker missing the shim.

Adds the same COMBO_BUILD "Settings Inline" WIDGET_CUSTOM block used by the Check/Item/Entrance Tracker settings: draws the settings window inline while it is not popped out.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9399688806.zip)
<!--- section:artifacts:end -->