### PR TITLE
Combo-owned cross-game Hint Tracker

### DIFF
--- a/combo/CMakeLists.txt
+++ b/combo/CMakeLists.txt
@@ -37,6 +37,7 @@ set(COMBOUI_SOURCES
     gui/ComboTrackerSwap.cpp
     gui/ComboAudioBridge.cpp
     gui/ComboAnchorRoomWindow.cpp
+    gui/ComboHintTracker.cpp
 )
 add_library(comboui SHARED ${COMBOUI_SOURCES})
 set_target_properties(comboui PROPERTIES PREFIX "")

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -269,6 +269,15 @@ static FnComboUIRegister ComboUI_RestoreTrackerIntent = nullptr;
 typedef void (*FnComboUISetRosterProvider)(const char* (*)());
 static FnComboUISetRosterProvider ComboUI_SetAnchorRosterProvider = nullptr;
 
+// ComboShip (#164): combo Hint Tracker — push the slot's hints slice + read state into comboui, and
+// receive reveal reports back from both game DLLs.
+typedef void (*FnComboUISetHintTrackerData)(int, const char*, const char*);
+static FnComboUISetHintTrackerData ComboUI_SetHintTrackerData = nullptr;
+typedef void (*FnSetHintRevealOot)(void (*)(int, const char*));
+static FnSetHintRevealOot SOH_SetComboHintRevealCb = nullptr;
+typedef void (*FnSetHintRevealMm)(void (*)(int, int, int, const char*, const char*));
+static FnSetHintRevealMm MM_SetComboHintRevealCb = nullptr;
+
 // ComboShip-owned unified ROM extraction (see ComboExtract.h). The split init lets us create the
 // shared window from soh.o2r before any ROM exists, run the extraction screen, then finish.
 static FnVoid SOH_InitWindowOnly = nullptr;
@@ -428,14 +437,20 @@ static int Combo_TakeEvictionNotice() {
 }
 
 static void EraseComboContainer(int slot) {
-    std::lock_guard<std::mutex> lk(g_containerMutex);
-    g_containerCache.erase(slot);
-    // MM's dormant save is now stale: leave it marked resident and the next load skips re-reading it,
-    // and any dormant MM write would put the erased save back into the slot.
-    if (g_MmSaveInMemorySlot == slot)
-        g_MmSaveInMemorySlot = -1;
-    std::error_code ec;
-    std::filesystem::remove(ComboContainerPath(slot), ec);
+    {
+        std::lock_guard<std::mutex> lk(g_containerMutex);
+        g_containerCache.erase(slot);
+        // MM's dormant save is now stale: leave it marked resident and the next load skips re-reading it,
+        // and any dormant MM write would put the erased save back into the slot.
+        if (g_MmSaveInMemorySlot == slot)
+            g_MmSaveInMemorySlot = -1;
+        std::error_code ec;
+        std::filesystem::remove(ComboContainerPath(slot), ec);
+    }
+    // ComboShip (#164): clear the Hint Tracker outside the lock — its push path re-takes the mutex, and
+    // the window would otherwise keep showing the deleted slot's hints on the file-select screen.
+    if (ComboUI_SetHintTrackerData)
+        ComboUI_SetHintTrackerData(-1, "", "");
 }
 
 // Copy a whole slot (both games + baked rando) — OOT file-select "copy file". Registered into OOT
@@ -1104,6 +1119,94 @@ static void SaveComboCompletion(int slot) {
     c["combo"]["completion"]["triforce"] = g_comboTriforceDone;
     FlushContainer(slot);
 }
+
+// ComboShip (#164): push the slot's hints slice + read state into comboui's Hint Tracker. Reads the
+// container under the mutex, then calls out with it released (the DLL setters must never re-enter it).
+static void Combo_PushHintTrackerData(int slot) {
+    if (!ComboUI_SetHintTrackerData)
+        return;
+    if (!ComboIsValidSlot(slot)) {
+        ComboUI_SetHintTrackerData(-1, "", "");
+        return;
+    }
+    std::string hints, read;
+    {
+        std::lock_guard<std::mutex> lk(g_containerMutex);
+        auto& c = LoadOrCreateContainer(slot);
+        const auto combo = c.value("combo", nlohmann::json::object());
+        hints = combo.value("rando", nlohmann::json::object()).value("hints", nlohmann::json::object()).dump();
+        read = combo.value("hintsRead", nlohmann::json::object()).dump();
+    }
+    ComboUI_SetHintTrackerData(slot, hints.c_str(), read.c_str());
+}
+
+// Set-semantics insert into the container's combo.hintsRead[bucket]. Caller holds g_containerMutex.
+// matchField (object values only) compares just that member, so a varying sibling — an MM trap check's
+// re-rolled disguise text — can't add a duplicate entry per talk. First write wins.
+static bool ComboHintsReadInsert(nlohmann::json& c, const char* bucket, const nlohmann::json& value,
+                                 const char* matchField) {
+    nlohmann::json& arr = c["combo"]["hintsRead"][bucket];
+    if (!arr.is_array())
+        arr = nlohmann::json::array();
+    for (auto& e : arr) {
+        if (matchField ? e.value(matchField, std::string()) == value.value(matchField, std::string()) : e == value)
+            return false;
+    }
+    arr.push_back(value);
+    return true;
+}
+
+// Persist one reveal and re-push the read state. Runs on the reporting game's thread, so the container
+// write is mutex-guarded and the comboui push happens after the lock is released.
+static void Combo_RecordHintRead(int fileNum, const char* bucket, const nlohmann::json& value,
+                                 const char* matchField = nullptr) {
+    bool inserted = false;
+    {
+        std::lock_guard<std::mutex> lk(g_containerMutex);
+        auto& c = LoadOrCreateContainer(fileNum);
+        inserted = ComboHintsReadInsert(c, bucket, value, matchField);
+        if (inserted)
+            FlushContainer(fileNum);
+    }
+    if (inserted)
+        Combo_PushHintTrackerData(fileNum);
+}
+
+// OOT reported a revealed hint (keyed by the combo checkName it was applied from). OnRandoHintRevealed
+// can fire repeatedly per textbox — the set-semantics insert makes that free.
+static void Combo_OnOotHintRevealed(int fileNum, const char* comboKey) try {
+    if (!ComboIsValidSlot(fileNum) || !comboKey || comboKey[0] == '\0')
+        return;
+    Combo_RecordHintRead(fileNum, "oot", std::string(comboKey));
+} catch (const std::exception& e) {
+    std::cerr << "[ComboShip] Combo_OnOotHintRevealed threw: " << e.what() << std::endl;
+} catch (...) { std::cerr << "[ComboShip] Combo_OnOotHintRevealed threw a non-std exception" << std::endl; }
+
+// MM reported a revealed hint. kind: 0 = cross gossipPool pick (poolIndex), 1 = native MM stone hint
+// (no upfront list, so the tracker shows these as a revealed-only group), 2 = NPC itemLocations hint.
+static void Combo_OnMmHintRevealed(int fileNum, int kind, int poolIndex, const char* key, const char* text) try {
+    if (!ComboIsValidSlot(fileNum))
+        return;
+    switch (kind) {
+        case 0:
+            if (poolIndex >= 0)
+                Combo_RecordHintRead(fileNum, "mmPool", poolIndex);
+            return;
+        case 1:
+            if (key && key[0] != '\0')
+                Combo_RecordHintRead(fileNum, "mmNative",
+                                     nlohmann::json{ { "check", key }, { "text", text ? text : "" } }, "check");
+            return;
+        case 2:
+            if (key && key[0] != '\0')
+                Combo_RecordHintRead(fileNum, "mmNpc", std::string(key));
+            return;
+        default:
+            return;
+    }
+} catch (const std::exception& e) {
+    std::cerr << "[ComboShip] Combo_OnMmHintRevealed threw: " << e.what() << std::endl;
+} catch (...) { std::cerr << "[ComboShip] Combo_OnMmHintRevealed threw a non-std exception" << std::endl; }
 
 // Registered into both games: record THIS game's final-boss kill for its slot and return 1 iff BOTH
 // games' bosses are now dead. game/fileNum use the GameId convention (0=OOT, 1=MM).
@@ -2212,6 +2315,16 @@ static void Combo_OnOOTSaveInit(int fileNum) {
     // A new file starts in OOT. Explicit because not every delete path clears the container
     // (DeleteFileOnDeath calls DeleteZeldaFile directly), so a stale MM could otherwise survive here.
     Combo_SetLastGame(fileNum, ComboRando::GAME_OOT);
+    // ComboShip (#164): a fresh file must never inherit the previous one's hint read state. Unconditional
+    // — a slot whose container survived a delete path gets here with no pending seed to rebake.
+    {
+        std::lock_guard<std::mutex> lk(g_containerMutex);
+        auto& c = LoadOrCreateContainer(fileNum);
+        if (c.contains("combo") && c["combo"].is_object() && c["combo"].contains("hintsRead")) {
+            c["combo"].erase("hintsRead");
+            FlushContainer(fileNum);
+        }
+    }
     // ComboShip: bind the pending consolidated seed to this slot — bake it into the container's
     // combo.rando (self-contained), then push it into both DLLs so foreign data is live immediately.
     nlohmann::json seed;
@@ -2225,7 +2338,7 @@ static void Combo_OnOOTSaveInit(int fileNum) {
             if (!seed.is_null())
                 c["combo"]["rando"] = seed;
             // A rebaked slot is a NEW seed: a completed prior one must not instantly finish this hunt
-            // (or report both bosses already dead).
+            // (or report both bosses already dead). Hint read state is already cleared above.
             if (c.contains("combo") && c["combo"].is_object())
                 c["combo"].erase("completion");
             FlushContainer(fileNum);
@@ -2281,6 +2394,9 @@ static void Combo_OnOOTSaveInit(int fileNum) {
         std::cerr << "[ComboShip] ERROR: no consolidated seed for slot " << fileNum
                   << " — cannot create an MM rando save. Generate or load a seed first." << std::endl;
     }
+    // ComboShip (#164): the slot's hints are baked and its read state freshly erased — hand both to
+    // comboui's Hint Tracker.
+    Combo_PushHintTrackerData(fileNum);
     // The creation path builds the save in MM's live gSaveContext.
     g_MmSaveInMemorySlot = fileNum;
 }
@@ -2309,6 +2425,7 @@ static void Combo_OnOOTSaveLoad(int fileNum) {
                 MM_LoadComboRando(rando.c_str());
         }
     }
+    Combo_PushHintTrackerData(fileNum); // #164: this slot's hints + persisted read state
     if (!MM_LoadSaveForCombo || g_MmSaveInMemorySlot == fileNum) {
         Combo_OnTriforceProgress(0, fileNum);
         Combo_ResumeMMIfLastSavedThere(fileNum);
@@ -2510,6 +2627,9 @@ int main(int argc, char** argv) {
     SOH_DumpRandoHintData = (FnDumpData)GetSym(sohModule, "SOH_DumpRandoHintData");
     SOH_ApplyComboHints = (FnApplyHints)GetSym(sohModule, "SOH_ApplyComboHints");
     SOH_SetComboHintsPresent = (FnSetHintsPresent)GetSym(sohModule, "SOH_SetComboHintsPresent");
+    // #164: combo Hint Tracker reveal reporting.
+    SOH_SetComboHintRevealCb = (FnSetHintRevealOot)GetSym(sohModule, "SOH_SetComboHintRevealCb");
+    MM_SetComboHintRevealCb = (FnSetHintRevealMm)GetSym(mmModule, "MM_SetComboHintRevealCb");
     SOH_PrepRandoContext = (FnVoidV)GetSym(sohModule, "SOH_PrepRandoContext");
     SOH_RestoreRandoSettings = (FnTakeStr)GetSym(sohModule, "SOH_RestoreRandoSettings");
     MM_RestoreRandoSettings = (FnTakeStr)GetSym(mmModule, "MM_RestoreRandoSettings");
@@ -2794,6 +2914,11 @@ int main(int argc, char** argv) {
     if (SOH_SetCrossDeliver || MM_SetCrossDeliver) {
         std::cout << "[ComboShip] Cross-game item delivery seam registered." << std::endl;
     }
+    // #164: combo Hint Tracker — both games report a hint the moment it displays.
+    if (SOH_SetComboHintRevealCb)
+        SOH_SetComboHintRevealCb(Combo_OnOotHintRevealed);
+    if (MM_SetComboHintRevealCb)
+        MM_SetComboHintRevealCb(Combo_OnMmHintRevealed);
 
     // --- 4. Initialize OOT game ---
 
@@ -2827,6 +2952,7 @@ int main(int argc, char** argv) {
         ComboUI_RestoreTrackerIntent = (FnComboUIRegister)GetSym(comboUIModule, "ComboUI_RestoreTrackerIntent");
         ComboUI_SetAnchorRosterProvider =
             (FnComboUISetRosterProvider)GetSym(comboUIModule, "ComboUI_SetAnchorRosterProvider");
+        ComboUI_SetHintTrackerData = (FnComboUISetHintTrackerData)GetSym(comboUIModule, "ComboUI_SetHintTrackerData");
         if (ComboUI_SetAnchorRosterProvider)
             ComboUI_SetAnchorRosterProvider(&ComboAnchor::Combo_Anchor_GetRoster);
         if (ComboUI_Register) {

--- a/combo/gui/ComboHintTracker.cpp
+++ b/combo/gui/ComboHintTracker.cpp
@@ -1,0 +1,557 @@
+// combo/gui/ComboHintTracker.cpp — see ComboHintTracker.h
+#include "ComboHintTracker.h"
+#include "ComboForeground.h"  // foreground game for the OnlyPaused gate
+#include "ComboTrackerSwap.h" // ForegroundPaused (shared with the icon trackers)
+#include "ComboWidgetStyle.h"
+#include <imgui.h>
+#include <libultraship/libultraship.h> // CVar bridge
+#include <ship/Context.h>
+#include <ship/window/gui/IconsFontAwesome4.h>
+#include <nlohmann/json.hpp>
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace ComboRando {
+
+namespace {
+
+constexpr const char* kCvarEnabled = "gCombo.HintTracker.Enabled";
+constexpr const char* kCvarWindowType = "gCombo.HintTracker.WindowType";
+constexpr const char* kCvarOnlyPaused = "gCombo.HintTracker.OnlyPaused";
+constexpr const char* kCvarShowUnrevealed = "gCombo.HintTracker.ShowUnrevealed";
+constexpr const char* kCvarShowJunk = "gCombo.HintTracker.ShowJunk";
+constexpr const char* kCvarHideRead = "gCombo.HintTracker.HideRead";
+constexpr int kDefaultWindowType = 1; // 1 = normal window (the hint list is text-heavy)
+
+// Launcher push side. The launcher owns/reuses its buffers and can call from a game DLL's thread,
+// so the strings are COPIED under this mutex; parsing happens on the draw thread via sDirty.
+std::mutex sPushMutex;
+std::string sPushedHints;
+std::string sPushedRead;
+int sPushedSlot = -1;
+bool sDirty = false;
+
+struct Entry {
+    std::string key;   // reveal key (comboKey / pool index / MM item name)
+    std::string label; // display label
+    std::string text;  // sanitized hint text
+    bool read = false;
+};
+struct Group {
+    std::string title;
+    std::vector<Entry> entries;
+    bool junk = false; // gated behind ShowJunk
+};
+
+int sSlot = -1;
+std::vector<Group> sGroups;
+char sSearchBuf[128] = {};
+
+// Strip OOT CustomMessage control codes (MF_ENCODE output) down to plain text: %<color> and
+// $<icon> pairs, box/line breaks, and the player-name token. Mirrors CustomMessage::Clean.
+std::string Sanitize(std::string s) {
+    std::string out;
+    out.reserve(s.size());
+    for (size_t i = 0; i < s.size(); ++i) {
+        const char c = s[i];
+        if ((c == '%' || c == '$') && i + 1 < s.size()) {
+            ++i; // drop the code letter too
+            continue;
+        }
+        if (c == '&' || c == '^') {
+            out.push_back('\n');
+            continue;
+        }
+        if (c == '@') {
+            out += "Link";
+            continue;
+        }
+        if (c == '#') {
+            continue;
+        }
+        if (static_cast<unsigned char>(c) < 0x20 && c != '\n') {
+            continue;
+        }
+        out.push_back(c);
+    }
+    // Collapse the blank line a "&^" pair leaves behind.
+    while (true) {
+        size_t p = out.find("\n\n\n");
+        if (p == std::string::npos) {
+            break;
+        }
+        out.erase(p, 1);
+    }
+    return out;
+}
+
+// "__ALWAYS__Song from Impa0" / "__TRIAL__Forest Trial1" -> the name without the copy digits.
+std::string StripCopySuffix(std::string s) {
+    while (!s.empty() && std::isdigit(static_cast<unsigned char>(s.back()))) {
+        s.pop_back();
+    }
+    return s;
+}
+
+bool HasPrefix(const std::string& s, const char* p) {
+    return s.rfind(p, 0) == 0;
+}
+
+// nlohmann's value()/[] throw on a type mismatch, so every node is fetched defensively.
+const nlohmann::json* Node(const nlohmann::json& j, const char* key) {
+    if (!j.is_object()) {
+        return nullptr;
+    }
+    auto it = j.find(key);
+    return it == j.end() ? nullptr : &*it;
+}
+
+// Visit each element of an array node under its own guard: a malformed entry is skipped, not fatal.
+template <typename Fn> void ForEachElement(const nlohmann::json* arr, Fn&& fn) {
+    if (!arr || !arr->is_array()) {
+        return;
+    }
+    for (const auto& e : *arr) {
+        try {
+            fn(e);
+        } catch (...) { /* skip this entry */
+        }
+    }
+}
+
+// `ordinal` is the entry's 1-based position in its own group. The sentinel keys carry the generator's
+// producedHints/producedJunk counters, which are shared across categories — numbering from those would
+// start the stone list at #(trials + always + 1).
+std::string LabelForOotKey(const std::string& key, int ordinal) {
+    if (key == "__GANONDORF__") {
+        return "Ganondorf";
+    }
+    if (key == "__ALTAR_CHILD__") {
+        return "Child Altar";
+    }
+    if (key == "__ALTAR_ADULT__") {
+        return "Adult Altar";
+    }
+    if (HasPrefix(key, "__STONE__")) {
+        return "Gossip Stone #" + std::to_string(ordinal);
+    }
+    if (HasPrefix(key, "__JUNK__")) {
+        return "Junk Hint #" + std::to_string(ordinal);
+    }
+    if (HasPrefix(key, "__TRIAL__")) {
+        return StripCopySuffix(key.substr(9));
+    }
+    if (HasPrefix(key, "__ALWAYS__")) {
+        return StripCopySuffix(key.substr(10));
+    }
+    return key; // a real gossip-stone check name
+}
+
+// Display group of an OOT hint, by its generator "type". Indices into the group list Rebuild lays
+// out; keep the two in sync.
+enum OotGroup { kGrpStones = 0, kGrpAltarChild, kGrpAltarAdult, kGrpGanondorf, kGrpTrials, kGrpAlways, kGrpJunk };
+
+int OotGroupForType(const std::string& type) {
+    if (type == "altarChild") {
+        return kGrpAltarChild;
+    }
+    if (type == "altarAdult") {
+        return kGrpAltarAdult;
+    }
+    if (type == "ganondorf") {
+        return kGrpGanondorf;
+    }
+    if (type == "trial") {
+        return kGrpTrials;
+    }
+    if (type == "always") {
+        return kGrpAlways;
+    }
+    if (type == "junk") {
+        return kGrpJunk;
+    }
+    return kGrpStones; // WotH / Foolish / Song / Overworld / Dungeon / NamedItem / Random
+}
+
+// Rebuild the display model from the pushed strings. Corrupt input -> empty (never throws).
+void Rebuild(const std::string& hintsJson, const std::string& readJson) {
+    sGroups.clear();
+    sGroups.resize(7);
+    sGroups[kGrpStones].title = "Gossip Stones";
+    sGroups[kGrpAltarChild].title = "Temple of Time Altar (Child)";
+    sGroups[kGrpAltarAdult].title = "Temple of Time Altar (Adult)";
+    sGroups[kGrpGanondorf].title = "Ganondorf";
+    sGroups[kGrpTrials].title = "Trials";
+    sGroups[kGrpAlways].title = "Always Hints";
+    sGroups[kGrpJunk].title = "Junk Hints";
+    sGroups[kGrpJunk].junk = true;
+
+    std::set<std::string> readOot, readNpc;
+    std::set<int> readPool;
+    std::vector<std::pair<std::string, std::string>> revealedNative;
+    nlohmann::json rs = nlohmann::json::object();
+    try {
+        if (!readJson.empty()) {
+            rs = nlohmann::json::parse(readJson);
+        }
+    } catch (...) { /* corrupt -> no read state */
+    }
+    // Every element is read under its own guard: one bad entry must cost only that entry.
+    ForEachElement(Node(rs, "oot"), [&](const nlohmann::json& k) { readOot.insert(k.get<std::string>()); });
+    ForEachElement(Node(rs, "mmPool"), [&](const nlohmann::json& i) { readPool.insert(i.get<int>()); });
+    ForEachElement(Node(rs, "mmNpc"), [&](const nlohmann::json& k) { readNpc.insert(k.get<std::string>()); });
+    ForEachElement(Node(rs, "mmNative"), [&](const nlohmann::json& e) {
+        revealedNative.emplace_back(e.value("check", std::string()), e.value("text", std::string()));
+    });
+
+    nlohmann::json h = nlohmann::json::object();
+    if (hintsJson.empty()) {
+        sGroups.clear(); // nothing pushed yet -> "no seed loaded"
+        return;
+    }
+    try {
+        h = nlohmann::json::parse(hintsJson);
+    } catch (...) {
+        sGroups.clear(); // unparseable -> "no seed loaded"
+        return;
+    }
+
+    ForEachElement(Node(h, "oot"), [&](const nlohmann::json& e) {
+        Entry en;
+        en.key = e.value("checkName", std::string());
+        if (en.key.empty()) {
+            return;
+        }
+        const nlohmann::json* msgs = Node(e, "messages");
+        if (msgs && msgs->is_array() && !msgs->empty()) {
+            en.text = Sanitize((*msgs)[0].value("en", std::string()));
+        }
+        en.read = readOot.count(en.key) != 0;
+        Group& grp = sGroups[OotGroupForType(e.value("type", std::string()))];
+        en.label = LabelForOotKey(en.key, static_cast<int>(grp.entries.size()) + 1);
+        grp.entries.push_back(std::move(en));
+    });
+
+    const nlohmann::json* mm = Node(h, "mm");
+    Group pool;
+    pool.title = "Majora's Mask - Cross-Game Stone Pool";
+    ForEachElement(mm ? Node(*mm, "gossipPool") : nullptr, [&](const nlohmann::json& g) {
+        const int idx = static_cast<int>(pool.entries.size());
+        Entry en;
+        en.key = std::to_string(idx);
+        en.label = "Pool Hint #" + std::to_string(idx + 1);
+        en.text = g.value("text", std::string());
+        en.read = readPool.count(idx) != 0;
+        pool.entries.push_back(std::move(en));
+    });
+    sGroups.push_back(std::move(pool));
+
+    // MM's own stone hints are composed at talk time from live save state, so there is no upfront
+    // list — only what the game has already shown.
+    Group native;
+    native.title = "Majora's Mask - Revealed Stone Hints";
+    for (auto& [check, text] : revealedNative) {
+        Entry en;
+        en.key = check;
+        en.label = check.empty() ? "Gossip Stone" : check;
+        en.text = text;
+        en.read = true;
+        native.entries.push_back(std::move(en));
+    }
+    sGroups.push_back(std::move(native));
+
+    Group npc;
+    npc.title = "Majora's Mask - Item Hints";
+    const nlohmann::json* itemLocs = mm ? Node(*mm, "itemLocations") : nullptr;
+    if (itemLocs && itemLocs->is_object()) {
+        for (auto& [item, text] : itemLocs->items()) {
+            if (!text.is_string()) {
+                continue;
+            }
+            Entry en;
+            en.key = item;
+            en.label = item;
+            en.text = text.get<std::string>();
+            en.read = readNpc.count(item) != 0;
+            npc.entries.push_back(std::move(en));
+        }
+    }
+    sGroups.push_back(std::move(npc));
+    // A slot with no baked hints pushes "{}" — read as no seed, not as an all-filtered-out list.
+    if (std::all_of(sGroups.begin(), sGroups.end(), [](const Group& g) { return g.entries.empty(); })) {
+        sGroups.clear();
+    }
+}
+
+// Take the pushed strings (draw thread only) and re-parse if they changed.
+void PollPush() {
+    std::string hints, read;
+    int slot;
+    {
+        std::lock_guard<std::mutex> lock(sPushMutex);
+        if (!sDirty) {
+            return;
+        }
+        sDirty = false;
+        hints = sPushedHints;
+        read = sPushedRead;
+        slot = sPushedSlot;
+    }
+    sSlot = slot;
+    Rebuild(hints, read);
+}
+
+std::string ToLower(std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return s;
+}
+
+std::shared_ptr<ComboHintTrackerWindow> sWindow;
+
+} // namespace
+
+void ComboHintTrackerWindow::DrawElement() {
+    PollPush();
+
+    const ImVec4 theme = ComboMenu_ThemeColor();
+    const bool showUnrevealed = CVarGetInteger(kCvarShowUnrevealed, 0) != 0;
+    const bool showJunk = CVarGetInteger(kCvarShowJunk, 0) != 0;
+    const bool hideRead = CVarGetInteger(kCvarHideRead, 0) != 0;
+
+    if (sSlot < 0 || sGroups.empty()) {
+        ImGui::TextDisabled("No seed loaded.");
+        return;
+    }
+
+    ComboMenu_PushInput(theme);
+    ImGui::SetNextItemWidth(-1.0f);
+    ImGui::InputTextWithHint("##hintsearch", "Search hints...", sSearchBuf, sizeof(sSearchBuf));
+    ComboMenu_PopInput();
+    const std::string query = ToLower(sSearchBuf);
+
+    int total = 0, read = 0;
+    for (const Group& g : sGroups) {
+        if (g.junk && !showJunk) {
+            continue;
+        }
+        for (const Entry& e : g.entries) {
+            ++total;
+            read += e.read ? 1 : 0;
+        }
+    }
+    ImGui::TextDisabled("Revealed %d / %d", read, total);
+    ImGui::Separator();
+
+    const ImVec4 kReadColor(0.6f, 0.6f, 0.6f, 1.0f);
+    const ImVec4 kHiddenColor(0.5f, 0.5f, 0.5f, 1.0f);
+    int shownTotal = 0;
+    for (const Group& g : sGroups) {
+        if (g.junk && !showJunk) {
+            continue;
+        }
+        // Pre-filter so an empty group (all read + HideRead, or no search match) never shows a header.
+        std::vector<const Entry*> shown;
+        for (const Entry& e : g.entries) {
+            if (hideRead && e.read) {
+                continue;
+            }
+            if (!query.empty()) {
+                std::string hay = ToLower(e.label);
+                if (e.read || showUnrevealed) {
+                    hay += "\n" + ToLower(e.text);
+                }
+                if (hay.find(query) == std::string::npos) {
+                    continue;
+                }
+            }
+            shown.push_back(&e);
+        }
+        if (shown.empty()) {
+            continue;
+        }
+        shownTotal += static_cast<int>(shown.size());
+        // "###<title>" pins the ImGui ID to the title so the live count in the label can't reset the
+        // collapse state on every search keystroke or reveal.
+        std::string header = g.title + " (" + std::to_string(shown.size()) + ")###" + g.title;
+        if (!ImGui::CollapsingHeader(header.c_str(), ImGuiTreeNodeFlags_DefaultOpen)) {
+            continue;
+        }
+        for (const Entry* e : shown) {
+            ImGui::PushID(e->key.c_str());
+            ImGui::TextColored(e->read ? kReadColor : theme, "%s %s", e->read ? ICON_FA_CHECK : ICON_FA_QUESTION,
+                               e->label.c_str());
+            ImGui::Indent();
+            if (e->read || showUnrevealed) {
+                ImGui::PushStyleColor(ImGuiCol_Text, e->read ? kReadColor : ImGui::GetStyleColorVec4(ImGuiCol_Text));
+                ImGui::TextWrapped("%s", e->text.c_str());
+                ImGui::PopStyleColor();
+            } else {
+                ImGui::TextColored(kHiddenColor, "???");
+            }
+            ImGui::Unindent();
+            ImGui::PopID();
+        }
+    }
+    if (shownTotal == 0) {
+        ImGui::TextDisabled("Nothing to show with the current filters.");
+    }
+}
+
+void ComboHintTrackerWindow::Draw() {
+    if (!IsVisible()) {
+        return;
+    }
+    auto ctx = Ship::Context::GetRawInstance();
+    if (!ctx || !ctx->GetWindow() || !ctx->GetWindow()->GetGui()) {
+        return;
+    }
+    // comboui's per-module GImGui must point at the shared context (same pattern as ComboMenu).
+    ImGui::SetCurrentContext(ctx->GetWindow()->GetGui()->GetImGuiContext());
+
+    const bool floating = CVarGetInteger(kCvarWindowType, kDefaultWindowType) == 0;
+    // OnlyPaused follows the FOREGROUND game's pause state (the dormant game's is stale), and only
+    // applies to the floating overlay — a real window the player opened stays open.
+    if (floating && CVarGetInteger(kCvarOnlyPaused, 0) != 0 &&
+        !ComboTracker::ForegroundPaused(ComboUI::GetForegroundGame())) {
+        SyncVisibilityConsoleVariable();
+        return;
+    }
+
+    ImGuiWindowFlags flags = 0;
+    // Only the real window gets a close box (mirrors GuiWindow::Draw); the chrome-less overlay has no
+    // title bar to put one in, so it stays nullptr there.
+    bool* pOpen = &mIsVisible;
+    if (floating) {
+        ImGui::SetNextWindowPos(ImVec2(20.0f, 20.0f), ImGuiCond_FirstUseEver);
+        ImGui::SetNextWindowSize(ImVec2(420.0f, 480.0f), ImGuiCond_FirstUseEver);
+        ImGui::SetNextWindowBgAlpha(0.65f);
+        flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav;
+        pOpen = nullptr;
+    } else {
+        ImGui::SetNextWindowSize(ImVec2(500.0f, 600.0f), ImGuiCond_FirstUseEver);
+    }
+    // Distinct ImGui/Gui-map identity from OOT's native "Hint Tracker"; the "##" tail is not displayed.
+    if (ImGui::Begin("Hint Tracker##Combo", pOpen, flags)) {
+        DrawElement();
+    }
+    ImGui::End();
+    SyncVisibilityConsoleVariable();
+}
+
+void RegisterHintTrackerWindow() {
+    auto ctx = Ship::Context::GetRawInstance();
+    if (!ctx || !ctx->GetWindow() || !ctx->GetWindow()->GetGui()) {
+        return;
+    }
+    if (!sWindow) {
+        sWindow = std::make_shared<ComboHintTrackerWindow>(kCvarEnabled, "Hint Tracker##Combo");
+    }
+    ctx->GetWindow()->GetGui()->AddGuiWindow(sWindow);
+}
+
+void DrawHintTrackerSharedPanel() {
+    const ImVec4 theme = ComboMenu_ThemeColor();
+    bool changed = false;
+
+    const ImGuiTableFlags tableFlags = ImGuiTableFlags_SizingStretchSame | ImGuiTableFlags_NoSavedSettings;
+    if (ImGui::BeginTable("##hinttrackercols", 2, tableFlags)) {
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+
+        const bool shown = CVarGetInteger(kCvarEnabled, 0) != 0;
+        std::string txt =
+            std::string(shown ? ICON_FA_WINDOW_CLOSE : ICON_FA_EXTERNAL_LINK_SQUARE) + " Toggle Hint Tracker";
+        ComboMenu_PushButton(theme);
+        if (ImGui::Button(txt.c_str())) {
+            CVarSetInteger(kCvarEnabled, shown ? 0 : 1);
+            if (auto ctx = Ship::Context::GetRawInstance(); ctx && ctx->GetWindow() && ctx->GetWindow()->GetGui()) {
+                if (auto win = ctx->GetWindow()->GetGui()->GetGuiWindow("Hint Tracker##Combo")) {
+                    if (shown) {
+                        win->Hide();
+                    } else {
+                        win->Show();
+                    }
+                }
+            }
+            changed = true;
+        }
+        ComboMenu_PopButton();
+        ImGui::TextDisabled("One window for both games' combo-generated hints.");
+
+        ImGui::SeparatorText("Appearance");
+        const char* kWindowTypes[] = { "Floating (overlay)", "Window" };
+        int wt = CVarGetInteger(kCvarWindowType, kDefaultWindowType);
+        ComboMenu_PushCombobox(theme);
+        if (ImGui::Combo("Window type", &wt, kWindowTypes, 2)) {
+            CVarSetInteger(kCvarWindowType, wt);
+            changed = true;
+        }
+        ComboMenu_PopCombobox();
+
+        ComboMenu_PushCheckbox(theme);
+        bool onlyPaused = CVarGetInteger(kCvarOnlyPaused, 0) != 0;
+        if (ImGui::Checkbox("Only show while paused", &onlyPaused)) {
+            CVarSetInteger(kCvarOnlyPaused, onlyPaused ? 1 : 0);
+            changed = true;
+        }
+        if (onlyPaused && wt != 0) {
+            ImGui::TextDisabled("Only applies to the floating overlay.");
+        }
+
+        ImGui::SeparatorText("Filters");
+        bool showUnrevealed = CVarGetInteger(kCvarShowUnrevealed, 0) != 0;
+        if (ImGui::Checkbox("Spoil unrevealed hints", &showUnrevealed)) {
+            CVarSetInteger(kCvarShowUnrevealed, showUnrevealed ? 1 : 0);
+            changed = true;
+        }
+        bool hideRead = CVarGetInteger(kCvarHideRead, 0) != 0;
+        if (ImGui::Checkbox("Hide hints already read", &hideRead)) {
+            CVarSetInteger(kCvarHideRead, hideRead ? 1 : 0);
+            changed = true;
+        }
+        bool showJunk = CVarGetInteger(kCvarShowJunk, 0) != 0;
+        if (ImGui::Checkbox("Show junk hints", &showJunk)) {
+            CVarSetInteger(kCvarShowJunk, showJunk ? 1 : 0);
+            changed = true;
+        }
+        ComboMenu_PopCheckbox();
+
+        ImGui::EndTable();
+    }
+
+    ImGui::TextDisabled("Read state is stored per save slot and resets when the slot is regenerated.");
+
+    if (changed) {
+        if (auto ctx = Ship::Context::GetRawInstance(); ctx && ctx->GetWindow() && ctx->GetWindow()->GetGui()) {
+            ctx->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+        }
+    }
+}
+
+} // namespace ComboRando
+
+// ComboShip: the launcher pushes the slot's hints slice + read state here (at slot bind/load and
+// after every reveal). Strings are copied — the launcher reuses its buffers — and parsed lazily on
+// the draw thread.
+#ifdef _WIN32
+extern "C" __declspec(dllexport) void ComboUI_SetHintTrackerData(int slot, const char* hintsJson,
+                                                                 const char* readStateJson)
+#else
+extern "C" void ComboUI_SetHintTrackerData(int slot, const char* hintsJson, const char* readStateJson)
+#endif
+{
+    try {
+        std::lock_guard<std::mutex> lock(ComboRando::sPushMutex);
+        ComboRando::sPushedSlot = slot;
+        ComboRando::sPushedHints = hintsJson ? hintsJson : "";
+        ComboRando::sPushedRead = readStateJson ? readStateJson : "";
+        ComboRando::sDirty = true;
+    } catch (...) { /* never unwind across the C-ABI boundary */
+    }
+}

--- a/combo/gui/ComboHintTracker.h
+++ b/combo/gui/ComboHintTracker.h
@@ -1,0 +1,36 @@
+// combo/gui/ComboHintTracker.h
+//
+// ComboShip-owned unified Hint Tracker (issue #164). Replaces soh's OOT-only vendored hint tracker
+// (hidden in combo builds): combo injects every OOT hint as a pre-rendered MESSAGE hint, so native's
+// Journal/WotH/found views are dead, and MM never had a tracker at all.
+//
+// The window draws ONLY from plain strings the launcher pushes (ComboUI_SetHintTrackerData) — no
+// ResourceManager or game-DLL dependency — so it renders under either foreground game without the
+// dormant-draw machinery the icon trackers need. Read state is launcher-owned and per-slot
+// (.combosav combo.hintsRead); the games report reveals through SOH_/MM_SetComboHintRevealCb.
+#pragma once
+
+#include <ship/window/gui/GuiWindow.h>
+
+namespace ComboRando {
+
+// Registered in ComboUI_Register alongside the other combo-owned windows.
+void RegisterHintTrackerWindow();
+
+// Settings > Hint Tracker panel (combo-owned; no per-game proxy block).
+void DrawHintTrackerSharedPanel();
+
+class ComboHintTrackerWindow final : public Ship::GuiWindow {
+  public:
+    using GuiWindow::GuiWindow;
+    void Draw() override;
+
+  protected:
+    void InitElement() override {
+    }
+    void UpdateElement() override {
+    }
+    void DrawElement() override;
+};
+
+} // namespace ComboRando

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -8,6 +8,7 @@
 #include "ComboTrackerCommon.h" // kKinds (HideBackground CVars for the tracker panels)
 #include "ComboTrackerSwap.h"
 #include "ComboAnchorRoomWindow.h"  // combo-native floating Anchor room window
+#include "ComboHintTracker.h"       // combo-owned unified Hint Tracker (#164)
 #include "rando/ComboPlaythrough.h" // plando: ParseSpoilerPlacements + Suffix/BuildForeignArray + slot paths
 #include <imgui.h>
 #include <libultraship/libultraship.h>         // CVar bridge (CVarGet/Set* incl. color) + color.h (Color_RGBA8)
@@ -463,6 +464,7 @@ struct HubEntry {
         COMBO_PLANDO,
         COMBO_TRACKER,
         COMBO_CHECK_TRACKER,
+        COMBO_HINT_TRACKER,
         COMBO_NETWORK
     } kind;
     const ComboRando::GameMenu* game = nullptr; // ENGINE/OOT_RANDO/MM_RANDO
@@ -1295,6 +1297,12 @@ void ComboMenu::DrawSharedPanel() {
         chk.group = "Settings";
         chk.kind = HubEntry::COMBO_CHECK_TRACKER;
         e.push_back(std::move(chk));
+        // Combo-owned Hint Tracker panel (#164): one window for both games' combo-generated hints.
+        HubEntry hnt;
+        hnt.label = "Hint Tracker";
+        hnt.group = "Settings";
+        hnt.kind = HubEntry::COMBO_HINT_TRACKER;
+        e.push_back(std::move(hnt));
         if (!e.empty())
             groups.push_back({ "Settings", std::move(e) });
         // Network group: the Anchor team-sync control (covers BOTH games) plus the Ship of Harkinian
@@ -1425,6 +1433,8 @@ void ComboMenu::DrawSharedPanel() {
         DrawTrackerSharedPanel();
     } else if (active->kind == HubEntry::COMBO_CHECK_TRACKER) {
         DrawCheckTrackerSharedPanel();
+    } else if (active->kind == HubEntry::COMBO_HINT_TRACKER) {
+        DrawHintTrackerSharedPanel();
     } else if (active->kind == HubEntry::COMBO_NETWORK) {
         DrawNetworkSharedPanel();
     } else {
@@ -1475,11 +1485,11 @@ void ComboMenu::DrawGamePanel(const char* gameKey) {
              strcmp(sidebar, "General") == 0)) {
             return false;
         }
-        // Rando settings live in Shared, Item/Check Tracker sidebars in the Shared tracker panels;
-        // only Entrance/Hint Tracker (OOT-only, no shared panel yet) remain here.
+        // Rando settings live in Shared, Item/Check/Hint Tracker sidebars in the Shared tracker panels
+        // (the combo Hint Tracker replaces OOT's native one); only Entrance Tracker remains here.
         const char* randoSec = isOot ? "Randomizer" : "Rando";
         if (section && strcmp(section, randoSec) == 0) {
-            return sidebar && (strcmp(sidebar, "Entrance Tracker") == 0 || strcmp(sidebar, "Hint Tracker") == 0);
+            return sidebar && strcmp(sidebar, "Entrance Tracker") == 0;
         }
         return true;
     };
@@ -1770,4 +1780,15 @@ extern "C" void ComboUI_Register(void)
 
     // Combo-native floating Anchor room window (toggled from the Anchor panel).
     ComboRando::RegisterAnchorRoomWindow();
+
+    // Combo-owned unified Hint Tracker (#164). OOT's native one is unreachable now that its sidebar is
+    // hidden, so force it shut here — a config that persisted gOpenWindows.HintTracker=1 would
+    // otherwise keep showing a window with no settings and no combo hint content.
+    ComboRando::RegisterHintTrackerWindow();
+    for (const auto& [cvar, name] : { std::pair{ "gOpenWindows.HintTracker", "Hint Tracker" },
+                                      std::pair{ "gOpenWindows.HintTrackerSettings", "Hint Tracker Settings" } }) {
+        CVarSetInteger(cvar, 0);
+        if (auto win = gui->GetGuiWindow(name))
+            win->Hide();
+    }
 }

--- a/combo/gui/ComboTrackerSwap.cpp
+++ b/combo/gui/ComboTrackerSwap.cpp
@@ -124,25 +124,6 @@ bool DormantPausedOnly(int kindIdx, int bg) {
     return CVarGetInteger(p.mmCvar, 0) == 1; // MM's button modes (2/3) stay always-show while dormant
 }
 
-// The foreground game's pause state, from its DLL (the dormant game's own is stale). Fails open
-// (paused) so a missing module/export degrades to the previous always-show behavior.
-bool ForegroundPaused(int fg) {
-#ifdef _WIN32
-    static int (*sFn[2])(void) = {};
-    static bool sTried[2] = {};
-    if (!sTried[fg]) {
-        sTried[fg] = true;
-        if (HMODULE h = GetModuleHandleA(fg == 0 ? "soh.dll" : "2ship.dll")) {
-            sFn[fg] = (int (*)(void))GetProcAddress(h, fg == 0 ? "SOH_IsPausedForCombo" : "MM_IsPausedForCombo");
-        }
-    }
-    if (sFn[fg]) {
-        return sFn[fg]() != 0;
-    }
-#endif
-    return true;
-}
-
 // Write the derived visibility only on change (SetTracker writes the CVar and Show/Hides the
 // GuiWindow; doing that unconditionally every frame would fight the games' own Draw gating).
 void ApplyDerived(const ComboTracker::Win& w, bool visible) {
@@ -206,7 +187,7 @@ void Reconcile(int kindIdx) {
     // A dormant tracker set to "only while paused" follows the FOREGROUND game's pause state (its
     // own is stale); peek-hold still overrides.
     const bool onlyPaused = DormantPausedOnly(kindIdx, bg);
-    bool wantBg = master && ((!hideBg && (!onlyPaused || ForegroundPaused(fg))) || sPeeks[kindIdx].held);
+    bool wantBg = master && ((!hideBg && (!onlyPaused || ComboTracker::ForegroundPaused(fg))) || sPeeks[kindIdx].held);
     // A dormant game's tracker needs its ResourceManager registered (icons) and, for dormant MM,
     // an active OOT save whose MM counterpart it can show — not the title/file-select screens.
     if (wantBg && !Ship::CrossRMRegistry::Get(bg == 0 ? "oot" : "mm")) {
@@ -366,6 +347,26 @@ void SwapWindow::Draw() {
 }
 
 } // namespace
+
+bool ComboTracker::ForegroundPaused(int fg) {
+#ifdef _WIN32
+    static int (*sFn[2])(void) = {};
+    static bool sTried[2] = {};
+    if (fg != 0 && fg != 1) {
+        return true;
+    }
+    if (!sTried[fg]) {
+        sTried[fg] = true;
+        if (HMODULE h = GetModuleHandleA(fg == 0 ? "soh.dll" : "2ship.dll")) {
+            sFn[fg] = (int (*)(void))GetProcAddress(h, fg == 0 ? "SOH_IsPausedForCombo" : "MM_IsPausedForCombo");
+        }
+    }
+    if (sFn[fg]) {
+        return sFn[fg]() != 0;
+    }
+#endif
+    return true;
+}
 
 bool ComboTracker::GetMasterVisible(int tracker) {
     return CVarGetInteger(kKinds[tracker].enabledCvar, 0) != 0;

--- a/combo/gui/ComboTrackerSwap.h
+++ b/combo/gui/ComboTrackerSwap.h
@@ -22,4 +22,8 @@ void RegisterSwap();
 bool GetMasterVisible(int tracker);
 void SetMasterVisible(int tracker, bool visible);
 
+// The FOREGROUND game's pause state, from its DLL (the dormant game's own is stale). Fails open
+// (paused) so a missing module/export degrades to always-show. Shared with the combo Hint Tracker.
+bool ForegroundPaused(int fg);
+
 } // namespace ComboTracker

--- a/docs/deviations/rando.md
+++ b/docs/deviations/rando.md
@@ -1403,3 +1403,90 @@ keeping the seed escapable is generation's job, not the hint layer's.
 
 **Residual:** NO_LOGIC + MM start has no re-entry guarantee — that mode's point. No MM-side setter
 exists (nothing in MM reads the value); add one when a consumer appears.
+
+## Combo-owned unified Hint Tracker (#164) (2026-08-20)
+
+**Why:** the Hint Tracker arrived in the 2026-07-13 soh merge as vendored OOT-only code, reachable
+only from the OOT per-game tab. It is a poor fit for combo seeds even for OOT alone: combo injects
+every hint as a pre-rendered MESSAGE hint (`SOH_ApplyComboHints`), so native's Journal view,
+WotH/Foolish coloring and found-tracking are all dead. MM had no hint tracker at all. Replaced by a
+combo-owned window under Settings, directly below Check Tracker, covering both games.
+
+**No generator changes.** The tracker reads the seed's existing `hints` slice
+(`combo/rando/CrossHints.h`): `hints.oot[] {checkName, type, messages[{en,de,fr}]}` and
+`hints.mm {gossipPool[{weight,text}], itemLocations{item -> text}}`.
+
+**New files (no merge risk):** `combo/gui/ComboHintTracker.h`/`.cpp` — the `"Hint Tracker##Combo"`
+GuiWindow (the `##` tail keeps a distinct Gui-map/ImGui identity from OOT's native `"Hint Tracker"`)
+plus the Settings panel. It draws only from plain strings the launcher pushes — no ResourceManager or
+game-DLL dependency — so it renders under either foreground game with none of the dormant-draw
+machinery the icon trackers need. `ComboTracker::ForegroundPaused` was de-`static`ed out of
+`ComboTrackerSwap.cpp` so the window's OnlyPaused option reuses the same fail-open pause probe.
+
+**Read-state store.** `.combosav` gains `combo.hintsRead`:
+
+    "hintsRead": {
+      "oot":      ["__GANONDORF__", "__STONE__3", ...],   // combo checkName keys
+      "mmPool":   [0, 4, 7],                              // hints.mm.gossipPool indices
+      "mmNative": [{ "check": "...", "text": "..." }],     // MM's own stone hints
+      "mmNpc":    ["Great Fairy Sword", ...]              // hints.mm.itemLocations keys
+    }
+
+Absent means empty. Every bucket is set-semantics (insert-if-absent), so a hook that fires repeatedly
+per textbox is free, and `FlushContainer` only runs on an actual insert. `mmNative` dedupes on `check`
+alone (first write wins): a trap check's disguise name re-rolls per scene init, so comparing the whole
+`{check, text}` object would append a fresh entry — and flush the container — on every talk.
+`Combo_OnOOTSaveInit` erases `combo.hintsRead` unconditionally, not only on the rebake path: a slot
+whose container survived a delete path arrives with no pending seed, and the new file must not inherit
+the old one's read marks. `EraseComboContainer` pushes an empty slot -1 payload so a deleted slot's
+hints stop showing on the file-select screen. MM-native stone hints have no stable upfront list (they
+are composed at talk time from live save state), so they appear only as a "revealed" group built from
+`mmNative`.
+
+**Three new ABI points:**
+- `soh.dll` `SOH_SetComboHintRevealCb(void (*)(int fileNum, const char* comboKey))` — OOT's
+  `OnRandoHintRevealed` subscriber (registered once from `SOH_LoadComboRando`) maps the
+  `RandomizerHint` back to the combo `checkName` it was applied from and reports it. Non-combo hints
+  (native static hints, warp songs) and disabled hints are dropped.
+- `2ship.dll` `MM_SetComboHintRevealCb(void (*)(int fileNum, int kind, int poolIndex, const char* key,
+  const char* text))` — kind 0 = cross `gossipPool` pick (by index, from a new report-only out-param on
+  `EnGs.cpp GetRandomCheck`), 1 = native MM stone hint (key = combo-spoiler check name, plain text),
+  2 = NPC `itemLocations` hint (key = item friendly name, reported where
+  `Rando.cpp GetItemLocationHintName`'s COMBO_BUILD branch resolves). `SECOND_GS_MESSAGE` reports only
+  in the paid-and-shown branch. `DmStk.cpp`'s Skull Kid taunt now resolves the Oath-to-Order location
+  inside the branch that actually has a `{{location}}` placeholder — resolving it for the taunt marked
+  the hint read without the player ever seeing it. The out-param changes no draw logic and consumes no RNG, so the stone
+  draw stays byte-identical.
+- `comboui.dll` `ComboUI_SetHintTrackerData(int slot, const char* hintsJson, const char* readStateJson)`
+  — pushed at `Combo_OnOOTSaveInit` (after bake) and `Combo_OnOOTSaveLoad`, and re-pushed after every
+  reveal that actually inserted. Push-only; there is no comboui -> launcher direction, so manual
+  mark-read from the UI is a later phase. comboui copies both strings under a small mutex (the launcher
+  reuses its buffers and the reveal path runs on the reporting game's thread) and re-parses lazily on
+  the draw thread via a dirty flag; corrupt JSON degrades to "no seed loaded".
+
+**Shared hint resolver.** `SOH_ApplyComboHints`' resolution loop was extracted into
+`Combo_WalkComboHints(hints, isTaken, emit, ...)`, used by two callers. Apply runs it with `isTaken =
+ctx->GetHint(rh)->IsEnabled()` and records `RandomizerHint -> checkName` as it goes; the lazy replay
+(`Combo_EnsureHintKeyMap`) runs it with a claimed-set predicate over the pushed blob's hints slice.
+**The replay is the path that actually serves every real flow**: it is keyed on `OOT_ForeignMapGen()`,
+and `SOH_LoadComboRando` bumps that generation unconditionally after apply, so the first reveal of a
+session always rebuilds from the blob. Apply-side recording is only a narrow safety net for a process
+where the blob was never pushed. That makes the two walks staying one function load-bearing, not
+belt-and-braces: the sentinel (`__STONE__n`/`__TRIAL__…`/`__JUNK__n`) to physical-stone mapping
+depends on the claiming order. Both callers build into a local map and commit (map + generation stamp)
+only past a successful walk, so a throw logs and retries at the next reveal instead of latching an
+empty map. Worst case a wrong entry is marked read.
+
+**Native OOT Hint Tracker suppressed.** `"Hint Tracker"` is gone from the OOT per-game tab's rando
+allow-list (only Entrance Tracker remains), and `ComboUI_Register` forces
+`gOpenWindows.HintTracker`/`…Settings` to 0 and `Hide()`s both windows via the Gui map — a config that
+persisted `HintTracker=1` would otherwise keep showing a window with no reachable settings and no
+combo hint content. This closes the `docs/merges/2026-07-13.md` follow-up for that window pair.
+
+**New CVars:** `gCombo.HintTracker.{Enabled, WindowType, OnlyPaused, ShowUnrevealed, ShowJunk,
+HideRead}`. Unread entries render as `???` unless ShowUnrevealed; the search box only matches text the
+player is allowed to see.
+
+**Residuals:** MM's plain-text recomposition for a native stone hint may diverge cosmetically from the
+formatted in-game string (colors/line breaks are stripped); MM-native NPC hints outside the combo
+`itemLocations` path are not reported; there is no manual mark-read.

--- a/docs/merges/2026-07-13.md
+++ b/docs/merges/2026-07-13.md
@@ -153,8 +153,9 @@ COMBO_BUILD-guarded and unchanged in intent. Notable calls:
   `<ship/window/Window.h>` (combo LUS layout).
 - **Assets**: the 8 mm pot/triforce materials were re-spliced with soh chest materials by the soh
   merge (same class as #50) — restored wholesale from the mm vendor snapshot.
-- **Follow-up (open)**: gate the new OOT-only Hint Tracker windows per foreground game in
-  `combo/gui/ComboTrackerCommon.h`.
+- **Follow-up (closed 2026-08-20)**: the OOT-only Hint Tracker windows never needed per-foreground
+  gating — issue #164 replaced them with a combo-owned unified Hint Tracker and force-hides both
+  native windows (`docs/deviations/rando.md`, "Combo-owned unified Hint Tracker (#164)").
 
 ## Workflow fixes (root cause of the conflict storm)
 

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -4037,6 +4037,13 @@ extern "C" void (*gMMComboMarkForeignObtained)(int srcGame, const char* checkNam
 extern "C" __declspec(dllexport) void MM_SetMarkForeignObtained(void (*cb)(int, const char*)) {
     gMMComboMarkForeignObtained = cb;
 }
+// ComboShip (#164): combo Hint Tracker reveal sink. kind: 0 = cross gossipPool pick (poolIndex),
+// 1 = native MM stone hint (key = check name, text = plain hint), 2 = NPC itemLocations hint (key = item).
+extern "C" void (*gMMComboHintReveal)(int fileNum, int kind, int poolIndex, const char* key,
+                                      const char* text) = nullptr;
+extern "C" __declspec(dllexport) void MM_SetComboHintRevealCb(void (*cb)(int, int, int, const char*, const char*)) {
+    gMMComboHintReveal = cb;
+}
 // ComboShip: end-gating seam (mirrors OOT). z_boss_07.c calls gComboFinalBossDefeated when Majora dies.
 extern "C" int (*gComboFinalBossDefeated)(int game, int fileNum) = nullptr;
 extern "C" __declspec(dllexport) void MM_SetFinalBossDefeatedCb(int (*cb)(int, int)) {

--- a/mm/2s2h/Rando/ActorBehavior/DmStk.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/DmStk.cpp
@@ -30,9 +30,10 @@ void ApplyOathHint(u16* textId, bool* loadFromMessageTable) {
     } else {
         msg = "I can hear the Giants Melody echoing "
               "%y{{location}}%w. But it's too late! They can't help you now!";
+        // ComboShip (#164): resolved only in this branch — the taunt has no {{location}}, and resolving
+        // it there would mark the hint read in the tracker without the player ever seeing it.
+        CustomMessage::Replace(&msg, "{{location}}", Rando::GetItemLocationHintName(RI_SONG_OATH, false));
     }
-
-    CustomMessage::Replace(&msg, "{{location}}", Rando::GetItemLocationHintName(RI_SONG_OATH, false));
 
     CustomMessage::Entry entry = {
         .nextMessageID = (u16)0xFFFF,

--- a/mm/2s2h/Rando/ActorBehavior/EnGs.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGs.cpp
@@ -93,7 +93,9 @@ s32 GetNormalizedCost() {
 
 // outForeignText: ComboShip out-param — set when the pick lands on a cross-game (OOT) hint, which
 // has no RandoCheckId. Caller must display it directly instead of resolving a check/item name.
-RandoCheckId GetRandomCheck(bool repeatableOnlyObtained = false, std::string* outForeignText = nullptr) {
+// outForeignIndex: ComboShip (#164) report-only out-param — that hint's gossipPool index.
+RandoCheckId GetRandomCheck(bool repeatableOnlyObtained = false, std::string* outForeignText = nullptr,
+                            int* outForeignIndex = nullptr) {
     Player* player = GET_PLAYER(gPlayState);
     if (player->talkActor == nullptr || player->talkActor->id != ACTOR_EN_GS) {
         return RC_UNKNOWN;
@@ -172,11 +174,43 @@ RandoCheckId GetRandomCheck(bool repeatableOnlyObtained = false, std::string* ou
             if (outForeignText) {
                 *outForeignText = comboTexts[comboIdx];
             }
+            if (outForeignIndex) {
+                *outForeignIndex = (int)comboIdx;
+            }
             return RC_UNKNOWN;
         }
     }
     return weightedChecks.empty() ? RC_UNKNOWN : weightedChecks.back().first;
 }
+
+#ifdef COMBO_BUILD
+// ComboShip (#164): combo Hint Tracker reveal sink (the launcher registers it, see BenPort.cpp).
+extern "C" void (*gMMComboHintReveal)(int fileNum, int kind, int poolIndex, const char* key, const char* text);
+
+// Report a stone hint the game is about to display: a cross-game pool pick by index (kind 0), or a
+// native MM check by its combo-spoiler name (kind 1, plain text — no color codes). A trap check's
+// disguise name re-rolls per scene init, so the launcher dedupes kind 1 on the check name alone.
+static void ComboReportStoneHint(int poolIndex, RandoCheckId rc, bool showExact) {
+    if (gMMComboHintReveal == nullptr || gSaveContext.fileNum == 0xFF) {
+        return;
+    }
+    if (poolIndex >= 0) {
+        gMMComboHintReveal(gSaveContext.fileNum, 0, poolIndex, "", "");
+        return;
+    }
+    if (rc == RC_UNKNOWN) {
+        return;
+    }
+    const std::string& display = Rando::StaticData::GetCheckDisplayName(rc);
+    const std::string key = display.empty() ? Rando::StaticData::CheckNames[rc] : display;
+    const std::string text = Rando::StaticData::GetItemName(RANDO_SAVE_CHECKS[rc].randoItemId, true, rc) +
+                             " is hidden " + Rando::StaticData::GetLocationNameForHint(rc, showExact);
+    gMMComboHintReveal(gSaveContext.fileNum, 1, -1, key.c_str(), text.c_str());
+}
+#else
+static void ComboReportStoneHint(int, RandoCheckId, bool) {
+}
+#endif
 
 void Rando::ActorBehavior::InitEnGsBehavior() {
     bool shouldRegister =
@@ -195,7 +229,8 @@ void Rando::ActorBehavior::InitEnGsBehavior() {
 
         if (RANDO_SAVE_OPTIONS[RO_HINTS_GOSSIP_STONES]) {
             std::string foreignText; // ComboShip: set when the pick is a cross-game (OOT) hint
-            RandoCheckId randoCheckId = GetRandomCheck(false, &foreignText);
+            int foreignIndex = -1;   // ComboShip (#164): its gossipPool index, for the Hint Tracker
+            RandoCheckId randoCheckId = GetRandomCheck(false, &foreignText, &foreignIndex);
             if (randoCheckId == RC_UNKNOWN && foreignText.empty()) {
                 return;
             }
@@ -204,6 +239,7 @@ void Rando::ActorBehavior::InitEnGsBehavior() {
 
             if (!foreignText.empty()) {
                 entry.msg = "They say " + foreignText + ".";
+                ComboReportStoneHint(foreignIndex, RC_UNKNOWN, false);
             } else {
                 auto& saveCheck = RANDO_SAVE_CHECKS[randoCheckId];
 
@@ -218,6 +254,7 @@ void Rando::ActorBehavior::InitEnGsBehavior() {
                                        Rando::StaticData::GetItemName(saveCheck.randoItemId, true, randoCheckId));
                 CustomMessage::Replace(&entry.msg, "{{location}}",
                                        Rando::StaticData::GetLocationNameForHint(randoCheckId, showExact));
+                ComboReportStoneHint(-1, randoCheckId, showExact);
             }
 
             // Replace colors before line break calculation
@@ -271,6 +308,7 @@ void Rando::ActorBehavior::InitEnGsBehavior() {
 
                     gSaveContext.rupeeAccumulator -= cost;
                     cost *= 2;
+                    ComboReportStoneHint(-1, randoCheckId, true); // paid for, so it really displays
                 }
             } else {
                 entry.msg = "Foolish... Come back later when you have more sense.";

--- a/mm/2s2h/Rando/Rando.cpp
+++ b/mm/2s2h/Rando/Rando.cpp
@@ -10,6 +10,8 @@
 #include <ship/Context.h>
 #ifdef COMBO_BUILD
 #include "rando/CrossForeign.h" // ComboShip: family-B foreign-item-location fallback
+// ComboShip (#164): combo Hint Tracker reveal sink (the launcher registers it, see BenPort.cpp).
+extern "C" void (*gMMComboHintReveal)(int fileNum, int kind, int poolIndex, const char* key, const char* text);
 #endif
 
 // When a save is loaded, we want to unregister all hooks and re-register them if it's a rando save
@@ -76,6 +78,10 @@ std::string Rando::GetItemLocationHintName(RandoItemId randoItemId, bool exact) 
             }
             auto hintIt = s_hints.itemLocations.find(friendlyName);
             if (hintIt != s_hints.itemLocations.end()) {
+                // ComboShip (#164): this NPC hint is about to be shown — mark it read in the tracker.
+                if (gMMComboHintReveal != nullptr) {
+                    gMMComboHintReveal(slot, 2, -1, friendlyName.c_str(), hintIt->second.c_str());
+                }
                 return hintIt->second;
             }
 

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -544,12 +544,23 @@ void OOT_DeliverForeign(RandomizerCheck rc) {
     }
 }
 
+// ComboShip (#164): combo Hint Tracker reveal reporter, defined in OTRGlobals.cpp (it owns the
+// RandomizerHint -> combo hint-key map).
+void OOT_ComboHintRevealed(RandomizerHint hintKey);
+
 // ComboShip: launcher pushes the baked combo rando (foreign map + cross-hints) once per save-load.
 // Store the blob and rebuild the OOT foreign cache from it. Idempotent (pushed at bind and load).
 extern "C" __declspec(dllexport) void SOH_LoadComboRando(const char* json) {
     ComboRando::Combo_SetForeignJson(json);
     g_ootForeignMap = ComboRando::LoadForeignForGame(0, ComboRando::GAME_OOT);
     ++g_ootForeignGen; // invalidate the foreign-draw caches keyed on this
+    // ComboShip (#164): subscribe once — this is the earliest point a combo seed is known to be live,
+    // and the hook list must not collect a duplicate on each push.
+    static bool sHintRevealHooked = false;
+    if (!sHintRevealHooked) {
+        sHintRevealHooked = true;
+        GameInteractor::Instance->RegisterGameHook<GameInteractor::OnRandoHintRevealed>(OOT_ComboHintRevealed);
+    }
 }
 #endif
 

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -141,6 +141,9 @@
 #include "soh/ShipInit.hpp"
 #ifdef COMBO_BUILD
 #include "ComboMenuSharedContext.h" // ComboShip: shared per-DLL ImGui context helper (combo-owned)
+#include "rando/CrossForeign.h"     // ComboShip (#164): g_comboForeignJson for the hint-key map replay
+#include "soh/Enhancements/randomizer/hook_handlers.h" // ComboShip (#164): OOT_ForeignMapGen
+#include <functional>                                  // ComboShip (#164): shared hint-resolution callbacks
 #endif
 
 #ifdef _MSC_VER
@@ -4513,11 +4516,136 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoHintData(void) {
 // Set by the launcher just before SOH_ApplyRandoPlacements; back-compat default is "no" so an old
 // dropped seed file (generated before Phase 3) still gets the force-off vanilla-hint behavior.
 static bool sComboHintsPresent = false;
+
+// ComboShip (#164): RandomizerHint -> the combo checkName it was applied from, so a reveal can be
+// reported to the combo Hint Tracker (whose read state is keyed by combo key, not by RandomizerHint).
+static std::unordered_map<int, std::string> sComboHintKeys;
+static uint64_t sComboHintKeysGen = (uint64_t)-1; // OOT_ForeignMapGen() the map was built for
+
+// ComboShip: one resolution walk over a combo hints payload, shared by apply and by the lazy map
+// replay. `isTaken` reports an already-claimed hint slot; `emit` receives each resolution in claiming
+// order. Both callers MUST walk this identically or the sentinel -> stone mapping drifts.
+static void
+Combo_WalkComboHints(const nlohmann::json& hints, const std::function<bool(RandomizerHint)>& isTaken,
+                     const std::function<void(RandomizerHint, const std::string&, std::vector<CustomMessage>&)>& emit,
+                     int& applied, int& skipped) {
+    const std::vector<RandomizerCheck> stones = Rando::StaticData::GetGossipStoneLocations();
+    for (auto& entry : hints.value("oot", nlohmann::json::array())) {
+        std::string checkName = entry.value("checkName", "");
+        std::vector<CustomMessage> messages;
+        for (auto& m : entry.value("messages", nlohmann::json::array()))
+            messages.emplace_back(m.value("en", ""), m.value("de", ""), m.value("fr", ""));
+        if (messages.empty()) {
+            ++skipped;
+            continue;
+        }
+
+        RandomizerHint rh = RH_NONE;
+        if (checkName == "__GANONDORF__") {
+            rh = RH_GANONDORF_HINT;
+        } else if (checkName == "__ALTAR_CHILD__") {
+            rh = RH_ALTAR_CHILD;
+        } else if (checkName == "__ALTAR_ADULT__") {
+            rh = RH_ALTAR_ADULT;
+        } else if (checkName.rfind("__", 0) == 0) {
+            // "__STONE__N"/"__TRIAL__.../"__JUNK__...": CrossHints.h assigns these to an abstract
+            // stone SLOT (count only, not a specific check — combo doesn't pick which physical
+            // stone gets which content). Claim the next still-empty gossip-stone check for it.
+            for (RandomizerCheck rc : stones) {
+                RandomizerHint candidate = Rando::StaticData::gossipStoneCheckToHint.count(rc)
+                                               ? Rando::StaticData::gossipStoneCheckToHint[rc]
+                                               : RH_NONE;
+                if (candidate != RH_NONE && !isTaken(candidate)) {
+                    rh = candidate;
+                    break;
+                }
+            }
+            if (rh == RH_NONE) {
+                ++skipped;
+                continue;
+            }
+        } else {
+            auto rcIt = Rando::StaticData::locationNameToEnum.find(checkName);
+            if (rcIt == Rando::StaticData::locationNameToEnum.end() ||
+                !Rando::StaticData::gossipStoneCheckToHint.count(rcIt->second)) {
+                ++skipped;
+                continue;
+            }
+            rh = Rando::StaticData::gossipStoneCheckToHint[rcIt->second];
+        }
+        if (rh == RH_NONE || isTaken(rh)) {
+            ++skipped;
+            continue;
+        }
+        emit(rh, checkName, messages);
+        ++applied;
+    }
+}
+
+// ComboShip (#164): the launcher's combo Hint Tracker reveal sink.
+extern "C" void (*gComboHintReveal)(int fileNum, const char* comboKey) = nullptr;
+
+// Rebuild sComboHintKeys from the pushed seed blob when it doesn't match the live one. Covers every
+// load path where SOH_ApplyComboHints didn't run in this process; the shared walk keeps it drift-free.
+// Builds into a local and commits on success only — a half-built map must never latch as current-gen.
+static void Combo_EnsureHintKeyMap() {
+    const uint64_t gen = OOT_ForeignMapGen();
+    if (sComboHintKeysGen == gen) {
+        return;
+    }
+    std::unordered_map<int, std::string> built;
+    try {
+        nlohmann::json hints =
+            nlohmann::json::parse(ComboRando::g_comboForeignJson).value("hints", nlohmann::json::object());
+        int applied = 0, skipped = 0;
+        Combo_WalkComboHints(
+            hints, [&](RandomizerHint rh) { return built.count(rh) != 0; },
+            [&](RandomizerHint rh, const std::string& key, std::vector<CustomMessage>&) { built[rh] = key; }, applied,
+            skipped);
+    } catch (const std::exception& e) {
+        SPDLOG_ERROR("[ComboShip] Combo_EnsureHintKeyMap: exception: {} (will retry next reveal)", e.what());
+        return;
+    } catch (...) {
+        SPDLOG_ERROR("[ComboShip] Combo_EnsureHintKeyMap: unknown exception (will retry next reveal)");
+        return;
+    }
+    sComboHintKeys = std::move(built);
+    sComboHintKeysGen = gen;
+}
+
+// ComboShip (#164): OnRandoHintRevealed subscriber (registered from SOH_LoadComboRando). The hook can
+// fire for disabled hints and for native/warp-song hints combo never wrote — both are dropped here.
+// Fires from C textbox code, so nothing may escape: the whole body is guarded.
+void OOT_ComboHintRevealed(RandomizerHint hintKey) try {
+    if (!gComboHintReveal || hintKey == RH_NONE) {
+        return;
+    }
+    auto ctx = OTRGlobals::Instance->gRandoContext;
+    if (!ctx || !ctx->GetHint(hintKey)->IsEnabled()) {
+        return;
+    }
+    Combo_EnsureHintKeyMap();
+    auto it = sComboHintKeys.find(hintKey);
+    if (it == sComboHintKeys.end()) {
+        return;
+    }
+    gComboHintReveal(gSaveContext.fileNum, it->second.c_str());
+} catch (const std::exception& e) {
+    SPDLOG_ERROR("[ComboShip] OOT_ComboHintRevealed: exception: {}", e.what());
+} catch (...) { SPDLOG_ERROR("[ComboShip] OOT_ComboHintRevealed: unknown exception"); }
 #endif
 
 extern "C" __declspec(dllexport) void SOH_SetComboHintsPresent(int present) {
 #ifdef COMBO_BUILD
     sComboHintsPresent = present != 0;
+#endif
+}
+
+extern "C" __declspec(dllexport) void SOH_SetComboHintRevealCb(void (*cb)(int, const char*)) {
+#ifdef COMBO_BUILD
+    gComboHintReveal = cb;
+#else
+    (void)cb;
 #endif
 }
 
@@ -4535,59 +4663,17 @@ extern "C" __declspec(dllexport) void SOH_ApplyComboHints(const char* json) {
         auto ctx = OTRGlobals::Instance->gRandoContext;
         nlohmann::json hints = nlohmann::json::parse(json);
         int applied = 0, skipped = 0;
-        for (auto& entry : hints.value("oot", nlohmann::json::array())) {
-            std::string checkName = entry.value("checkName", "");
-            std::vector<CustomMessage> messages;
-            for (auto& m : entry.value("messages", nlohmann::json::array()))
-                messages.emplace_back(m.value("en", ""), m.value("de", ""), m.value("fr", ""));
-            if (messages.empty()) {
-                ++skipped;
-                continue;
-            }
-
-            RandomizerHint rh = RH_NONE;
-            if (checkName == "__GANONDORF__") {
-                rh = RH_GANONDORF_HINT;
-            } else if (checkName == "__ALTAR_CHILD__") {
-                rh = RH_ALTAR_CHILD;
-            } else if (checkName == "__ALTAR_ADULT__") {
-                rh = RH_ALTAR_ADULT;
-            } else if (checkName.rfind("__", 0) == 0) {
-                // "__STONE__N"/"__TRIAL__.../"__JUNK__...": CrossHints.h assigns these to an abstract
-                // stone SLOT (count only, not a specific check — combo doesn't pick which physical
-                // stone gets which content). Claim the next still-empty gossip-stone check for it.
-                auto stones = Rando::StaticData::GetGossipStoneLocations();
-                RandomizerCheck freeStone = RC_UNKNOWN_CHECK;
-                for (RandomizerCheck rc : stones) {
-                    RandomizerHint candidate = Rando::StaticData::gossipStoneCheckToHint.count(rc)
-                                                   ? Rando::StaticData::gossipStoneCheckToHint[rc]
-                                                   : RH_NONE;
-                    if (candidate != RH_NONE && !ctx->GetHint(candidate)->IsEnabled()) {
-                        freeStone = rc;
-                        rh = candidate;
-                        break;
-                    }
-                }
-                if (freeStone == RC_UNKNOWN_CHECK) {
-                    ++skipped;
-                    continue;
-                }
-            } else {
-                auto rcIt = Rando::StaticData::locationNameToEnum.find(checkName);
-                if (rcIt == Rando::StaticData::locationNameToEnum.end() ||
-                    !Rando::StaticData::gossipStoneCheckToHint.count(rcIt->second)) {
-                    ++skipped;
-                    continue;
-                }
-                rh = Rando::StaticData::gossipStoneCheckToHint[rcIt->second];
-            }
-            if (rh == RH_NONE || ctx->GetHint(rh)->IsEnabled()) {
-                ++skipped;
-                continue;
-            }
-            ctx->AddHint(rh, Rando::Hint(rh, messages));
-            ++applied;
-        }
+        std::unordered_map<int, std::string> built;
+        Combo_WalkComboHints(
+            hints, [&](RandomizerHint rh) { return ctx->GetHint(rh)->IsEnabled(); },
+            [&](RandomizerHint rh, const std::string& checkName, std::vector<CustomMessage>& messages) {
+                ctx->AddHint(rh, Rando::Hint(rh, messages));
+                built[rh] = checkName;
+            },
+            applied, skipped);
+        // Committed only past the walk — a throw leaves the previous gen stamped so the lazy replay retries.
+        sComboHintKeys = std::move(built);
+        sComboHintKeysGen = OOT_ForeignMapGen();
 
         // Native fills whatever combo didn't pre-populate (altar/Biggoron/mask-shop/skulltula-count/
         // ganondorf-joke/etc static hints; each self-skips an already-enabled key) + warp song texts.


### PR DESCRIPTION
Closes #164. Supersedes #166.

Moves the Hint Tracker into ComboShip Settings (directly under Check Tracker) as a combo-owned window showing combo-generated hints for both games, replacing the OOT-only native tracker (hidden in combo builds; its Journal/WotH/found views were already dead for combo seeds).

- New `combo/gui/ComboHintTracker`: unified window + settings panel (`gCombo.HintTracker.*`), grouped OOT stones/altar/Ganondorf/trials/always/junk + MM cross pool/revealed native/NPC hints, unread masked as "???" by default, search + hide-read filters. Draws from pushed strings only - no game-DLL/RM dependency.
- Read state: OOT `OnRandoHintRevealed` bridged via rh->comboKey map (shared resolver, deterministic replay); MM stone/NPC reveals reported via new `MM_SetComboHintRevealCb`; persisted in `.combosav` `combo.hintsRead`, erased on rebake, cleared on slot delete.
- MM in-game behavior unchanged (random pool kept); no generator/seed-format changes.
- ABI: `ComboUI_SetHintTrackerData`, `SOH_SetComboHintRevealCb`, `MM_SetComboHintRevealCb` (push model).

All four targets build clean (Debug). Code-reviewed; 10 findings fixed (ABI throw guard, gen-stamp ordering, taunt-path hint leak, mmNative dedup, stale-slot clears, per-entry JSON validation, UI fixes). UNPLAYTESTED - checklist in docs/deviations/rando.md section.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9403914112.zip)
<!--- section:artifacts:end -->