### PR TITLE
feat(combo): cross-game Personal Notes window (#165)

### DIFF
--- a/combo/CMakeLists.txt
+++ b/combo/CMakeLists.txt
@@ -37,9 +37,15 @@ set(COMBOUI_SOURCES
     gui/ComboTrackerSwap.cpp
     gui/ComboAudioBridge.cpp
     gui/ComboAnchorRoomWindow.cpp
+    gui/ComboNotesWindow.cpp
 )
 add_library(comboui SHARED ${COMBOUI_SOURCES})
 set_target_properties(comboui PROPERTIES PREFIX "")
+# ImGui's std::string InputText helper ships in the fetched tree but not in libultraship's ImGui
+# target. GetProperties re-exports imgui_SOURCE_DIR here (FetchContent ran in libultraship's scope).
+include(FetchContent)
+FetchContent_GetProperties(ImGui)
+target_sources(comboui PRIVATE ${imgui_SOURCE_DIR}/misc/cpp/imgui_stdlib.cpp)
 # ComboShip: deploy comboui.dll directly into the shared runtime dir (x64/<config>),
 # matching how soh/2ship set their own RUNTIME_OUTPUT_DIRECTORY. Without this, a
 # per-target `--target comboui` build lands in build/x64/combo/<config> and never

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -269,6 +269,10 @@ static FnComboUIRegister ComboUI_RestoreTrackerIntent = nullptr;
 typedef void (*FnComboUISetRosterProvider)(const char* (*)());
 static FnComboUISetRosterProvider ComboUI_SetAnchorRosterProvider = nullptr;
 
+// ComboShip (#165): hand comboui the launcher-owned per-slot notes accessors (combo.notes).
+typedef void (*FnComboUISetNotesStore)(const char* (*)(int), void (*)(int, const char*));
+static FnComboUISetNotesStore ComboUI_SetNotesStore = nullptr;
+
 // ComboShip-owned unified ROM extraction (see ComboExtract.h). The split init lets us create the
 // shared window from soh.o2r before any ROM exists, run the extraction screen, then finish.
 static FnVoid SOH_InitWindowOnly = nullptr;
@@ -385,6 +389,15 @@ static nlohmann::json& LoadOrCreateContainer(int fileNum) {
             parsed = false;
         }
     }
+    // ComboShip (#165): one-time migrate SoH's per-save notes into combo.notes. Absent-key gate only,
+    // so a deliberately cleared combo note is never re-migrated.
+    if (parsed && !(j.contains("combo") && j["combo"].is_object() && j["combo"].contains("notes"))) {
+        try {
+            auto& pn = j.at("oot").at("sections").at("itemTrackerData").at("data").at("personalNotes");
+            if (pn.is_string() && !pn.get<std::string>().empty())
+                j["combo"]["notes"] = pn;
+        } catch (...) {} // oot section absent/null — nothing to migrate
+    }
     if (!parsed)
         j = nlohmann::json{ { "comboVersion", 1 }, { "comboRelease", COMBO_RELEASE_VERSION },
                             { "slot", fileNum },   { "oot", nullptr },
@@ -495,6 +508,46 @@ static int Combo_GetLastGame(int fileNum) {
     auto& c = LoadOrCreateContainer(fileNum);
     int g = c.value("combo", nlohmann::json::object()).value("lastGame", (int)ComboRando::GAME_OOT);
     return (g == ComboRando::GAME_MM) ? ComboRando::GAME_MM : ComboRando::GAME_OOT;
+}
+
+// ComboShip (#165): the slot's cross-game personal notes. One note per slot, editable from either
+// game. Returned in a thread_local buffer (same lifetime contract as Combo_ReadGameSave).
+static const char* Combo_GetNotes(int fileNum) {
+    thread_local std::string buf;
+    if (!ComboIsValidSlot(fileNum)) {
+        buf.clear();
+        return buf.c_str();
+    }
+    std::lock_guard<std::mutex> lk(g_containerMutex);
+    buf.clear();
+    // find()-based: never throws (comboui calls these by raw fn-ptr) and never copies combo.rando.
+    auto& c = LoadOrCreateContainer(fileNum);
+    auto combo = c.find("combo");
+    if (combo != c.end() && combo->is_object()) {
+        auto n = combo->find("notes");
+        if (n != combo->end() && n->is_string())
+            buf = n->get<std::string>();
+    }
+    return buf.c_str();
+}
+
+static void Combo_SetNotes(int fileNum, const char* text) {
+    if (!text || !ComboIsValidSlot(fileNum))
+        return;
+    std::lock_guard<std::mutex> lk(g_containerMutex);
+    auto& c = LoadOrCreateContainer(fileNum);
+    const std::string* cur = nullptr;
+    auto combo = c.find("combo");
+    if (combo != c.end() && combo->is_object()) {
+        auto n = combo->find("notes");
+        if (n != combo->end() && n->is_string())
+            cur = &n->get_ref<const std::string&>();
+    }
+    // Unchanged — don't rewrite the container on every debounce (absent/non-string compares as "").
+    if (cur ? *cur == text : !*text)
+        return;
+    c["combo"]["notes"] = text;
+    FlushContainer(fileNum);
 }
 
 // ComboShip (issue #1): erasing a slot from either game's file-select wipes BOTH saves — each game
@@ -2212,6 +2265,13 @@ static void Combo_OnOOTSaveInit(int fileNum) {
     // A new file starts in OOT. Explicit because not every delete path clears the container
     // (DeleteFileOnDeath calls DeleteZeldaFile directly), so a stale MM could otherwise survive here.
     Combo_SetLastGame(fileNum, ComboRando::GAME_OOT);
+    // ComboShip (#165): a fresh file starts with an empty personal note. Written, never erased — an
+    // absent key is the "never migrated" sentinel, so erasing could resurrect the old file's note.
+    {
+        std::lock_guard<std::mutex> lk(g_containerMutex);
+        LoadOrCreateContainer(fileNum)["combo"]["notes"] = "";
+        FlushContainer(fileNum);
+    }
     // ComboShip: bind the pending consolidated seed to this slot — bake it into the container's
     // combo.rando (self-contained), then push it into both DLLs so foreign data is live immediately.
     nlohmann::json seed;
@@ -2829,6 +2889,9 @@ int main(int argc, char** argv) {
             (FnComboUISetRosterProvider)GetSym(comboUIModule, "ComboUI_SetAnchorRosterProvider");
         if (ComboUI_SetAnchorRosterProvider)
             ComboUI_SetAnchorRosterProvider(&ComboAnchor::Combo_Anchor_GetRoster);
+        ComboUI_SetNotesStore = (FnComboUISetNotesStore)GetSym(comboUIModule, "ComboUI_SetNotesStore");
+        if (ComboUI_SetNotesStore)
+            ComboUI_SetNotesStore(&Combo_GetNotes, &Combo_SetNotes);
         if (ComboUI_Register) {
             ComboUI_Register();
             std::cout << "[ComboShip] comboui registered (unified menu installed)." << std::endl;

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -8,6 +8,7 @@
 #include "ComboTrackerCommon.h" // kKinds (HideBackground CVars for the tracker panels)
 #include "ComboTrackerSwap.h"
 #include "ComboAnchorRoomWindow.h"  // combo-native floating Anchor room window
+#include "ComboNotesWindow.h"       // combo-owned cross-game Personal Notes window
 #include "rando/ComboPlaythrough.h" // plando: ParseSpoilerPlacements + Suffix/BuildForeignArray + slot paths
 #include <imgui.h>
 #include <libultraship/libultraship.h>         // CVar bridge (CVarGet/Set* incl. color) + color.h (Color_RGBA8)
@@ -113,11 +114,9 @@ constexpr const char* SyncItemsAndFlags = "gRemote.Anchor.RoomSettings.SyncItems
 // that plays an edited consolidated spoiler back verbatim. Resolved like the combo-gen syms above.
 typedef const char* (*FnDump)(void);
 typedef int (*FnRequestReload)(const char*);
-typedef int (*FnGetActiveFileNum)(void);
 FnDump sSohDump = nullptr;
 FnDump sMmDump = nullptr;
 FnRequestReload sRequestReload = nullptr;
-FnGetActiveFileNum sGetActiveFileNum = nullptr;
 void ResolvePlandoSyms() {
 #ifdef _WIN32
     if (HMODULE h = GetModuleHandleA("soh.dll")) {
@@ -125,8 +124,6 @@ void ResolvePlandoSyms() {
             sSohDump = (FnDump)GetProcAddress(h, "SOH_DumpRandoStaticData");
         if (!sRequestReload)
             sRequestReload = (FnRequestReload)GetProcAddress(h, "SOH_RequestComboReload");
-        if (!sGetActiveFileNum)
-            sGetActiveFileNum = (FnGetActiveFileNum)GetProcAddress(h, "SOH_GetActiveFileNum");
     }
     if (HMODULE h = GetModuleHandleA("2ship.dll")) {
         if (!sMmDump)
@@ -646,6 +643,16 @@ void DrawTrackerSharedPanel() {
             changed = true;
         }
 
+        ImGui::SeparatorText("Personal Notes (both games)");
+        bool notes = ComboNotes::WindowShown();
+        ComboRando::ComboMenu_PushCheckbox(theme);
+        if (ImGui::Checkbox("Show Personal Notes window", &notes)) {
+            ComboNotes::SetWindowShown(notes);
+            changed = true;
+        }
+        ComboRando::ComboMenu_PopCheckbox();
+        ImGui::TextDisabled("One note per save slot, shared by both games.");
+
         ImGui::EndTable();
     }
 
@@ -993,7 +1000,7 @@ void PlandoLoad() {
         sPlando.loadedJson = readFile(sPlando.spoilerPaths[sPlando.spoilerSel]);
         srcLabel = std::filesystem::path(sPlando.spoilerPaths[sPlando.spoilerSel]).filename().string();
     } else {
-        int slot = sGetActiveFileNum ? sGetActiveFileNum() : -1;
+        int slot = ComboTracker::OotActiveSlot();
         if (slot >= 0) {
             try {
                 auto cj = nlohmann::json::parse(
@@ -1770,4 +1777,7 @@ extern "C" void ComboUI_Register(void)
 
     // Combo-native floating Anchor room window (toggled from the Anchor panel).
     ComboRando::RegisterAnchorRoomWindow();
+
+    // Combo-owned cross-game Personal Notes window (toggled from the Shared item tracker panel).
+    ComboNotes::RegisterWindow();
 }

--- a/combo/gui/ComboNotesWindow.cpp
+++ b/combo/gui/ComboNotesWindow.cpp
@@ -1,0 +1,118 @@
+// combo/gui/ComboNotesWindow.cpp — see ComboNotesWindow.h
+#include "ComboNotesWindow.h"
+#include "ComboWidgetStyle.h"   // themed input styling (comboui cannot call the games' UIWidgets)
+#include "ComboTrackerCommon.h" // ComboTracker::OotActiveSlot + SetTracker
+#include <imgui.h>
+#include <misc/cpp/imgui_stdlib.h>     // InputTextMultiline over a std::string (vendored with ImGui)
+#include <libultraship/libultraship.h> // CVar bridge
+#include <ship/Context.h>
+#include <string>
+
+namespace {
+
+constexpr const char* kVisibilityCvar = "gCombo.Tracker.NotesWindow";
+// The ##Combo suffix keeps our ImGui identity distinct from soh's retired "Personal Notes" window.
+constexpr const char* kWindowName = "Personal Notes##Combo";
+
+// Launcher-owned per-slot note store (registered via ComboUI_SetNotesStore).
+const char* (*sGet)(int) = nullptr;
+void (*sSet)(int, const char*) = nullptr;
+
+std::string sBuf;
+int sLoadedSlot = -1;
+bool sDirty = false;
+int sDirtySlot = -1;
+double sLastEdit = 0.0;
+
+std::shared_ptr<ComboNotesWindow> sWindow;
+
+} // namespace
+
+// Callers always flush BEFORE reloading sBuf, so sBuf still holds sDirtySlot's text here.
+void ComboNotes::FlushPending() {
+    if (sDirty && sSet && sDirtySlot >= 0) {
+        sSet(sDirtySlot, sBuf.c_str());
+    }
+    sDirty = false;
+}
+
+void ComboNotesWindow::Draw() {
+    auto ctx = Ship::Context::GetRawInstance();
+    if (!ctx || !ctx->GetWindow() || !ctx->GetWindow()->GetGui()) {
+        return;
+    }
+    // comboui's per-module GImGui must point at the shared context (same pattern as ComboMenu/SwapWindow).
+    ImGui::SetCurrentContext(ctx->GetWindow()->GetGui()->GetImGuiContext());
+
+    if (!IsVisible()) {
+        ComboNotes::FlushPending(); // closing the window must not drop a just-typed note
+        sLoadedSlot = -1;           // an erase/copy/new file can change the note while we're hidden
+        return;
+    }
+
+    int slot = ComboTracker::OotActiveSlot();
+    if (slot != sLoadedSlot) {
+        ComboNotes::FlushPending();
+        sLoadedSlot = slot;
+        sBuf = (slot >= 0 && sGet) ? sGet(slot) : ""; // copy out of the launcher's thread_local now
+    }
+    if (slot < 0) {
+        return; // no save loaded (title/file select)
+    }
+
+    ImGui::SetNextWindowSize(ImVec2(400, 300), ImGuiCond_FirstUseEver);
+    if (ImGui::Begin(kWindowName, nullptr, ImGuiWindowFlags_NoFocusOnAppearing)) {
+        DrawElement();
+    }
+    ImGui::End();
+    SyncVisibilityConsoleVariable();
+}
+
+void ComboNotesWindow::DrawElement() {
+    ComboRando::ComboMenu_PushInput(ComboRando::ComboMenu_ThemeColor());
+    bool edited = ImGui::InputTextMultiline("##ComboNotes", &sBuf, ImVec2(-FLT_MIN, ImGui::GetContentRegionAvail().y),
+                                            ImGuiInputTextFlags_AllowTabInput);
+    ComboRando::ComboMenu_PopInput();
+
+    if (edited) {
+        sDirty = true;
+        sDirtySlot = sLoadedSlot;
+        sLastEdit = ImGui::GetTime();
+    }
+    // Persist on focus loss, or 2s after the last keystroke (SoH's 40-idle-frame equivalent).
+    if (ImGui::IsItemDeactivatedAfterEdit() || (sDirty && ImGui::GetTime() - sLastEdit > 2.0)) {
+        ComboNotes::FlushPending();
+    }
+}
+
+bool ComboNotes::WindowShown() {
+    return CVarGetInteger(kVisibilityCvar, 0) != 0;
+}
+
+void ComboNotes::SetWindowShown(bool shown) {
+    ComboTracker::SetTracker({ kVisibilityCvar, kWindowName }, shown);
+}
+
+void ComboNotes::RegisterWindow() {
+    auto ctx = Ship::Context::GetRawInstance();
+    if (!ctx || !ctx->GetWindow() || !ctx->GetWindow()->GetGui()) {
+        return;
+    }
+    if (!sWindow) {
+        sWindow = std::make_shared<ComboNotesWindow>(kVisibilityCvar, kWindowName);
+    }
+    ctx->GetWindow()->GetGui()->AddGuiWindow(sWindow);
+}
+
+// ComboShip (#165): the launcher hands comboui its per-slot notes accessors here (called at startup,
+// right before ComboUI_Register).
+#ifdef _WIN32
+extern "C" __declspec(dllexport) void ComboUI_SetNotesStore(const char* (*getter)(int),
+                                                            void (*setter)(int, const char*))
+#else
+extern "C" void ComboUI_SetNotesStore(const char* (*getter)(int), void (*setter)(int, const char*))
+#endif
+{
+    sGet = getter;
+    sSet = setter;
+}

--- a/combo/gui/ComboNotesWindow.h
+++ b/combo/gui/ComboNotesWindow.h
@@ -1,0 +1,35 @@
+// combo/gui/ComboNotesWindow.h
+//
+// ComboShip (#165): combo-native cross-game Personal Notes window. Replaces soh's OOT-only item
+// tracker notes (compiled out in combo builds). One note per save slot, stored by the launcher as
+// combo.notes in the slot's .combosav (accessors pushed in via ComboUI_SetNotesStore), so the same
+// text is editable from either game and survives OOT<->MM switches.
+#pragma once
+
+#include <ship/window/gui/GuiWindow.h>
+
+namespace ComboNotes {
+
+// Registered in ComboUI_Register alongside the tracker windows; toggled from the Shared tracker panel.
+void RegisterWindow();
+
+bool WindowShown();
+void SetWindowShown(bool shown);
+
+// Persist pending edits now (window close, slot change, debounce, game switch, shutdown).
+void FlushPending();
+
+} // namespace ComboNotes
+
+class ComboNotesWindow final : public Ship::GuiWindow {
+  public:
+    using GuiWindow::GuiWindow;
+    void Draw() override;
+
+  protected:
+    void InitElement() override {
+    }
+    void UpdateElement() override {
+    }
+    void DrawElement() override;
+};

--- a/combo/gui/ComboTrackerCommon.h
+++ b/combo/gui/ComboTrackerCommon.h
@@ -1,13 +1,36 @@
 // combo/gui/ComboTrackerCommon.h
 //
-// Tracker-window plumbing shared by ComboTrackerVisibility (foreground follow) and
-// ComboTrackerSwap (game swap): the CVar + Gui-map levers for the per-game tracker windows.
+// Tracker-window plumbing shared across comboui: the CVar + Gui-map levers for the per-game tracker
+// windows, plus the active-slot resolve every panel needs.
 
 #pragma once
 
 #include <libultraship/libultraship.h>
+#ifdef _WIN32
+#include <windows.h> // GetModuleHandleA/GetProcAddress (SOH_GetActiveFileNum)
+#endif
 
 namespace ComboTracker {
+
+// Active OOT save slot (0-2), or -1 at the title/file-select screens. The slot is combo-wide, so
+// every comboui caller shares this one latched resolve (inline statics are per-DLL, not per-TU).
+inline int OotActiveSlot() {
+#ifdef _WIN32
+    static int (*sGetFileNum)(void) = nullptr;
+    static bool sTried = false;
+    if (!sTried) {
+        sTried = true;
+        if (HMODULE soh = GetModuleHandleA("soh.dll")) {
+            sGetFileNum = (int (*)(void))GetProcAddress(soh, "SOH_GetActiveFileNum");
+        }
+    }
+    if (sGetFileNum) {
+        int slot = sGetFileNum();
+        return (slot >= 0 && slot <= 2) ? slot : -1;
+    }
+#endif
+    return -1;
+}
 
 struct Win {
     const char* cvar; // visibility CVar (source of truth; MM's CheckTracker reads it directly)

--- a/combo/gui/ComboTrackerSwap.cpp
+++ b/combo/gui/ComboTrackerSwap.cpp
@@ -15,6 +15,7 @@ namespace {
 
 using ComboTracker::kKinds;
 using ComboTracker::kTrackers;
+using ComboTracker::OotActiveSlot;
 
 constexpr float kHoldSeconds = 0.5f;
 constexpr float kHoldDragCancelSqr = 5.0f * 5.0f; // px² of movement that turns a hold into a drag
@@ -26,25 +27,6 @@ struct Peek {
     bool held = false;      // hold fired; the dormant game's window shows until release
 };
 Peek sPeeks[ComboTracker::kSwapCount];
-
-// Active OOT save slot (0-2), or -1 at the title/file-select screens.
-int OotActiveSlot() {
-#ifdef _WIN32
-    static int (*sGetFileNum)(void) = nullptr;
-    static bool sTried = false;
-    if (!sTried) {
-        sTried = true;
-        if (HMODULE soh = GetModuleHandleA("soh.dll")) {
-            sGetFileNum = (int (*)(void))GetProcAddress(soh, "SOH_GetActiveFileNum");
-        }
-    }
-    if (sGetFileNum) {
-        int slot = sGetFileNum();
-        return (slot >= 0 && slot <= 2) ? slot : -1;
-    }
-#endif
-    return -1;
-}
 
 // Combined Triforce progress (#136): counts live in the two game DLLs, the goal in soh's copy of the
 // slot's seed. Returns false unless the loaded seed's goal is a hunt.

--- a/combo/gui/ComboTrackerVisibility.cpp
+++ b/combo/gui/ComboTrackerVisibility.cpp
@@ -13,6 +13,7 @@
 #include "ComboAudioBridge.h"          // ComboAudio::SyncAllToMM (on MM entry)
 #include "ComboTrackerCommon.h"        // kTrackers/SetTracker (shared with ComboTrackerSwap)
 #include "ComboTrackerBridge.h"        // ComboTracker::SyncAppearance (re-assert on transitions)
+#include "ComboNotesWindow.h"          // ComboNotes::FlushPending (persist notes across transitions)
 #ifdef _WIN32
 #include <windows.h> // GetModuleHandleA/GetProcAddress for the MM_ReloadControls entry point
 #endif
@@ -149,11 +150,16 @@ extern "C" __declspec(dllexport) void ComboUI_OnForegroundGame(int game) {
     // Re-assert shared tracker appearance (per-game edits made while dormant lose). A sticky swap
     // re-applies itself next frame via the swap window's reconcile.
     ComboTracker::SyncAppearance();
+
+    // ComboShip (#165): persist any pending note text at the transition.
+    ComboNotes::FlushPending();
 }
 
 // Launcher, just before shutdown: restore the backgrounded game's settings-window CVars so they
 // don't persist as "off" (main tracker CVars are derived and recomputed on next boot).
 extern "C" __declspec(dllexport) void ComboUI_RestoreTrackerIntent(void) {
+    // ComboShip (#165): the launcher calls this pre-shutdown, so a just-typed note still lands.
+    ComboNotes::FlushPending();
     // Only the background game's CVars are forced-hidden; the foreground game's live values already
     // reflect the user's latest toggles (a stale snapshot would clobber them).
     const int bg = sForegroundGame ^ 1;

--- a/docs/deviations/tracker.md
+++ b/docs/deviations/tracker.md
@@ -227,3 +227,43 @@ range), new "Only enable while paused" checkbox + a hint when the window type is
   (pre-existing upstream nesting); MM honors paused-only in both. The shared panel says so inline.
 - The per-group scale is still MM-only; OOT has no equivalent, so a non-1.0 group scale breaks
   cross-game icon parity by design.
+
+## Cross-game Personal Notes (issue #165)
+
+**Why:** SoH's item-tracker notes live in the OOT save's `itemTrackerData` section, so a note taken
+in OOT was invisible in MM and the MM-side tracker had no notes at all. Worse, the notes widget is
+reachable during the dormant-game peek, and its save path (`SaveSection(gSaveContext.fileNum, ...)`)
+would flush a stale OOT saveBlock while MM held the foreground. The note is per *slot*, not per game,
+so the launcher — the owner of the merged container — is the right place for it.
+
+**Vendored (`COMBO_BUILD`-guarded, all in `soh/.../randomizer_item_tracker.cpp`):**
+- The `DisplayType.Notes` clause in the main-window OR-condition (`ItemTrackerWindow::DrawElement`).
+- The main-window `DrawNotes()` call.
+- The separate "Personal Notes" floating-window block.
+- The `personalNotesWiget` `MenuDrawItem` call in `ItemTrackerSettingsWindow::DrawElement`.
+- The `personalNotesWiget` definition + `AddSearchWidget` registration.
+- `ItemTrackerSaveFile` writes an empty `personalNotes` (nothing in a combo build can edit or clear
+  the loaded buffer, so the pre-migration text would otherwise round-trip forever).
+
+`DrawNotes`, `itemTrackerNotes`, and the `itemTrackerData` load/init functions are untouched: the
+section keeps round-tripping so a combo container can be migrated (and standalone SoH is unaffected).
+Migration runs at container load, before any save could scrub the legacy field.
+
+**Combo-owned:**
+- `combo/gui/ComboNotesWindow.{h,cpp}` — `ComboNotesWindow` (registered in `ComboUI_Register`,
+  visibility CVar `gCombo.Tracker.NotesWindow`, ImGui identity `Personal Notes##Combo`). Buffer is a
+  `std::string` edited through the vendored `misc/cpp/imgui_stdlib` overload (compiled into comboui)
+  — never an `ImVector` (see `boot-shutdown.md`). Hidden entirely when no save is loaded. Toggled
+  from Shared > Item Tracker.
+- `combo/ComboShip.cpp` — `Combo_GetNotes`/`Combo_SetNotes` over `combo.notes` (find()-based so the
+  raw-fn-ptr calls can't throw and never deep-copy `combo.rando`; unchanged-value short-circuit so
+  the debounce doesn't rewrite the container); `LoadOrCreateContainer` one-time migration of
+  `oot.sections.itemTrackerData.data.personalNotes` into `combo.notes`, gated on the key being
+  *absent* so a deliberately cleared note is never resurrected; `Combo_OnOOTSaveInit` writes an empty
+  `combo.notes` so a fresh file starts blank (written, never erased — erasing would re-arm the
+  migration gate; outside the seed branch, so it runs even when seed parsing fails).
+- Seam: `ComboUI_SetNotesStore(getter, setter)`, resolved next to `ComboUI_SetAnchorRosterProvider`.
+- Flush points: window close, slot change, `IsItemDeactivatedAfterEdit`, a 2s wall-clock debounce
+  (SoH's 40-idle-frame equivalent), `ComboUI_OnForegroundGame` (OOT<->MM switch), and
+  `ComboUI_RestoreTrackerIntent` (launcher pre-shutdown). Every reload of the buffer flushes first,
+  so the pending text always belongs to `sDirtySlot`.

--- a/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer_item_tracker.cpp
@@ -1824,8 +1824,13 @@ void ItemTrackerInitFile(bool isDebug) {
 }
 
 void ItemTrackerSaveFile(SaveContext* saveContext, int sectionID, bool fullSave) {
+#ifdef COMBO_BUILD
+    // ComboShip (#165): notes live in combo.notes; scrub the legacy field so stale text stops round-tripping.
+    SaveManager::Instance->SaveData("personalNotes", "");
+#else
     SaveManager::Instance->SaveData("personalNotes",
                                     std::string(std::begin(itemTrackerNotes), std::end(itemTrackerNotes)).c_str());
+#endif
 }
 
 void ItemTrackerLoadFile() {
@@ -1906,16 +1911,23 @@ void ItemTrackerWindow::DrawElement() {
             (CVarGetInteger(CVAR_TRACKER_ITEM("DisplayType.TriforcePieces"), SECTION_DISPLAY_HIDDEN) ==
              SECTION_DISPLAY_MAIN_WINDOW) ||
             (CVarGetInteger(CVAR_TRACKER_ITEM("DisplayType.FishingPole"), SECTION_DISPLAY_EXTENDED_HIDDEN) ==
-             SECTION_DISPLAY_EXTENDED_MAIN_WINDOW) ||
-            (CVarGetInteger(CVAR_TRACKER_ITEM("DisplayType.Notes"), SECTION_DISPLAY_HIDDEN) ==
-             SECTION_DISPLAY_MAIN_WINDOW)) {
+             SECTION_DISPLAY_EXTENDED_MAIN_WINDOW)
+// ComboShip (#165): native notes replaced by the combo-owned cross-game Personal Notes window.
+#ifndef COMBO_BUILD
+            || (CVarGetInteger(CVAR_TRACKER_ITEM("DisplayType.Notes"), SECTION_DISPLAY_HIDDEN) ==
+                SECTION_DISPLAY_MAIN_WINDOW)
+#endif
+        ) {
             BeginFloatingWindows("Item Tracker");
             DrawItemsInRows(mainWindowItems, 6);
 
+// ComboShip (#165): native notes replaced by the combo-owned cross-game Personal Notes window.
+#ifndef COMBO_BUILD
             if (CVarGetInteger(CVAR_TRACKER_ITEM("DisplayType.Notes"), SECTION_DISPLAY_HIDDEN) ==
                 SECTION_DISPLAY_MAIN_WINDOW) {
                 DrawNotes();
             }
+#endif
             EndFloatingWindows();
         }
 
@@ -2034,6 +2046,8 @@ void ItemTrackerWindow::DrawElement() {
             EndFloatingWindows();
         }
 
+// ComboShip (#165): native notes replaced by the combo-owned cross-game Personal Notes window.
+#ifndef COMBO_BUILD
         if (CVarGetInteger(CVAR_TRACKER_ITEM("DisplayType.Notes"), SECTION_DISPLAY_HIDDEN) ==
                 SECTION_DISPLAY_SEPARATE &&
             (CVarGetInteger(CVAR_TRACKER_ITEM("WindowType"), TRACKER_WINDOW_FLOATING) == TRACKER_WINDOW_WINDOW ||
@@ -2045,6 +2059,7 @@ void ItemTrackerWindow::DrawElement() {
             DrawNotes(true);
             EndFloatingWindows();
         }
+#endif
 
         if (CVarGetInteger("gTrackers.ItemTracker.TotalChecks.DisplayType", SECTION_DISPLAY_MINIMAL_HIDDEN) ==
             SECTION_DISPLAY_MINIMAL_SEPARATE) {
@@ -2250,7 +2265,10 @@ void ItemTrackerSettingsWindow::DrawElement() {
             shouldUpdateVectors = true;
         }
 
+// ComboShip (#165): native notes replaced by the combo-owned cross-game Personal Notes window.
+#ifndef COMBO_BUILD
         SohGui::mSohMenu->MenuDrawItem(personalNotesWiget, 250, THEME_COLOR);
+#endif
         SohGui::mSohMenu->MenuDrawItem(hookshotIdentWidget, 250, THEME_COLOR);
         SohGui::mSohMenu->MenuDrawItem(openChestIdentWidget, 250, THEME_COLOR);
 
@@ -2437,6 +2455,8 @@ void RegisterItemTrackerWidgets() {
     SohGui::mSohMenu->AddSearchWidget(
         { fishingPoleTracking, "Randomizer", "Item Tracker", "General Settings", "icon" });
 
+// ComboShip (#165): native notes replaced by the combo-owned cross-game Personal Notes window.
+#ifndef COMBO_BUILD
     personalNotesWiget = { .name = "Personal notes", .type = WidgetType::WIDGET_CVAR_COMBOBOX };
     static const char* notesDisabledTooltip =
         "Disabled because tracker is set to floating and display combo is enabled.";
@@ -2450,6 +2470,7 @@ void RegisterItemTrackerWidgets() {
         .Callback([](WidgetInfo& info) { shouldUpdateVectors = true; });
     ;
     SohGui::mSohMenu->AddSearchWidget({ personalNotesWiget, "Randomizer", "Item Tracker", "General Settings" });
+#endif
 
     hookshotIdentWidget = { .name = "Show Hookshot Identifiers", .type = WidgetType::WIDGET_CVAR_CHECKBOX };
     hookshotIdentWidget.CVar(CVAR_TRACKER_ITEM("HookshotIdentifier"))


### PR DESCRIPTION
Closes #165.

SoH's Item Tracker "Personal Notes" was OOT-only: the text persisted in the `itemTrackerData` section of the OOT save, MM had no equivalent, and during a dormant OOT tracker peek the notes box stayed editable and could flush a stale OOT saveBlock into the combosav.

## What this does
- New combo-owned **Personal Notes** floating window in comboui.dll, toggled from Combo Menu > Shared > Item Tracker. One note per save slot, shared by both games, visible/editable whichever game is foreground.
- Storage: `combo.notes` in `Save/file{N+1}.combosav`, via launcher accessors pushed into comboui (`ComboUI_SetNotesStore`). Debounced persist (focus loss / 2s idle) plus flushes on window close, slot change, OOT<->MM transition, and pre-shutdown.
- One-time migration of existing `oot...itemTrackerData.data.personalNotes` into `combo.notes` (absent-key gated so a cleared note never resurrects); fresh files start with an empty note; erase/copy behave via the container.
- SoH's native notes UI is COMBO_BUILD-hidden (5 guards) and the legacy save field is scrubbed on save, which also removes the dormant-peek stale-save hazard.
- Cleanup: `OotActiveSlot()` deduplicated into ComboTrackerCommon.h (3 copies -> 1); notes input uses the vendored imgui_stdlib.

Deviations documented in docs/deviations/tracker.md.

## Testing
- comboui, soh, ComboShip all build clean (Debug); clang-format-14 verified no-op on touched files.
- Unplaytested. Checklist: persist across relaunch; edit from MM foreground; no cross-slot bleed; erase/copy; legacy migration; no notes option left in SoH tracker settings; quit-right-after-typing persists.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9416478289.zip)
<!--- section:artifacts:end -->