### PR TITLE
Fire randomize-on-gen hooks on combo seed paths + Sync Randomized Cosmetics

### DIFF
--- a/combo/CMakeLists.txt
+++ b/combo/CMakeLists.txt
@@ -39,6 +39,7 @@ set(COMBOUI_SOURCES
     gui/ComboAnchorRoomWindow.cpp
     gui/ComboNotesWindow.cpp
     gui/ComboHintTracker.cpp
+    gui/ComboCosmeticsSync.cpp
 )
 add_library(comboui SHARED ${COMBOUI_SOURCES})
 set_target_properties(comboui PROPERTIES PREFIX "")

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -217,6 +217,9 @@ typedef void (*FnApplyHints)(const char*);
 typedef void (*FnSetHintsPresent)(int);
 static FnApplyHints SOH_ApplyComboHints = nullptr;
 static FnSetHintsPresent SOH_SetComboHintsPresent = nullptr;
+// #169: OOT's generation-completion hooks (cosmetics/audio randomize-on-gen) — combo's fill never
+// reaches the vanilla fire site, so the launcher fires them itself (see Combo_FireGenRollHooksOnce).
+static FnVoidArgless SOH_FireGenerationCompleteHooks = nullptr;
 // Reload/remember-seed: restore settings + run the pool prep before re-applying saved placements.
 typedef void (*FnVoidV)(void);
 typedef void (*FnTakeStr)(const char*);
@@ -281,6 +284,27 @@ typedef void (*FnSetHintRevealOot)(void (*)(int, const char*));
 static FnSetHintRevealOot SOH_SetComboHintRevealCb = nullptr;
 typedef void (*FnSetHintRevealMm)(void (*)(int, int, int, const char*, const char*));
 static FnSetHintRevealMm MM_SetComboHintRevealCb = nullptr;
+
+// ComboShip (#169): combo-owned OOT->MM cosmetic color sync (combo/gui/ComboCosmeticsSync.cpp). The
+// gate predicate is exported too, so the launcher never duplicates the CVar reads.
+static FnVoidArgless ComboUI_SyncRandomizedCosmetics = nullptr;
+typedef int (*FnComboUIGate)(void);
+static FnComboUIGate ComboUI_CosmeticsSyncGateEnabled = nullptr;
+// Per-seed latch for the gen-roll hooks (comboui owns it — the exe has no CVar API). 1 = not rolled yet.
+typedef int (*FnClaimGenRollSeed)(unsigned long long);
+static FnClaimGenRollSeed ComboUI_ClaimGenRollSeed = nullptr;
+
+// ComboShip (#169): fire OOT's generation-completion hooks at most once per seed per machine, so the
+// silent auto-load on every boot cannot re-roll over cosmetic/audio edits the user made by hand.
+// force = fresh generation: still claim the seed (so later loads of it leave manual edits alone) but
+// roll regardless, keeping vanilla's unconditional gen-only semantics.
+static void Combo_FireGenRollHooksOnce(uint64_t masterSeed, bool force = false) {
+    if (!SOH_FireGenerationCompleteHooks)
+        return;
+    const bool claimed = ComboUI_ClaimGenRollSeed && ComboUI_ClaimGenRollSeed(masterSeed);
+    if (claimed || force)
+        SOH_FireGenerationCompleteHooks();
+}
 
 // ComboShip-owned unified ROM extraction (see ComboExtract.h). The split init lets us create the
 // shared window from soh.o2r before any ROM exists, run the extraction screen, then finish.
@@ -626,6 +650,7 @@ static std::atomic<bool> g_ComboPendingFinalize{ false }; // worker succeeded, m
 static std::string g_FinalizeOotApply;
 static std::filesystem::path g_FinalizeSpoilerPath;
 static uint32_t g_FinalizeDisplaySeed = 0;
+static uint32_t g_FinalizeMasterSeed = 0; // #169: the gen-roll latch keys off the master seed, not the display hash
 // Consolidated spoiler JSON for the just-generated seed. The worker writes the pending file from it;
 // Combo_OnOOTSaveInit bakes it into the slot's container and pushes it into both DLLs at Start.
 static std::string g_ConsolidatedJson;
@@ -1718,6 +1743,7 @@ static void RunComboFill(std::string inputSeed, ComboRando::ComboGenProgress* pr
         uint32_t displaySeed = ComboHash((inputSeed + sohDump + mmDump).c_str());
         g_FinalizeOotApply = ootApply.dump();
         g_FinalizeDisplaySeed = displaySeed;
+        g_FinalizeMasterSeed = masterSeed;
 
         // ComboShip: file_hash = the 5 icon indexes the file-select shows, derived from displaySeed
         // exactly as OOT's GenerateHash (decimal padded to 10, five 2-digit pairs).
@@ -2072,6 +2098,9 @@ static void Combo_FinalizeGenerate() {
     g_FinalizeSpoilerPath.clear();
     if (hintsPresent && SOH_ApplyComboHints)
         SOH_ApplyComboHints(hints.dump().c_str());
+    // #169: a fresh generation always re-rolls (vanilla gen-only semantics), and claims the seed on
+    // the way through so later loads of THIS seed leave the user's manual edits alone.
+    Combo_FireGenRollHooksOnce(g_FinalizeMasterSeed, /*force=*/true);
     // A fresh generation's live MM CVars already ARE this seed's settings, so slot-bind must fall
     // through to reading them directly — clear any stale reload-restore state left by an unstarted
     // pending seed (else it would apply THAT seed's MM settings over this generation's placements).
@@ -2309,6 +2338,10 @@ static int Combo_OnReloadRequest(const char* path) {
             SOH_SetComboSeedHash(displaySeed);
         if (hintsPresent && SOH_ApplyComboHints)
             SOH_ApplyComboHints(j.value("hints", nlohmann::json::object()).dump().c_str());
+        // #169: a seed recipient never runs Combo_FinalizeGenerate, so roll here too — the ctx seed is
+        // set by now, so it reproduces the generator's colors exactly. Not sync-gated: each hook
+        // subscriber checks its own CVars, and the latch keeps this to once per seed.
+        Combo_FireGenRollHooksOnce(masterSeed);
 
         // Reproduction is done — put the user's OOT settings back so comboship.json (and the menu)
         // stay authoritative. An explicit drop instead keeps the seed's settings as the new baseline.
@@ -2433,6 +2466,14 @@ static void Combo_OnOOTSaveInit(int fileNum) {
         if (MM_InitRandoSaveFile(fileNum, mmPlacements.c_str(), playerName) != 0) {
             std::cerr << "[ComboShip] ERROR: MM rando save creation FAILED for slot " << fileNum
                       << " — this slot's MM save has no placements. Re-create it." << std::endl;
+        } else if (ComboUI_SyncRandomizedCosmetics) {
+            // #169: MM has just rolled its own cosmetics (generation hook inside the call above); with
+            // sync on, hand it OOT's colors instead so the shared elements match. Roll OOT first: the
+            // latch skipped it at load time if the options were off, so enabling them mid-seed still
+            // syncs this seed's fresh colors rather than whatever was persisted.
+            if (ComboUI_CosmeticsSyncGateEnabled && ComboUI_CosmeticsSyncGateEnabled())
+                Combo_FireGenRollHooksOnce(seed.value("masterSeed", 0u));
+            ComboUI_SyncRandomizedCosmetics();
         }
         // Silent auto-load: the save now has the seed's settings baked in — return the CVars to the
         // user's config. An explicit drop leaves the seed's settings as the new persisted baseline.
@@ -2680,6 +2721,7 @@ int main(int argc, char** argv) {
     SOH_DumpRandoHintData = (FnDumpData)GetSym(sohModule, "SOH_DumpRandoHintData");
     SOH_ApplyComboHints = (FnApplyHints)GetSym(sohModule, "SOH_ApplyComboHints");
     SOH_SetComboHintsPresent = (FnSetHintsPresent)GetSym(sohModule, "SOH_SetComboHintsPresent");
+    SOH_FireGenerationCompleteHooks = (FnVoidArgless)GetSym(sohModule, "SOH_FireGenerationCompleteHooks");
     // #164: combo Hint Tracker reveal reporting.
     SOH_SetComboHintRevealCb = (FnSetHintRevealOot)GetSym(sohModule, "SOH_SetComboHintRevealCb");
     MM_SetComboHintRevealCb = (FnSetHintRevealMm)GetSym(mmModule, "MM_SetComboHintRevealCb");
@@ -3011,6 +3053,9 @@ int main(int argc, char** argv) {
         ComboUI_SetNotesStore = (FnComboUISetNotesStore)GetSym(comboUIModule, "ComboUI_SetNotesStore");
         if (ComboUI_SetNotesStore)
             ComboUI_SetNotesStore(&Combo_GetNotes, &Combo_SetNotes);
+        ComboUI_SyncRandomizedCosmetics = (FnVoidArgless)GetSym(comboUIModule, "ComboUI_SyncRandomizedCosmetics");
+        ComboUI_CosmeticsSyncGateEnabled = (FnComboUIGate)GetSym(comboUIModule, "ComboUI_CosmeticsSyncGateEnabled");
+        ComboUI_ClaimGenRollSeed = (FnClaimGenRollSeed)GetSym(comboUIModule, "ComboUI_ClaimGenRollSeed");
         if (ComboUI_Register) {
             ComboUI_Register();
             std::cout << "[ComboShip] comboui registered (unified menu installed)." << std::endl;

--- a/combo/gui/ComboCosmeticsSync.cpp
+++ b/combo/gui/ComboCosmeticsSync.cpp
@@ -1,0 +1,235 @@
+// combo/gui/ComboCosmeticsSync.cpp
+//
+// ComboShip (#169): copy OOT's randomized cosmetic colors onto MM's semantically-shared elements, so a
+// synced config comes out matching in both games. OOT is the source of truth: its randomize-on-gen roll
+// is seed-derived (same seed -> same colors), MM's is not. So we copy OOT -> MM, never the other way.
+//
+// Lives in comboui because it needs libultraship's CVar API directly — the CVar store is one shared
+// instance across the exe and every DLL, so the sync is plain reads/writes with no IPC. The launcher
+// drives it through the exports at the bottom (sync, its gate, and the per-seed gen-roll latch).
+#include <libultraship/libultraship.h> // CVar bridge
+#include <ship/Context.h>              // SaveConsoleVariablesNextFrame (persist the writes)
+#include <spdlog/spdlog.h>
+#include "ComboMenuModel.h" // cached MM_MenuApplyCVarChange resolver
+// RANDOMIZE_ON_RANDO_GEN_ONLY. Relative path on purpose: enhancementTypes.h is a zero-include enum
+// header, and comboui must not take soh/ onto its include path.
+#include "../../soh/soh/Enhancements/enhancementTypes.h"
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace {
+
+// Comma-separated seeds whose generation-completion roll already happened on this machine (see the
+// latch below). A list, not one slot: A -> B -> A must not re-roll A over the user's manual edits.
+constexpr const char* kGenRollSeedCVar = "gCombo.Rando.GenRollSeed";
+constexpr size_t kGenRollSeedsKept = 8;
+
+// One OOT color feeding one or more MM elements. Up to 4 targets, nullptr-terminated. ootAdvanced
+// marks OOT rows its editor only randomizes with AdvancedMode on (they legitimately never fire).
+struct CosmeticPair {
+    const char* ootId;
+    bool ootAdvanced;
+    const char* mmIds[4];
+};
+
+// Semantically-shared elements only. An advanced OOT row simply doesn't fire and MM keeps its own
+// roll — see the per-pair gate in CopyOne.
+const CosmeticPair kPairs[] = {
+    { "HUD.AButton", false, { "Buttons.A" } },
+    { "HUD.BButton", false, { "Buttons.B" } },
+    { "HUD.CButtons", false, { "Buttons.CLeft", "Buttons.CDown", "Buttons.CRight" } },
+    { "HUD.StartButton", false, { "Buttons.Start" } },
+    { "HUD.Dpad", false, { "Buttons.DPad" } },
+    { "Consumable.Hearts", false, { "HUD.Hearts" } },
+    { "Consumable.Magic", false, { "HUD.Magic" } },
+    { "HUD.Minimap", false, { "HUD.Minimap" } },
+    // Deliberate: OOT's Kokiri tunic drives all four MM forms. OOT's Goron/Zora tunic rolls are
+    // equipment colors with no MM equivalent, so they are intentionally not mirrored.
+    { "Link.KokiriTunic", false, { "Player.HumanTunic", "Player.DekuTunic", "Player.GoronTunic", "Player.ZoraTunic" } },
+    { "Link.Hair", true, { "Player.HumanHair", "Player.DekuHair" } },
+    { "Consumable.GreenRupee", true, { "HUD.RupeeIcon" } },
+    { "HUD.KeyCount", true, { "HUD.SmallKey" } },
+    { "Arrows.FirePrimary", false, { "Effects.FireArrowPrim" } },
+    { "Arrows.FireSecondary", true, { "Effects.FireArrowSec" } },
+    { "Arrows.IcePrimary", false, { "Effects.IceArrowPrim" } },
+    { "Arrows.IceSecondary", true, { "Effects.IceArrowSec" } },
+    { "Arrows.LightPrimary", false, { "Effects.LightArrowPrim" } },
+    { "Arrows.LightSecondary", true, { "Effects.LightArrowSec" } },
+    // The Primaries are advanced, but OOT derives them from the (non-advanced) Secondary roll, so both
+    // sides of each pair are populated even for default users.
+    { "SpinAttack.Level1Primary", true, { "Effects.SpinSlashCharge" } },
+    { "SpinAttack.Level1Secondary", false, { "Effects.SpinSlashBurst" } },
+    { "SpinAttack.Level2Primary", true, { "Effects.GreatSpinCharge" } },
+    { "SpinAttack.Level2Secondary", false, { "Effects.GreatSpinBurst" } },
+    { "Title.FileChoose", false, { "Menus.FileWindow", "Menus.FilePlates" } },
+    { "Trails.KokiriSword", false, { "Trails.KokiriSwordTrail" } },
+    { "Trails.Stick", true, { "Trails.DekuStickTrail" } },
+    { "Trails.Boomerang", true, { "Trails.ZoraBoomerangTrail" } },
+};
+
+// MM's live apply (ShipInit re-run). ComboMenuModel already caches it and retries until 2ship.dll
+// is loaded, so no second resolver here.
+Fn_MenuApplyCVar ResolveMMApply() {
+    ComboRando::ComboMenuModel::Get().EnsureLoaded();
+    Fn_MenuApplyCVar fn = ComboRando::ComboMenuModel::Get().Mm().applyCVarChange;
+    if (!fn) {
+        SPDLOG_WARN("[ComboShip] cosmetics sync skipped: 2ship.dll MM_MenuApplyCVarChange not resolved yet");
+    }
+    return fn;
+}
+
+std::string OotKey(const char* id, const char* leaf) {
+    return std::string("gCosmetics.") + id + leaf;
+}
+// MM's prefix is singular on purpose — that is what keeps its keys from colliding with OOT's.
+std::string MmKey(const char* id, const char* leaf) {
+    return std::string("gCosmetic.") + id + leaf;
+}
+
+// Copy one OOT color onto one MM element. Skipped unless the OOT side was randomized and the MM side
+// was randomized and unlocked: that also covers OOT's advanced rows (never randomized by default) and
+// MM's suppressed options (custom model override -> randomize skipped -> Changed stays 0).
+// A locked OOT row is a color the user deliberately pinned, so sync's job is to make MM match it.
+bool CopyOne(Fn_MenuApplyCVar apply, const char* ootId, const char* mmId) {
+    if (CVarGetInteger(OotKey(ootId, ".Changed").c_str(), 0) != 1 ||
+        CVarGetInteger(MmKey(mmId, ".Changed").c_str(), 0) != 1 ||
+        CVarGetInteger(MmKey(mmId, ".Locked").c_str(), 0) != 0) {
+        return false;
+    }
+    const std::string colorKey = MmKey(mmId, ".Color");
+    const std::string changedKey = MmKey(mmId, ".Changed");
+    const std::string rainbowKey = MmKey(mmId, ".Rainbow");
+    // A rainbow OOT source has no fixed color to copy — put MM on rainbow too so both keep cycling.
+    const bool rainbow = CVarGetInteger(OotKey(ootId, ".Rainbow").c_str(), 0) != 0;
+    if (rainbow) {
+        CVarSetInteger(rainbowKey.c_str(), 1);
+    } else {
+        Color_RGB8 src = CVarGetColor24(OotKey(ootId, ".Value").c_str(), Color_RGB8{ 255, 255, 255 });
+        // Alpha 255: every mapped MM option is supportsAlpha=false, and MM's draw path takes alpha
+        // from the caller rather than the CVar.
+        CVarSetColor(colorKey.c_str(), Color_RGBA8{ src.r, src.g, src.b, 255 });
+        CVarSetInteger(rainbowKey.c_str(), 0);
+    }
+    CVarSetInteger(changedKey.c_str(), 1);
+    apply(colorKey.c_str());
+    apply(changedKey.c_str());
+    apply(rainbowKey.c_str());
+    return true;
+}
+
+// Persist our CVar writes — mirrors MM's own CosmeticEditorSave, so they survive a restart.
+void RequestCVarSave() {
+    if (auto* ctx = Ship::Context::GetRawInstance()) {
+        ctx->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+    }
+}
+
+// Upstream-rename tripwire: after a roll, a live non-advanced OOT row has at least one of these keys;
+// neither present (-1 sentinel) means the id in kPairs no longer exists upstream.
+void WarnIfDeadOotId(const char* ootId) {
+    if (CVarGetInteger(OotKey(ootId, ".Changed").c_str(), -1) == -1 &&
+        CVarGetInteger(OotKey(ootId, ".Locked").c_str(), -1) == -1) {
+        SPDLOG_WARN("[ComboShip] cosmetics sync: OOT option '{}' has no CVars — renamed upstream?", ootId);
+    }
+}
+
+// True when at least one OOT OnGenerationCompletion subscriber (cosmetics, audio) would actually roll.
+bool AnyOotGenRollEnabled() {
+    return CVarGetInteger("gCosmetics.RandomizeCosmeticsGenModes", RANDOMIZE_OFF) == RANDOMIZE_ON_RANDO_GEN_ONLY ||
+           CVarGetInteger("gAudioEditor.RandomizeAudioGenModes", RANDOMIZE_OFF) == RANDOMIZE_ON_RANDO_GEN_ONLY;
+}
+
+} // namespace
+
+// Gate: the combo toggle plus BOTH games' randomize-on-generation options. The File-Load randomize
+// modes deliberately don't count — they re-roll OOT after the sync and would drift the games apart.
+extern "C" __declspec(dllexport) int ComboUI_CosmeticsSyncGateEnabled(void) {
+    if (CVarGetInteger("gCombo.Rando.SyncCosmetics", 0) != 1) {
+        return 0;
+    }
+    if (CVarGetInteger("gCosmetics.RandomizeCosmeticsGenModes", RANDOMIZE_OFF) != RANDOMIZE_ON_RANDO_GEN_ONLY) {
+        return 0;
+    }
+    return CVarGetInteger("gCosmetics.RandomizeOnSeedGen", 0) == 1 ? 1 : 0;
+}
+
+extern "C" __declspec(dllexport) void ComboUI_SyncRandomizedCosmetics(void) {
+    if (!ComboUI_CosmeticsSyncGateEnabled()) {
+        return;
+    }
+    Fn_MenuApplyCVar apply = ResolveMMApply();
+    if (!apply) {
+        return;
+    }
+    int copied = 0;
+    std::vector<const char*> suspects;
+    for (const auto& pair : kPairs) {
+        int pairCopied = 0;
+        for (const char* mmId : pair.mmIds) {
+            if (!mmId) {
+                break;
+            }
+            if (CopyOne(apply, pair.ootId, mmId)) {
+                ++pairCopied;
+            }
+        }
+        copied += pairCopied;
+        if (pairCopied == 0 && !pair.ootAdvanced) {
+            suspects.push_back(pair.ootId);
+        }
+    }
+    // Only meaningful when something copied: a rename kills one pair, an OOT "Reset All" or no roll
+    // at all kills every pair and must stay silent.
+    if (copied > 0) {
+        for (const char* ootId : suspects) {
+            WarnIfDeadOotId(ootId);
+        }
+    }
+    RequestCVarSave();
+    SPDLOG_INFO("[ComboShip] cosmetics sync: {} MM elements took OOT's colors", copied);
+}
+
+// Per-seed roll latch (#169): the generation-completion hooks must roll once per seed per machine,
+// else the silent auto-load on every boot would re-roll over the user's manual cosmetic edits.
+// Returns 1 (and claims the seed) only when this seed is not among the last kGenRollSeedsKept claimed
+// and some subscriber is actually enabled to roll. Hex strings, not int CVars: the int store is 32-bit.
+extern "C" __declspec(dllexport) int ComboUI_ClaimGenRollSeed(unsigned long long seed) {
+    // Claiming with every option off would burn the seed, so enabling them mid-seed would do nothing.
+    if (!AnyOotGenRollEnabled()) {
+        return 0;
+    }
+    char hex[24];
+    std::snprintf(hex, sizeof(hex), "%016llx", seed);
+    std::vector<std::string> claimed;
+    const std::string stored = CVarGetString(kGenRollSeedCVar, "");
+    for (size_t pos = 0; pos < stored.size();) {
+        size_t comma = stored.find(',', pos);
+        if (comma == std::string::npos) {
+            comma = stored.size();
+        }
+        std::string tok = stored.substr(pos, comma - pos);
+        if (!tok.empty()) {
+            if (tok == hex) {
+                return 0;
+            }
+            claimed.push_back(tok);
+        }
+        pos = comma + 1;
+    }
+    claimed.emplace_back(hex);
+    if (claimed.size() > kGenRollSeedsKept) {
+        claimed.erase(claimed.begin(), claimed.begin() + (claimed.size() - kGenRollSeedsKept));
+    }
+    std::string out;
+    for (const std::string& tok : claimed) {
+        if (!out.empty()) {
+            out += ',';
+        }
+        out += tok;
+    }
+    CVarSetString(kGenRollSeedCVar, out.c_str());
+    RequestCVarSave();
+    return 1;
+}

--- a/combo/gui/ComboMenu.cpp
+++ b/combo/gui/ComboMenu.cpp
@@ -1693,6 +1693,19 @@ void ComboMenu::DrawComboPanel() {
                         "and the Mask Shop key/entrance exclusions, so Ocarina of Time stays enterable from nothing.");
     ImGui::Separator();
 
+    // Cosmetics (#169): each game randomizes on its own by default; sync makes MM take OOT's colors.
+    ImGui::SeparatorText("Cosmetics");
+    bool syncCosmetics = CVarGetInteger("gCombo.Rando.SyncCosmetics", 0) != 0;
+    ComboRando::ComboMenu_PushCheckbox(goalTheme);
+    if (ImGui::Checkbox("Sync Randomized Cosmetics", &syncCosmetics)) {
+        CVarSetInteger("gCombo.Rando.SyncCosmetics", syncCosmetics ? 1 : 0);
+    }
+    ComboRando::ComboMenu_PopCheckbox();
+    ImGui::TextDisabled("Applies only when BOTH games' \"randomize cosmetics on randomizer generation\" options are\n"
+                        "enabled. Shared elements (buttons, hearts, magic, minimap, Link's tunic, ...) take Ocarina\n"
+                        "of Time's colors in Majora's Mask.");
+    ImGui::Separator();
+
     // Seed field -> shared CVar the generator reads (same source the native file-select
     // "Generate a new seed" option uses).
     ImGui::SetNextItemWidth(260.0f);

--- a/docs/deviations/rando.md
+++ b/docs/deviations/rando.md
@@ -1490,3 +1490,132 @@ player is allowed to see.
 **Residuals:** MM's plain-text recomposition for a native stone hint may diverge cosmetically from the
 formatted in-game string (colors/line breaks are stripped); MM-native NPC hints outside the combo
 `itemLocations` path are not reported; there is no manual mark-read.
+
+## Randomize cosmetics on combo generation + cross-game sync (#169) (2026-08-21)
+
+**Why:** both games offer "randomize all cosmetics when a randomizer seed is generated"
+(`gCosmetics.RandomizeCosmeticsGenModes` = On Rando Gen Only; MM's `gCosmetics.RandomizeOnSeedGen`),
+but combo owns generation and never reaches either game's vanilla fire site, so neither hook ran. The
+same gap silently disabled both Audio Editors' "randomize all on rando gen" — they consume the same
+two hooks, and they are the only other consumers, so firing the hooks fixes them too.
+
+**Vendored deltas (all inside existing combo-only functions):**
+
+- `soh/soh/OTRGlobals.cpp` — `SOH_ApplyRandoPlacements` now calls `ctx->SetSeed(sComboRandoSeed)` when
+  the launcher supplied a seed. Combo bypasses `Playthrough_Init`/spoiler-load, the only vanilla
+  `SetSeed` sites, so the ctx seed sat at 0 and every seed-derived feature degenerated: save
+  `finalSeed` was always 0, Anchor's roster seed-mismatch check compared 0 to 0, and the in-game
+  seeded derivations (EnemyRandomizer, ExtraTraps, MirroredWorld, Audio) were not per-seed at all.
+  Both the fresh-gen and the reload path call `SOH_SetComboRandoSeed(masterSeed)` before the apply, so
+  generator and reloader agree; the u64→u32 truncation is consistent across clients.
+- `soh/soh/OTRGlobals.cpp` — new export `SOH_FireGenerationCompleteHooks`, an RM-scoped
+  `ExecuteHooks<OnGenerationCompletion>()` (same `CrossRMRegistry::Get("oot")` pattern as
+  `SOH_MenuApplyCVarChange`; the cosmetic consumers patch OOT gfx). Vanilla fires this from the rando
+  worker thread — we fire from the main thread, which is strictly safer. The `ExecuteHooks` call is
+  wrapped in `try`/`catch(...)` with `SPDLOG_ERROR`, like the MM side: subscribers reach `std::map::at`
+  and allocate, and a throw must not unwind across the C ABI into `ComboShip.exe`.
+- `soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp` and `soh/soh/Enhancements/audio/AudioEditor.cpp` —
+  both seeded branches (`RandomizeColor`, `RandomizeGroup`) fold in the `Rando::Context` seed in one
+  strictly degenerate case: `!IS_RANDO && fileCreatedAt == 0`. Vanilla seeds from
+  `IS_RANDO ? GetSeed() : fileCreatedAt`, but combo fires the gen roll at file select where `IS_RANDO`
+  is false and no file is loaded, so both terms are 0 and every seed would get the *same* palette and
+  the *same* audio shuffle. With the `SetSeed` above in place the rolls are genuinely seed-derived and
+  reproduce identically on the generator and on every recipient. Vanilla is bit-for-bit unchanged in
+  every other case (any real save has a nonzero `fileCreatedAt`).
+- `mm/2s2h/BenPort.cpp` — `MM_InitRandoSaveFile` now fires `ExecuteHooks<OnRandoSeedGeneration>()`,
+  mirroring `OnFileCreate.cpp`'s tail (that function re-implements `OnFileCreate`'s body and had omitted
+  only this line). Deliberately placed *after* the placement `try`/`catch` and inside its own
+  `try`/`catch`: a throwing cosmetic/audio subscriber must not send the catch path off to rebuild the
+  slot as a placement-less vanilla save. `MM_InitRandoSaveFile` intentionally re-implements
+  `OnFileCreate`'s tail rather than calling it, so it must be re-audited whenever upstream changes
+  `OnFileCreate`; a shared-helper refactor was considered and declined precisely because the hook fire
+  has to sit outside the try/catch.
+- `mm/2s2h/Enhancements/Audio/AudioEditor.cpp` — `ReplayCurrentBGM` early-returns on
+  `NA_BGM_DISABLED`. MM's audio randomize-on-gen subscriber now runs while MM is dormant (combo fires
+  the hook during OOT's save init), where the active seq id is `0xFFFF`; the queued
+  `SEQCMD_PLAY_SEQUENCE` would index `gSequenceMap[0xFFFF]` and crash on MM's first frame after a
+  portal. Replaying a disabled BGM is meaningless in vanilla too, so the guard is behavior-neutral there.
+
+**Where combo fires them.** OOT: end of `Combo_FinalizeGenerate`, after `SOH_ApplyComboHints` and
+before the pending-settings bookkeeping. Also on the seed-**reload** path (`Combo_OnReloadRequest`,
+after the placement apply + seed hash): a client that merely loads a shared seed never runs
+`Combo_FinalizeGenerate`, so without this its OOT colors would never roll at all. Since the roll is
+seed-derived, the recipient reproduces the generator's colors exactly. MM: inside
+`MM_InitRandoSaveFile`, i.e. per rando save-file creation (fresh or reloaded seed) — exactly vanilla
+MM's semantics.
+
+**Once per seed, per machine.** The reload path runs on *every* boot (silent auto-load re-applies the
+remembered seed), so an unconditional fire there would re-roll on each launch and wipe cosmetic/audio
+edits the user made by hand. A persisted latch CVar (`gCombo.Rando.GenRollSeed`, a comma-separated list
+of master seeds as hex strings — the int CVar store is 32-bit) makes the roll happen once per seed:
+`ComboUI_ClaimGenRollSeed` returns 1 (and appends the seed) only when the seed is not already in the
+list, and `Combo_FireGenRollHooksOnce` fires on that. The list keeps the **last 8** seeds, not one slot:
+with a single slot, playing seed A, then B, then A again would re-roll A over the user's manual edits.
+Beyond 8 the oldest entry is pruned, so a very long rotation can cost one extra roll — the failure mode
+is a re-roll, never a lost seed. A claim also only happens when a subscriber is actually **enabled** to
+roll (OOT cosmetics mode == `RANDOMIZE_ON_RANDO_GEN_ONLY`, or `gAudioEditor.RandomizeAudioGenModes` ==
+the same); otherwise the default config's every-boot auto-load would silently burn each seed and turning
+the options on mid-seed would do nothing. A fresh generation passes `force=true`: it claims the seed
+(so subsequent loads leave manual edits alone) but fires regardless, which is vanilla's unconditional
+gen-only semantics. The fire is deliberately **not** coupled to the cosmetics sync gate — each hook
+subscriber gates on its own CVars, and a recipient who wants audio randomization but not cosmetic sync
+must still get its roll. `Combo_OnOOTSaveInit` calls the same helper just before the sync when the sync
+gate passes, which is what makes enabling the options plus sync mid-seed roll and sync fresh colors on
+the next file creation.
+
+**Sync Randomized Cosmetics** (`gCombo.Rando.SyncCosmetics`, default off, combo settings panel).
+`combo/gui/ComboCosmeticsSync.cpp` copies OOT's colors onto MM's semantically-shared elements after
+`MM_InitRandoSaveFile` returns 0 — MM has just rolled its own, so this overwrites it. OOT is the source
+of truth because its roll is seed-derived and MM's is not. It lives in comboui (not the launcher exe)
+because comboui already links libultraship, so the CVar API is called directly instead of through a
+hand-cast `GetProcAddress` shim; the launcher drives it through three exports,
+`ComboUI_SyncRandomizedCosmetics`, `ComboUI_CosmeticsSyncGateEnabled` (one predicate, so the gate's CVar
+reads are never duplicated) and `ComboUI_ClaimGenRollSeed` (the latch above). The CVar store is one
+shared instance across the exe and every DLL (shared `libultraship.dll`), so this is plain CVar
+reads/writes with no IPC. MM's `MM_MenuApplyCVarChange` comes from `ComboMenuModel`'s cached resolver,
+which retries until `2ship.dll` is loaded.
+
+- **Gate:** sync on AND OOT mode == `RANDOMIZE_ON_RANDO_GEN_ONLY` AND MM's `RandomizeOnSeedGen` == 1.
+  The File-Load modes deliberately don't count — they re-roll OOT *after* the sync and would drift the
+  games apart again. The UI note says so.
+- **Keys:** OOT `gCosmetics.<Id>.{Value,Changed,Locked,Rainbow}` vs MM `gCosmetic.<Id>.{Color,Changed,
+  Locked,Rainbow}`. The singular MM prefix is what keeps the two games' cosmetic keys from colliding —
+  do not "fix" it.
+- **Per-pair gate:** copy only when OOT `.Changed`==1 && MM `.Changed`==1 && MM `.Locked`==0. That covers
+  OOT's *advanced* rows (not randomized unless AdvancedMode, so they simply don't fire and MM keeps its
+  own color), MM's suppressed options (custom model override → randomize skipped → `Changed` stays 0),
+  and MM rows the user locked. A **locked OOT** row is deliberately still copied: it is a color the user
+  pinned, and sync's job is to make MM match it.
+- **Copy:** OOT RGB via `CVarGetColor24` with alpha 255 — every mapped MM option is `supportsAlpha=false`
+  and MM's draw path takes alpha from the caller, never from the CVar — plus `.Changed`=1, `.Rainbow`=0,
+  then `MM_MenuApplyCVarChange` on each written key, mirroring MM's own `CosmeticEditorRefreshElement`.
+  A **rainbow** OOT source has no fixed color to copy, so MM gets `.Rainbow`=1 instead and both keep
+  cycling (reachable when the user turned rainbow on for an *advanced* row, which the gen roll then never
+  overwrites).
+- **Drift tripwire:** each pair carries an `ootAdvanced` flag. When a non-advanced pair copies nothing
+  and its OOT row has neither `.Changed` nor `.Locked` (read with a `-1` sentinel), the id no longer
+  exists upstream — logged as a warning naming the pair. The warnings only fire when the run copied at
+  least one *other* pair: an upstream rename kills one mapping while the rest still copy, whereas an OOT
+  "Reset All" or a run where no roll happened kills all 16 non-advanced pairs and must stay silent.
+  Cheap, non-fatal, and the only signal we get that an upstream rename has silently broken a mapping.
+
+**Residuals:**
+
+- OOT's *advanced* rows are not rolled for default users, so their MM counterparts keep their own random
+  color. That includes the three arrow **Secondary** colors — a default user can get two-tone arrow
+  mismatches (OOT rolls the primaries only; MM's secondaries keep their independent roll). The spin
+  attack pairs are unaffected: OOT derives its advanced Primaries from the non-advanced Secondary roll.
+- Link's tunic is mapped Kokiri → all four MM forms on purpose. OOT's Goron/Zora tunic rolls are
+  equipment colors with no MM equivalent and are intentionally not mirrored.
+- `ctx->SetSeed` means OOT saves created from this version on persist a real `finalSeed`, while saves
+  made before it carry 0. Per project policy save compatibility across versions is not required, so
+  `COMBO_RELEASE_VERSION` is unchanged; the practical effect is that a pre-existing save and a new one
+  disagree on seeded features and can report an Anchor seed mismatch against each other.
+- The fire is the whole `OnGenerationCompletion` hook, so it also rolls OOT's Audio Editor "randomize
+  all on rando gen" (the hook's only other subscriber). That is intended — the same combo gap had
+  silently disabled it too.
+- The sync itself only ever runs from `Combo_OnOOTSaveInit`, so a seed loaded but never started keeps
+  MM's own colors until a slot is created.
+- A hand-edited seed file with no `masterSeed` key falls back to 0 consistently on every path (latch,
+  `SOH_SetComboRandoSeed`, the rolls), so all such seeds share one palette and one audio shuffle — the
+  pre-existing behavior of `SOH_SetComboRandoSeed(0)`, not a new deviation.

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -2918,6 +2918,15 @@ extern "C" __declspec(dllexport) int MM_InitRandoSaveFile(int fileNum, const cha
         return -1;
     }
 
+    // ComboShip: combo never runs native OnFileCreate, whose tail is this hook's only fire site
+    // (OnFileCreate.cpp:220) — without it MM's cosmetic/audio "randomize on rando gen" never triggers.
+    // Fired post-apply and outside the try above so a subscriber throw can't void the placements.
+    try {
+        GameInteractor::Instance->ExecuteHooks<GameInteractor::OnRandoSeedGeneration>();
+    } catch (const std::exception& e) {
+        SPDLOG_ERROR("[ComboShip] MM_InitRandoSaveFile: gen hook threw: {}", e.what());
+    } catch (...) { SPDLOG_ERROR("[ComboShip] MM_InitRandoSaveFile: gen hook threw a non-std exception"); }
+
     // Persist the rando save to the slot file.
     SaveManager_SaveCurrentForCombo();
     return 0;

--- a/mm/2s2h/Enhancements/Audio/AudioEditor.cpp
+++ b/mm/2s2h/Enhancements/Audio/AudioEditor.cpp
@@ -168,6 +168,13 @@ size_t AuthenticCountBySequenceType(SeqType type) {
 // which will lookup the proper override, or reset back to vanilla
 void ReplayCurrentBGM() {
     u16 curSeqId = AudioSeq_GetActiveSeqId(SEQ_PLAYER_BGM_MAIN);
+#ifdef COMBO_BUILD
+    // ComboShip: nothing to replay when no BGM is playing (e.g. MM dormant while combo generates) —
+    // queueing NA_BGM_DISABLED would index gSequenceMap[0xFFFF] on the next frame.
+    if (curSeqId == NA_BGM_DISABLED) {
+        return;
+    }
+#endif
     // TODO: replace with Audio_StartSeq when the macro is shared
     // The fade time and audio player flags will always be 0 in the case of replaying the BGM, so they are not set here
     // AudioSeq_QueueSeqCmd(0x00000000 | curSeqId);

--- a/soh/soh/Enhancements/audio/AudioEditor.cpp
+++ b/soh/soh/Enhancements/audio/AudioEditor.cpp
@@ -124,6 +124,13 @@ void RandomizeGroup(SeqType type, bool manual = true) {
 
             uint32_t finalSeed = type + (IS_RANDO ? Rando::Context::GetInstance()->GetSeed()
                                                   : static_cast<uint32_t>(gSaveContext.ship.stats.fileCreatedAt));
+#ifdef COMBO_BUILD
+            // ComboShip: combo fires gen rolls at file select where IS_RANDO is false and no file is
+            // loaded; fold in the combo seed only there, so rolls stay seed-derived instead of constant.
+            if (!IS_RANDO && gSaveContext.ship.stats.fileCreatedAt == 0) {
+                finalSeed += Rando::Context::GetInstance()->GetSeed();
+            }
+#endif
             ShipUtils::RandInit(finalSeed, &localRngState);
             shuffleState = &localRngState;
         }

--- a/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
+++ b/soh/soh/Enhancements/cosmetics/CosmeticsEditor.cpp
@@ -2098,6 +2098,13 @@ void RandomizeColor(CosmeticOption& cosmeticOption, bool manual = true) {
                                  cosmeticOption.defaultColor.b + cosmeticOption.defaultColor.a +
                                  (IS_RANDO ? Rando::Context::GetInstance()->GetSeed()
                                            : static_cast<uint32_t>(gSaveContext.ship.stats.fileCreatedAt));
+#ifdef COMBO_BUILD
+            // ComboShip: combo fires gen rolls at file select where IS_RANDO is false and no file is
+            // loaded; fold in the combo seed only there, so rolls stay seed-derived instead of constant.
+            if (!IS_RANDO && gSaveContext.ship.stats.fileCreatedAt == 0) {
+                finalSeed += Rando::Context::GetInstance()->GetSeed();
+            }
+#endif
 
             randomState = &local_seed_state;
             ShipUtils::RandInit(finalSeed, randomState);

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -3321,6 +3321,18 @@ extern "C" __declspec(dllexport) void SOH_MenuApplyCVarChange(const char* cvar) 
         ShipInit::Init(cvar);
 }
 
+// ComboShip: combo owns generation and never reaches GenerateRandomizerImgui, the only vanilla fire site
+// of this hook — so cosmetics/audio "randomize on rando gen" never ran. The launcher fires it instead.
+extern "C" __declspec(dllexport) void SOH_FireGenerationCompleteHooks(void) {
+    Ship::ResourceManagerScope rmScope(Ship::CrossRMRegistry::Get("oot")); // gfx patches load OOT resources
+    // Subscribers hit std::map::at and allocate; a throw must not unwind across the C ABI into the exe.
+    try {
+        GameInteractor::Instance->ExecuteHooks<GameInteractor::OnGenerationCompletion>();
+    } catch (const std::exception& e) {
+        SPDLOG_ERROR("[ComboShip] SOH_FireGenerationCompleteHooks: gen hook threw: {}", e.what());
+    } catch (...) { SPDLOG_ERROR("[ComboShip] SOH_FireGenerationCompleteHooks: gen hook threw a non-std exception"); }
+}
+
 #ifdef COMBO_BUILD
 // ComboShip: true when OOT is the foreground game (queries comboui's ComboUI_GetForegroundGame, resolved
 // once). SohMenuDevTools uses it to gate OOT's live-world dev viewers — opening OOT's tab while MM is
@@ -4820,6 +4832,11 @@ extern "C" __declspec(dllexport) void SOH_ApplyRandoPlacements(const char* json)
         if (!sComboHintsPresent) {
             CreateChildAltarHint();
             CreateAdultAltarHint();
+        }
+        // ComboShip: combo bypasses Playthrough_Init, so the ctx seed stays 0 and every seed-derived
+        // feature (cosmetics/audio randomize-on-gen, save finalSeed, Anchor mismatch) degenerates.
+        if (sComboRandoSeedSet) {
+            ctx->SetSeed((uint32_t)sComboRandoSeed);
         }
 #endif
 


### PR DESCRIPTION
Closes #169.

Combo runs its own seed generation, bypassing both games' vanilla fire sites for the randomize-on-generation hooks — so SoH's "Automatically Randomize All Cosmetics: On Rando Gen Only" and 2Ship's "Randomize all Cosmetics on Randomizer Generation" (and both Audio Editors' equivalents, same hooks) never ran on a combo seed.

**Fixes**
- Fire `OnGenerationCompletion` (OOT) and `OnRandoSeedGeneration` (MM) from the combo generation/reload/save-init paths. Rolls are latched once per seed per machine (last 8 seeds), so silent auto-load doesn't re-roll on every boot and manual edits survive.
- Set the OOT rando context seed on the combo apply path (was stuck at 0): gen-roll cosmetics/audio become seed-derived, saves persist a real `finalSeed`, Anchor seed-mismatch detection works.
- MM hook fires outside the placement try/catch with its own guard; dormant-MM `ReplayCurrentBGM` guarded against `NA_BGM_DISABLED` (crash: `gSequenceMap[0xFFFF]`).

**New: Sync Randomized Cosmetics** (combo panel, default off)
- When both games' randomize-on-gen options are enabled, shared elements (buttons, hearts, magic, minimap, tunic, arrows, spin attack, trails, file select) copy OOT's rolled colors into MM after MM's roll. Rainbow propagates instead of freezing. Seed recipients get the generator's exact colors (rolls are deterministic per seed).

Vendored delta: soh +26, mm +16 lines, COMBO_BUILD-guarded/combo-only, documented in `docs/deviations/rando.md`.

**Playtest**: enable both randomize options → generate → both games rolled; sync on → shared elements match across games; load the same seed on a second machine → colors match the generator; reboot → no re-roll.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9468293262.zip)
<!--- section:artifacts:end -->