### PR TITLE
Fix Song of Time taking MM keys: mirror integrity, load-path poison, Anchor merge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(COMBO_EPOCH 1)  # ← bump for ComboShip-owned breaks / o2r-forcing releases
 
 # Manual release identity; SOLE authority for combosave compat (gated in combo/ComboShip.cpp).
 # See docs/UPSTREAM_MERGES.md for the bump rule.
-set(COMBO_RELEASE_VERSION "0.2.1" CACHE STRING "ComboShip release version (manual; gates combosave compat)" FORCE)
+set(COMBO_RELEASE_VERSION "0.3.0" CACHE STRING "ComboShip release version (manual; gates combosave compat)" FORCE)
 
 set(COMBO_PINS "${CMAKE_CURRENT_SOURCE_DIR}/upstream-pins.json")
 # Reconfigure whenever the pins change so the derived version stays in sync.

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -175,7 +175,11 @@ static FnSetSaveCallback SOH_SetOnNewSaveCallback = nullptr;
 static FnSetSaveCallback SOH_SetOnLoadSaveCallback = nullptr;
 typedef void (*FnGetPlayerName)(unsigned char*);
 static FnGetPlayerName SOH_GetCurrentPlayerName = nullptr;
-static FnMMInitSave MM_LoadSaveForCombo = nullptr;
+// Nonzero = the slot's MM half is missing/broken; nothing was loaded (see SaveManager_LoadSaveFile).
+typedef int (*FnMMLoadSave)(int);
+static FnMMLoadSave MM_LoadSaveForCombo = nullptr;
+// Failure code behind a refused MM entry (return kind 3), for the OOT-side notice. Cleared on take.
+static FnInt MM_TakeComboLoadFailCode = nullptr;
 // #89 resume-into-MM: drop out of OOT's loop before it runs a Play frame / tell MM how it was entered.
 // SOH_IsOnFileSelect distinguishes a real file-select load from the OnLoadGame that TitleSetup fires
 // on the MM->OOT return (which must not bounce the player straight back into MM).
@@ -248,6 +252,9 @@ static FnSetCopyContainer SOH_SetCopyContainer = nullptr;
 // OOT polls this each frame (main thread) for slots whose container was backed up for a release mismatch.
 typedef void (*FnSetOutdatedSaveNotice)(int (*)());
 static FnSetOutdatedSaveNotice SOH_SetOutdatedSaveNotice = nullptr;
+// Same pattern for slots whose MM half was refused at the MM-entry seam (returns slot, writes the code).
+typedef void (*FnSetMMEntryFailNotice)(int (*)(int*));
+static FnSetMMEntryFailNotice SOH_SetMMEntryFailNotice = nullptr;
 
 // ComboShip: OOT forced placements (Link's Pocket etc.) the static dump can't carry — see
 // SOH_GetForcedPlacements. Seed-parameterized so the pick is deterministic per generated seed.
@@ -364,6 +371,8 @@ static std::map<int, nlohmann::json> g_containerCache;
 // Slots whose container was backed up for a COMBO_RELEASE_VERSION mismatch; guarded by g_containerMutex.
 // OOT drains it on the main thread (Combo_TakeEvictionNotice) to surface a popup.
 static std::vector<int> g_evictedSlots;
+// Slots whose MM half was refused at the MM-entry seam, as (slot, failure code); same drain pattern.
+static std::vector<std::pair<int, int>> g_mmEntryFailures;
 
 // Single place the foreground game changes, so every transition point notifies comboui consistently.
 static void Combo_SetForegroundGame(int game) {
@@ -471,6 +480,18 @@ static int Combo_TakeEvictionNotice() {
     int slot = g_evictedSlots.front();
     g_evictedSlots.erase(g_evictedSlots.begin());
     return slot;
+}
+
+// Same drain, for slots whose MM half MM refused to load. Returns the slot (-1 = none) + its failure code.
+static int Combo_TakeMMEntryFailure(int* outCode) {
+    std::lock_guard<std::mutex> lk(g_containerMutex);
+    if (g_mmEntryFailures.empty())
+        return -1;
+    auto entry = g_mmEntryFailures.front();
+    g_mmEntryFailures.erase(g_mmEntryFailures.begin());
+    if (outCode != nullptr)
+        *outCode = entry.second;
+    return entry.first;
 }
 
 static void EraseComboContainer(int slot) {
@@ -2526,8 +2547,11 @@ static void Combo_OnOOTSaveLoad(int fileNum) {
         return;
     }
     std::cout << "[ComboShip] Loading MM save for OOT slot " << fileNum << " (tracker peek)" << std::endl;
-    MM_LoadSaveForCombo(fileNum);
-    g_MmSaveInMemorySlot = fileNum;
+    // Read-only peek: on failure nothing was loaded, so the slot must NOT be marked resident — stale
+    // dormant memory would otherwise pose as this slot's save (and a dormant write would persist it).
+    if (MM_LoadSaveForCombo(fileNum) == 0) {
+        g_MmSaveInMemorySlot = fileNum;
+    }
     // Both counters are now live: catch a goal crossed while the game wasn't running (e.g. a teammate's
     // pieces applied to a dormant save). Latched, so it can't roll credits twice.
     Combo_OnTriforceProgress(0, fileNum);
@@ -2699,7 +2723,8 @@ int main(int argc, char** argv) {
     SOH_SetOnNewSaveCallback = (FnSetSaveCallback)GetSym(sohModule, "SOH_SetOnNewSaveCallback");
     SOH_SetOnLoadSaveCallback = (FnSetSaveCallback)GetSym(sohModule, "SOH_SetOnLoadSaveCallback");
     SOH_GetCurrentPlayerName = (FnGetPlayerName)GetSym(sohModule, "SOH_GetCurrentPlayerName");
-    MM_LoadSaveForCombo = (FnMMInitSave)GetSym(mmModule, "MM_LoadSaveForCombo");
+    MM_LoadSaveForCombo = (FnMMLoadSave)GetSym(mmModule, "MM_LoadSaveForCombo");
+    MM_TakeComboLoadFailCode = (FnInt)GetSym(mmModule, "MM_TakeComboLoadFailCode");
     SOH_ParkForComboMMResume = (FnVoid)GetSym(sohModule, "SOH_ParkForComboMMResume");
     MM_SetComboEntryIsResume = (FnMMInitSave)GetSym(mmModule, "MM_SetComboEntryIsResume");
     SOH_IsOnFileSelect = (FnIsOnFileSelect)GetSym(sohModule, "SOH_IsOnFileSelect");
@@ -2831,6 +2856,7 @@ int main(int argc, char** argv) {
     MM_LoadComboRando = (FnTakeStr)GetSym(mmModule, "MM_LoadComboRando");
     SOH_SetCopyContainer = (FnSetCopyContainer)GetSym(sohModule, "SOH_SetCopyContainer");
     SOH_SetOutdatedSaveNotice = (FnSetOutdatedSaveNotice)GetSym(sohModule, "SOH_SetOutdatedSaveNotice");
+    SOH_SetMMEntryFailNotice = (FnSetMMEntryFailNotice)GetSym(sohModule, "SOH_SetMMEntryFailNotice");
     SOH_SetDeleteForeignSave = (FnSetDeleteForeignSave)GetSym(sohModule, "SOH_SetDeleteForeignSave");
     MM_SetDeleteForeignSave = (FnSetDeleteForeignSave)GetSym(mmModule, "MM_SetDeleteForeignSave");
     SOH_DeleteSaveFile = (FnDeleteSaveFile)GetSym(sohModule, "SOH_DeleteSaveFile");
@@ -3169,6 +3195,9 @@ int main(int argc, char** argv) {
     // OOT owns the shared file-select; it polls for release-evicted slots and shows the outdated-save popup.
     if (SOH_SetOutdatedSaveNotice)
         SOH_SetOutdatedSaveNotice(&Combo_TakeEvictionNotice);
+    // Same seam for a refused MM entry — OOT is where the player lands afterwards.
+    if (SOH_SetMMEntryFailNotice)
+        SOH_SetMMEntryFailNotice(&Combo_TakeMMEntryFailure);
 
     // Cross-game erase seam (issue #1): erasing a save slot in either game wipes both saves.
     if (SOH_SetDeleteForeignSave)
@@ -3245,6 +3274,14 @@ int main(int argc, char** argv) {
                         // Session over: MM's dormant gSaveContext is post-quit state, so force the next
                         // save-load to re-read it from the container (else the tracker peek shows junk).
                         g_MmSaveInMemorySlot = -1;
+                        // Kind 3 = MM refused to load this slot's MM half. Point resume back at OOT so the
+                        // player isn't bounced into the same failure forever, and queue the OOT-side notice.
+                        if (g_mmReturnKind == 3) {
+                            Combo_SetLastGame(g_PendingMMFileNum, ComboRando::GAME_OOT);
+                            int code = MM_TakeComboLoadFailCode ? MM_TakeComboLoadFailCode() : 0;
+                            std::lock_guard<std::mutex> lk(g_containerMutex);
+                            g_mmEntryFailures.emplace_back(g_PendingMMFileNum, code);
+                        }
                     }
                 }
                 current = GAME_OOT;

--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -178,8 +178,6 @@ static FnGetPlayerName SOH_GetCurrentPlayerName = nullptr;
 // Nonzero = the slot's MM half is missing/broken; nothing was loaded (see SaveManager_LoadSaveFile).
 typedef int (*FnMMLoadSave)(int);
 static FnMMLoadSave MM_LoadSaveForCombo = nullptr;
-// Failure code behind a refused MM entry (return kind 3), for the OOT-side notice. Cleared on take.
-static FnInt MM_TakeComboLoadFailCode = nullptr;
 // #89 resume-into-MM: drop out of OOT's loop before it runs a Play frame / tell MM how it was entered.
 // SOH_IsOnFileSelect distinguishes a real file-select load from the OnLoadGame that TitleSetup fires
 // on the MM->OOT return (which must not bounce the player straight back into MM).
@@ -252,9 +250,6 @@ static FnSetCopyContainer SOH_SetCopyContainer = nullptr;
 // OOT polls this each frame (main thread) for slots whose container was backed up for a release mismatch.
 typedef void (*FnSetOutdatedSaveNotice)(int (*)());
 static FnSetOutdatedSaveNotice SOH_SetOutdatedSaveNotice = nullptr;
-// Same pattern for slots whose MM half was refused at the MM-entry seam (returns slot, writes the code).
-typedef void (*FnSetMMEntryFailNotice)(int (*)(int*));
-static FnSetMMEntryFailNotice SOH_SetMMEntryFailNotice = nullptr;
 
 // ComboShip: OOT forced placements (Link's Pocket etc.) the static dump can't carry — see
 // SOH_GetForcedPlacements. Seed-parameterized so the pick is deterministic per generated seed.
@@ -371,8 +366,6 @@ static std::map<int, nlohmann::json> g_containerCache;
 // Slots whose container was backed up for a COMBO_RELEASE_VERSION mismatch; guarded by g_containerMutex.
 // OOT drains it on the main thread (Combo_TakeEvictionNotice) to surface a popup.
 static std::vector<int> g_evictedSlots;
-// Slots whose MM half was refused at the MM-entry seam, as (slot, failure code); same drain pattern.
-static std::vector<std::pair<int, int>> g_mmEntryFailures;
 
 // Single place the foreground game changes, so every transition point notifies comboui consistently.
 static void Combo_SetForegroundGame(int game) {
@@ -480,18 +473,6 @@ static int Combo_TakeEvictionNotice() {
     int slot = g_evictedSlots.front();
     g_evictedSlots.erase(g_evictedSlots.begin());
     return slot;
-}
-
-// Same drain, for slots whose MM half MM refused to load. Returns the slot (-1 = none) + its failure code.
-static int Combo_TakeMMEntryFailure(int* outCode) {
-    std::lock_guard<std::mutex> lk(g_containerMutex);
-    if (g_mmEntryFailures.empty())
-        return -1;
-    auto entry = g_mmEntryFailures.front();
-    g_mmEntryFailures.erase(g_mmEntryFailures.begin());
-    if (outCode != nullptr)
-        *outCode = entry.second;
-    return entry.first;
 }
 
 static void EraseComboContainer(int slot) {
@@ -2724,7 +2705,6 @@ int main(int argc, char** argv) {
     SOH_SetOnLoadSaveCallback = (FnSetSaveCallback)GetSym(sohModule, "SOH_SetOnLoadSaveCallback");
     SOH_GetCurrentPlayerName = (FnGetPlayerName)GetSym(sohModule, "SOH_GetCurrentPlayerName");
     MM_LoadSaveForCombo = (FnMMLoadSave)GetSym(mmModule, "MM_LoadSaveForCombo");
-    MM_TakeComboLoadFailCode = (FnInt)GetSym(mmModule, "MM_TakeComboLoadFailCode");
     SOH_ParkForComboMMResume = (FnVoid)GetSym(sohModule, "SOH_ParkForComboMMResume");
     MM_SetComboEntryIsResume = (FnMMInitSave)GetSym(mmModule, "MM_SetComboEntryIsResume");
     SOH_IsOnFileSelect = (FnIsOnFileSelect)GetSym(sohModule, "SOH_IsOnFileSelect");
@@ -2856,7 +2836,6 @@ int main(int argc, char** argv) {
     MM_LoadComboRando = (FnTakeStr)GetSym(mmModule, "MM_LoadComboRando");
     SOH_SetCopyContainer = (FnSetCopyContainer)GetSym(sohModule, "SOH_SetCopyContainer");
     SOH_SetOutdatedSaveNotice = (FnSetOutdatedSaveNotice)GetSym(sohModule, "SOH_SetOutdatedSaveNotice");
-    SOH_SetMMEntryFailNotice = (FnSetMMEntryFailNotice)GetSym(sohModule, "SOH_SetMMEntryFailNotice");
     SOH_SetDeleteForeignSave = (FnSetDeleteForeignSave)GetSym(sohModule, "SOH_SetDeleteForeignSave");
     MM_SetDeleteForeignSave = (FnSetDeleteForeignSave)GetSym(mmModule, "MM_SetDeleteForeignSave");
     SOH_DeleteSaveFile = (FnDeleteSaveFile)GetSym(sohModule, "SOH_DeleteSaveFile");
@@ -3195,9 +3174,6 @@ int main(int argc, char** argv) {
     // OOT owns the shared file-select; it polls for release-evicted slots and shows the outdated-save popup.
     if (SOH_SetOutdatedSaveNotice)
         SOH_SetOutdatedSaveNotice(&Combo_TakeEvictionNotice);
-    // Same seam for a refused MM entry — OOT is where the player lands afterwards.
-    if (SOH_SetMMEntryFailNotice)
-        SOH_SetMMEntryFailNotice(&Combo_TakeMMEntryFailure);
 
     // Cross-game erase seam (issue #1): erasing a save slot in either game wipes both saves.
     if (SOH_SetDeleteForeignSave)
@@ -3274,14 +3250,6 @@ int main(int argc, char** argv) {
                         // Session over: MM's dormant gSaveContext is post-quit state, so force the next
                         // save-load to re-read it from the container (else the tracker peek shows junk).
                         g_MmSaveInMemorySlot = -1;
-                        // Kind 3 = MM refused to load this slot's MM half. Point resume back at OOT so the
-                        // player isn't bounced into the same failure forever, and queue the OOT-side notice.
-                        if (g_mmReturnKind == 3) {
-                            Combo_SetLastGame(g_PendingMMFileNum, ComboRando::GAME_OOT);
-                            int code = MM_TakeComboLoadFailCode ? MM_TakeComboLoadFailCode() : 0;
-                            std::lock_guard<std::mutex> lk(g_containerMutex);
-                            g_mmEntryFailures.emplace_back(g_PendingMMFileNum, code);
-                        }
                     }
                 }
                 current = GAME_OOT;

--- a/combo/gui/ComboTrackerSwap.cpp
+++ b/combo/gui/ComboTrackerSwap.cpp
@@ -64,12 +64,12 @@ void EnsureMmSaveLoadedForDormantDraw() {
     if (ComboUI::MmEverForeground()) {
         return;
     }
-    static void (*sLoadMmSave)(int) = nullptr;
+    static int (*sLoadMmSave)(int) = nullptr;
     static bool sTried = false;
     if (!sTried) {
         sTried = true;
         if (HMODULE mm = GetModuleHandleA("2ship.dll")) {
-            sLoadMmSave = (void (*)(int))GetProcAddress(mm, "MM_LoadSaveForCombo");
+            sLoadMmSave = (int (*)(int))GetProcAddress(mm, "MM_LoadSaveForCombo");
         }
     }
     static int sLoadedSlot = -1;
@@ -77,6 +77,9 @@ void EnsureMmSaveLoadedForDormantDraw() {
     if (!sLoadMmSave || slot < 0 || slot == sLoadedSlot) {
         return;
     }
+    // Nonzero = nothing loaded (missing/broken MM half); it parks fileNum at 0xFF and clears saveType, so
+    // the trackers go blank instead of showing the previous slot's save. Latch the slot anyway: retrying
+    // every draw would re-read the container and spam the log.
     sLoadMmSave(slot);
     sLoadedSlot = slot;
 #endif

--- a/docs/deviations/anchor.md
+++ b/docs/deviations/anchor.md
@@ -257,3 +257,36 @@ Fixes, all `COMBO_BUILD`:
 - `soh/soh/Network/Anchor/DummyPlayer.cpp` + `mm/2s2h/Network/Anchor/DummyPlayer.cpp`: remote puppet
   name tags now use the client's Anchor color (`client.color`) instead of the dark default
   (`NameTagOptions.textColor` alpha 0).
+
+## MM team-state merge + deferred cycle-save broadcast (2026-08-22)
+
+**Why:** MM's `HandlePacket_UpdateTeamState` replaced `saveInfo`/`shipSaveInfo` wholesale where OOT
+max-merges (`soh/soh/Network/Anchor/Packets/UpdateTeamState.cpp:283-290`), so a resync could truncate
+Small Keys, Stray Fairies and dungeon items — and, worse, hand us the peer's `saveType`, flipping
+`IS_RANDO` and silently unregistering every rando hook (including the Song of Time key restore).
+Separately, MMAnchor broadcast from `AfterEndOfCycleSave`, which can run *before* the rando restore hook:
+`RegisteredGameHooks<H>::functions` is an `std::unordered_map`, so hook order is not registration order
+and no ordering-based fix is sound.
+
+Fixes, receiver-only, no wire change (`mm/2s2h/Network/Anchor/MMAnchor.{h,cpp}`):
+- **Two early drop-guards**, neither conditioned on `IS_RANDO` — the handler is also reached with
+  `isDormantApply == true` from `PumpDormant`, which persists immediately afterwards, so an `IS_RANDO`-gated
+  guard would have skipped exactly the dormant path. (1) Local save not `SAVETYPE_RANDO` → warn and return;
+  there is no vanilla mode in ComboShip, so that means nothing usable is loaded, and preserving that
+  `saveType` through the merge *is* the original key-eating bug. (2) No `rando` block in the incoming
+  `shipSaveInfo` → warn and return: a non-rando peer serializes a zeroed `rando` struct
+  (`BenJsonConversions.hpp`), which the wholesale assign would turn into an empty `RANDO_SAVE_CHECKS`.
+- **Local `saveType` preserved** alongside `fileCreatedAt` in the receiver-local restore block.
+- **Max/OR-merge** `inventory.dungeonKeys`, `inventory.strayFairies`, `rando.foundDungeonKeys` (all `s8`,
+  `-1` when fresh, so signed max handles the sentinel) and OR `inventory.dungeonItems` (u8 bitfield).
+  Accepted, per the OOT precedent: a stale peer resync can re-grant a locally-spent Small Key.
+- **Deferred broadcast**: `AfterEndOfCycleSave` sets `pendingCycleSaveBroadcast`; MMAnchor's existing
+  `OnGameStateUpdate` hook sends it. `GameState_Update` runs `main` (where `Sram_SaveEndOfCycle` and all
+  `AfterEndOfCycleSave` hooks complete synchronously) before `GameInteractor_ExecuteOnGameStateUpdate`
+  (`mm/src/code/game.c:151-168`), so the send still lands the same frame, strictly after every restore.
+  A quit on that same frame drops the send harmlessly — peers re-request on connect. `Deactivate()` clears
+  the flag so an unsent broadcast can't fire unsolicited on the next activation.
+
+`Rando::MiscBehavior::OnFileLoad()` is still deliberately absent from the post-merge re-init block: it
+calls `CheckQueueReset()`, which would drop queued in-flight grants. Preserving the local `saveType`
+keeps its already-registered hooks valid, so it is not needed.

--- a/docs/deviations/boot-shutdown.md
+++ b/docs/deviations/boot-shutdown.md
@@ -489,3 +489,32 @@ the pre-fix segfault reproduced on demand; post-fix, `oot.z64` routes to the OoT
 (`SOH_ClassifyRom` accepts, MM never consulted) and `mm.z64` to the MM slot (SOH rejects, then
 `MM_ClassifyRom` accepts). Also verified by hand on Windows: ROMs dragged onto the extraction
 screen route through the `WM_DROPFILES`/DXGI path into the correct slots.
+
+## Three more quit-to-MM-title seams + refused MM entry (2026-08-22)
+
+Every path that reaches `TitleSetup_SetupTitleScreen` runs `Sram_InitNewSave()` (a `SAVETYPE_VANILLA`
+wipe) and then fires `OnSaveLoad`, which unregisters every `IS_RANDO` hook. The owl-save seam above
+covered one such path; three others were still unguarded, and all now route through the existing return
+hooks instead. Neither `Combo_RequestOwlSaveQuit()` nor `MM_RequestComboReturn()` stops the gamestate —
+the return hook drives the handoff — so none of these sites may `STOP_GAMESTATE`.
+
+- `z_kaleido_scope_NES.c` **save-prompt state 6** → `Combo_RequestOwlSaveQuit()`. Dead code in this tree;
+  guarded defensively so it cannot resurface as a save wipe.
+- `z_kaleido_scope_NES.c` **game-over Continue → "No"** → `Combo_RequestOwlSaveQuit()`. Vanilla discards
+  unsaved progress here too, so the semantics match. Both sites already set `pauseCtx->state =
+  PAUSE_STATE_OFF` first, so the branch cannot re-fire.
+- `DebugConsole.cpp` **`reset`** → `MM_RequestComboReturn()` (Ctrl+R semantics: persists only when
+  autosave is on). Transitively fixes `Ship_HandleConsoleCrashAsReset` and its callers. The
+  `gGameState == nullptr` early return is kept.
+
+**Return kind 3 — refused MM entry.** `title_setup.c` now checks `Combo_LoadMMSaveFile`'s return code and,
+on failure, calls `Combo_AbortMMEntry(code)` + `SET_NEXT_GAMESTATE(ConsoleLogo_Init)` instead of entering
+Play. The existing `OnGameStateMainStart` hook consumes the pending flag, calls `SOH_SetComboBootToTitle`
+like the owl-save quit, and fires `gComboReturnCallback(3)`. It must **not** run
+`SaveManager_SaveCurrentForCombo` for this kind: `gSaveContext` holds init defaults at that point, so
+persisting would create exactly the poisoned vanilla save the refusal exists to prevent. The launcher
+treats kind 3 as session-over (`g_MmSaveInMemorySlot = -1`) *plus* `Combo_SetLastGame(slot, GAME_OOT)` so
+resume can't bounce into the same failure, then queues an OOT-side popup via the new
+`SOH_SetMMEntryFailNotice` seam (`MM_TakeComboLoadFailCode` supplies the code) — same launcher-records /
+OOT-draws-on-the-main-thread pattern as the release-eviction notice. See `rando.md` for the load-side
+policy and the failure codes.

--- a/docs/deviations/boot-shutdown.md
+++ b/docs/deviations/boot-shutdown.md
@@ -490,7 +490,7 @@ the pre-fix segfault reproduced on demand; post-fix, `oot.z64` routes to the OoT
 `MM_ClassifyRom` accepts). Also verified by hand on Windows: ROMs dragged onto the extraction
 screen route through the `WM_DROPFILES`/DXGI path into the correct slots.
 
-## Three more quit-to-MM-title seams + refused MM entry (2026-08-22)
+## Three more quit-to-MM-title seams (2026-08-22)
 
 Every path that reaches `TitleSetup_SetupTitleScreen` runs `Sram_InitNewSave()` (a `SAVETYPE_VANILLA`
 wipe) and then fires `OnSaveLoad`, which unregisters every `IS_RANDO` hook. The owl-save seam above
@@ -507,14 +507,7 @@ the return hook drives the handoff — so none of these sites may `STOP_GAMESTAT
   autosave is on). Transitively fixes `Ship_HandleConsoleCrashAsReset` and its callers. The
   `gGameState == nullptr` early return is kept.
 
-**Return kind 3 — refused MM entry.** `title_setup.c` now checks `Combo_LoadMMSaveFile`'s return code and,
-on failure, calls `Combo_AbortMMEntry(code)` + `SET_NEXT_GAMESTATE(ConsoleLogo_Init)` instead of entering
-Play. The existing `OnGameStateMainStart` hook consumes the pending flag, calls `SOH_SetComboBootToTitle`
-like the owl-save quit, and fires `gComboReturnCallback(3)`. It must **not** run
-`SaveManager_SaveCurrentForCombo` for this kind: `gSaveContext` holds init defaults at that point, so
-persisting would create exactly the poisoned vanilla save the refusal exists to prevent. The launcher
-treats kind 3 as session-over (`g_MmSaveInMemorySlot = -1`) *plus* `Combo_SetLastGame(slot, GAME_OOT)` so
-resume can't bounce into the same failure, then queues an OOT-side popup via the new
-`SOH_SetMMEntryFailNotice` seam (`MM_TakeComboLoadFailCode` supplies the code) — same launcher-records /
-OOT-draws-on-the-main-thread pattern as the release-eviction notice. See `rando.md` for the load-side
-policy and the failure codes.
+**MM entry is never refused.** The return kinds stay 0/1/2; there is deliberately no "entry failed" kind.
+Nor is it repaired: an unusable MM half is logged loudly, the fail-closed load sentinel keeps stray writes
+and tracker draws off the slot, and play proceeds — re-creating the file is the remedy, and the legacy
+population is retired by the 0.3.0 container gate. See `rando.md` for the load-side failure codes.

--- a/docs/deviations/rando.md
+++ b/docs/deviations/rando.md
@@ -1114,6 +1114,65 @@ ComboShip could reach that state two ways, both now closed:
 Tripwire: `Combo_LoadMMSaveFile` logs an error whenever a loaded MM save isn't `SAVETYPE_RANDO`.
 Already-broken saves are not repaired — re-create the file.
 
+### Residual key-loss gaps closed (2026-08-22)
+
+The 2026-07-31 pass covered every *creation* path. A re-audit found four more ways the same symptom
+(Song of Time eating Small Keys) still reached players.
+
+**Loading never creates or persists.** `SaveManager_LoadSaveFile` used to build *and write* a fresh
+`SAVETYPE_VANILLA` save whenever the container had no `mm` section — reachable from the read-only dormant
+peek (`Combo_OnOOTSaveLoad` → `MM_LoadSaveForCombo`), which permanently poisoned the slot. That block is
+gone. The function now returns a code (`0` ok, `-1` missing, `-2` unreadable, `-3` migrate, `-4` no
+`newCycleSave`, `-5` parse throw), `Combo_LoadMMSaveFile` adds `-6` for a non-`SAVETYPE_RANDO` save, and
+every failure parks `gSaveContext.fileNum` at `0xFF` and clears `saveType`. Both halves of that matter:
+`0xFF` is the "no save" sentinel `Combo_MM_GiveDormantResolved`, `MM_MarkForeignObtained` and MMAnchor's
+`PumpDormant` all test, so a stray write lands *nowhere* rather than persisting the previous slot's save
+(or zeroed vanilla BSS) into the failed slot; and since `fileNum` is signed and `0xFF` still passes the
+peek trackers' `>= 0` test, only the cleared `saveType` (→ `IS_RANDO` false) stops them from drawing the
+previous slot's save as this one — `ItemTracker`'s peek gate was missing that `IS_RANDO` term and now has
+it. On any nonzero code `title_setup.c` calls `Combo_AbortMMEntry()` and bounces to `ConsoleLogo_Init`: Play is never
+entered, MM is never persisted (gSaveContext holds init defaults — writing them *is* the poison), and the
+launcher gets return kind 3. Kind 3 clears `g_MmSaveInMemorySlot`, points `lastGame` back at OOT so resume
+can't loop into the failure, and queues an OOT-side popup naming the slot and the code (same drain pattern
+as the release-eviction notice). The dormant peek only marks a slot resident when the load returned 0.
+`SaveManager_SysFlashrom_WriteData`'s owl branch also used to emit an `owlSave`-only section when its
+pre-read failed, which nothing could ever load again; under `COMBO_BUILD` it now seeds `newCycleSave` from
+the owl snapshot (resuming a little late beats a dead slot).
+
+**Key-mirror safety net.** A small-key check left `shuffled == false` delivers through vanilla `Item_Give`
+(`z_parameter.c:4228`), which bumps `inventory.dungeonKeys` but not `rando.foundDungeonKeys`; the cycle
+restore then truncates keys down to the stale mirror. A `COND_ID_HOOK(OnItemGive, ITEM_KEY_SMALL, IS_RANDO)`
+registered in `Rando::MiscBehavior::OnFileLoad()` (so it re-registers per `OnSaveLoad`, honoring the
+`COND_*` re-sample invariant) raises the mirror to the inventory count. It gates on
+`Map_IsInDungeonOrBossScene` because outside a dungeon `gSaveContext.mapIndex` is the overworld minimap
+index, which aliases key indices. Idempotent, monotonic, and a no-op after a rando grant. The two paths
+that could produce such a check are now loud rather than silent: `MM_InitRandoSaveFile` counts unknown
+checks/items and substitutes junk for an unknown *item* (keeping the check shuffled, so its vanilla key can
+never take the vanilla path), and `Spoiler/Apply.cpp` forces `shuffled = true` + `RI_JUNK` when an absent
+check's vanilla item is `RITYPE_SMALL_KEY`. Small keys are always shuffled in MM rando, so that is a
+provable anomaly — every other absent check keeps its legitimate vanilla revert.
+
+**Skeleton Key self-heals.** `Rando::GiveItem`'s `RI_SKELETON_KEY` case gated the mirror write on the
+*inventory* count, so it could not repair a desync. It now raises both counters independently to
+`max(current, N)` from a shared table (`Rando::skeletonKeyCounts`) — never lowering either, healing `-1`
+sentinels and drift in both directions. The headless oracle (`GiveItemForOracle`) had no
+`RI_SKELETON_KEY` case at all, so key-gated regions stayed unreachable during fill; it now shares the same
+table, and its four `RI_*_SMALL_KEY` cases normalize the mirror sentinel before bumping instead of a bare
+`++`. Consequence: newly generated skeleton-key seeds may place differently now that fill reachability is
+correct. Stored seeds re-apply saved placements and are unaffected.
+
+**Three edits are deliberately un-guarded**, because each is behavior-neutral upstream rather than a
+combo deviation: the `z_sram_NES.c:1279` moon-crash `memcpy` now targets `gSaveContext.save` like the
+sibling read two lines up (`save` is `SaveContext`'s first member, so the bytes landed identically
+before); `GiveItem.cpp`'s `RI_SKELETON_KEY` rewrite and the four `RI_*_SMALL_KEY` cases only ever raise
+counters that vanilla MM rando already intended to be equal; and `Rando.h`'s `skeletonKeyCounts` table
+plus `Rando::AddSmallKey()` are pure factoring of constants and arithmetic that already existed inline.
+
+**Anchor.** See `anchor.md` — MM's `HandlePacket_UpdateTeamState` wholesale-replaced `saveInfo`/
+`shipSaveInfo` (including `saveType` and the key counters), and the cycle-save broadcast could outrun the
+restore hook. Hook execution order is *not* registration order (`RegisteredGameHooks<H>::functions` is an
+`std::unordered_map`), so the fix defers the broadcast rather than ordering the hooks.
+
 ## Per-seed spoiler names + shop-only prices (2026-07-31)
 
 **Spoilers no longer overwrite each other.** Generation wrote a single

--- a/docs/deviations/rando.md
+++ b/docs/deviations/rando.md
@@ -1112,7 +1112,8 @@ ComboShip could reach that state two ways, both now closed:
   for the empty-placement early return.
 
 Tripwire: `Combo_LoadMMSaveFile` logs an error whenever a loaded MM save isn't `SAVETYPE_RANDO`.
-Already-broken saves are not repaired — re-create the file.
+Already-broken saves are not repaired — re-create the file. The legacy population from before this was
+caught is retired by the 0.3.0 container gate (see below).
 
 ### Residual key-loss gaps closed (2026-08-22)
 
@@ -1130,14 +1131,27 @@ every failure parks `gSaveContext.fileNum` at `0xFF` and clears `saveType`. Both
 (or zeroed vanilla BSS) into the failed slot; and since `fileNum` is signed and `0xFF` still passes the
 peek trackers' `>= 0` test, only the cleared `saveType` (→ `IS_RANDO` false) stops them from drawing the
 previous slot's save as this one — `ItemTracker`'s peek gate was missing that `IS_RANDO` term and now has
-it. On any nonzero code `title_setup.c` calls `Combo_AbortMMEntry()` and bounces to `ConsoleLogo_Init`: Play is never
-entered, MM is never persisted (gSaveContext holds init defaults — writing them *is* the poison), and the
-launcher gets return kind 3. Kind 3 clears `g_MmSaveInMemorySlot`, points `lastGame` back at OOT so resume
-can't loop into the failure, and queues an OOT-side popup naming the slot and the code (same drain pattern
-as the release-eviction notice). The dormant peek only marks a slot resident when the load returned 0.
+it. The dormant peek only marks a slot resident when the load returned 0, so it is strictly read-only and
+fail-closed: it never rebuilds, it just goes blank.
 `SaveManager_SysFlashrom_WriteData`'s owl branch also used to emit an `owlSave`-only section when its
 pre-read failed, which nothing could ever load again; under `COMBO_BUILD` it now seeds `newCycleSave` from
 the owl snapshot (resuming a little late beats a dead slot).
+
+**No rebuild, no repair, no blocked entry.** ComboShip never blocks MM entry *and* never repairs a save.
+There is deliberately nothing between those two: a missing or unloadable `mm` section means either the
+file was created with **no seed bound** — which `Combo_OnOOTSaveInit` already refuses loudly, writing no
+`mm` section at all — or the file is damaged. In both cases the load logs an error, the fail-closed
+sentinel above keeps stray writes and tracker draws off the slot, play proceeds, and the remedy is
+re-creating the file. `title_setup.c` therefore just calls `Combo_LoadMMSaveFile` and ignores the code;
+the return value's only consumers are that log and the dormant peek's success check.
+
+**Legacy broken saves are retired by the `0.3.0` container gate, not by runtime repair.**
+`LoadOrCreateContainer` backs up any container whose `comboRelease` differs in `major.minor` and starts
+fresh, so the pre-0.3.0 population poisoned by the old load-side auto-create is invalidated wholesale —
+there is no migration path for a save whose MM half was silently vanilla for an unknown stretch of play,
+and inventing one at runtime would only mask the bug. `SaveManager_InitNewSaveForSlot` does stamp
+`SAVETYPE_RANDO` before its write (it persists, and it is a combo-only function), so the legitimate
+creation path can never leave a vanilla MM save in the container even transiently.
 
 **Key-mirror safety net.** A small-key check left `shuffled == false` delivers through vanilla `Item_Give`
 (`z_parameter.c:4228`), which bumps `inventory.dungeonKeys` but not `rando.foundDungeonKeys`; the cycle

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -147,8 +147,8 @@ extern "C"
     sComboTransitionActive = true;
 }
 
-// kind: 0 = portal (walked out the Clock Tower), 1 = Ctrl+R reset, 2 = owl-save quit, 3 = refused save
-// load. Only a portal return continues the session in OOT; the rest end it and boot OOT to its title.
+// kind: 0 = portal (walked out the Clock Tower), 1 = Ctrl+R reset, 2 = owl-save quit. Only a portal
+// return continues the session in OOT; the other two end it and boot OOT to its title.
 extern "C" void (*gComboReturnCallback)(int kind) = nullptr;
 extern "C" __declspec(dllexport) void MM_SetOnComboReturnCallback(void (*cb)(int kind)) {
     gComboReturnCallback = cb;
@@ -168,29 +168,12 @@ static bool sComboOwlSaveQuitPending = false;
 extern "C" void Combo_RequestOwlSaveQuit(void) {
     sComboOwlSaveQuitPending = true;
 }
-// ComboShip: this slot's MM save is missing or broken. Never recreate it — Play is never entered, MM is
-// never persisted (gSaveContext holds init defaults, writing them would create the poison), and the
-// launcher gets kind 3, which cancels MM entry for this attempt and pops a notice with the fail code.
-// Nothing is latched: a later attempt on the same slot refuses again with a fresh popup.
-static bool sComboLoadFailPending = false;
-static int sComboLoadFailCode = 0;
-extern "C" void Combo_AbortMMEntry(int failCode) {
-    sComboLoadFailPending = true;
-    sComboLoadFailCode = failCode != 0 ? failCode : -1;
-}
-extern "C" __declspec(dllexport) int MM_TakeComboLoadFailCode(void) {
-    int code = sComboLoadFailCode;
-    sComboLoadFailCode = 0;
-    return code;
-}
 // Drop any unconsumed return request. Called as MM is entered: one left over from the previous session
 // would immediately quit the new one.
 static void Combo_ClearReturnRequests(void) {
     sComboReturnPending = false;
     sComboResetReturnPending = false;
     sComboOwlSaveQuitPending = false;
-    sComboLoadFailPending = false;
-    sComboLoadFailCode = 0;
 }
 // MM's own ResourceManager, created at first boot and kept alive for the whole process. A combo
 // transition swaps the Context's active RM between MM's and OOT's, so each game keeps its archives +
@@ -1147,18 +1130,15 @@ extern "C" void InitOTR(int argc, char* argv[]) {
         }
     });
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameStateMainStart>([]() {
-        if (!sComboReturnPending && !sComboResetReturnPending && !sComboOwlSaveQuitPending && !sComboLoadFailPending)
+        if (!sComboReturnPending && !sComboResetReturnPending && !sComboOwlSaveQuitPending)
             return;
         const bool isReset = sComboResetReturnPending;
         const bool isOwlSaveQuit = sComboOwlSaveQuitPending;
-        const bool isLoadFail = sComboLoadFailPending;
         sComboReturnPending = false;
         sComboResetReturnPending = false;
         sComboOwlSaveQuitPending = false;
-        sComboLoadFailPending = false;
-        // An owl save quit lands on OOT's title, like Ctrl+R, rather than resuming OOT gameplay. A refused
-        // save load has no session to resume either.
-        if (isOwlSaveQuit || isLoadFail) {
+        // An owl save quit lands on OOT's title, like Ctrl+R, rather than resuming OOT gameplay.
+        if (isOwlSaveQuit) {
             static void (*sFn)(void) = nullptr;
             static bool sTried = false;
             if (!sTried) {
@@ -1171,13 +1151,12 @@ extern "C" void InitOTR(int argc, char* argv[]) {
         }
         // Portal return always persists MM; a reset persists only when autosave is enabled. Never
         // persist outside gameplay: the title/attract path wipes save first (Sram_InitNewSave). An owl
-        // save has already written itself through the flashrom seam. A refused load must never persist —
-        // gSaveContext holds init defaults, so writing them would create the poison we just refused.
-        if (!isOwlSaveQuit && !isLoadFail && (!isReset || CVarGetInteger("gEnhancements.Saving.Autosave", 0)) &&
+        // save has already written itself through the flashrom seam.
+        if (!isOwlSaveQuit && (!isReset || CVarGetInteger("gEnhancements.Saving.Autosave", 0)) &&
             gSaveContext.gameMode == GAMEMODE_NORMAL)
             SaveManager_SaveCurrentForCombo();
         if (gComboReturnCallback)
-            gComboReturnCallback(isLoadFail ? 3 : (isOwlSaveQuit ? 2 : (isReset ? 1 : 0)));
+            gComboReturnCallback(isOwlSaveQuit ? 2 : (isReset ? 1 : 0));
         if (auto fast3d = std::dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetRawInstance()->GetWindow())) {
             fast3d->SetIsRunning(false);
         }
@@ -2641,7 +2620,8 @@ extern "C" void Combo_AdoptOOTGlobalOptions(void) {
 }
 
 // C-callable wrapper used by title_setup.c (which is a C file) to load a MM save from disk.
-// 0 = loaded; negative = the caller must refuse MM entry (SaveManager codes, plus -6 = not a rando save).
+// 0 = loaded a usable rando save; negative = nothing usable (SaveManager codes, plus -6 = loaded but not
+// a rando save). The caller REBUILDS on a negative code — it never refuses entry.
 extern "C" int Combo_LoadMMSaveFile(int mmFileNum) {
     int result = SaveManager_LoadSaveFile(mmFileNum);
     if (result != 0) {
@@ -2650,7 +2630,7 @@ extern "C" int Combo_LoadMMSaveFile(int mmFileNum) {
     // No vanilla mode in ComboShip: a non-rando save means the slot was created wrong, and every
     // IS_RANDO hook stays unregistered (COND_HOOK tests the condition once, at OnSaveLoad).
     if (gSaveContext.save.shipSaveInfo.saveType != SAVETYPE_RANDO) {
-        SPDLOG_ERROR("[ComboShip] MM save file{} is not SAVETYPE_RANDO — refusing MM entry", mmFileNum);
+        SPDLOG_ERROR("[ComboShip] MM save file{} is not SAVETYPE_RANDO — rebuilding a baseline", mmFileNum);
         return -6;
     }
     return 0;

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -147,8 +147,8 @@ extern "C"
     sComboTransitionActive = true;
 }
 
-// kind: 0 = portal (walked out the Clock Tower), 1 = Ctrl+R reset, 2 = owl-save quit. Only a portal
-// return continues the session in OOT; the other two end it and boot OOT to its title.
+// kind: 0 = portal (walked out the Clock Tower), 1 = Ctrl+R reset, 2 = owl-save quit, 3 = refused save
+// load. Only a portal return continues the session in OOT; the rest end it and boot OOT to its title.
 extern "C" void (*gComboReturnCallback)(int kind) = nullptr;
 extern "C" __declspec(dllexport) void MM_SetOnComboReturnCallback(void (*cb)(int kind)) {
     gComboReturnCallback = cb;
@@ -168,12 +168,29 @@ static bool sComboOwlSaveQuitPending = false;
 extern "C" void Combo_RequestOwlSaveQuit(void) {
     sComboOwlSaveQuitPending = true;
 }
+// ComboShip: this slot's MM save is missing or broken. Never recreate it — Play is never entered, MM is
+// never persisted (gSaveContext holds init defaults, writing them would create the poison), and the
+// launcher gets kind 3, which cancels MM entry for this attempt and pops a notice with the fail code.
+// Nothing is latched: a later attempt on the same slot refuses again with a fresh popup.
+static bool sComboLoadFailPending = false;
+static int sComboLoadFailCode = 0;
+extern "C" void Combo_AbortMMEntry(int failCode) {
+    sComboLoadFailPending = true;
+    sComboLoadFailCode = failCode != 0 ? failCode : -1;
+}
+extern "C" __declspec(dllexport) int MM_TakeComboLoadFailCode(void) {
+    int code = sComboLoadFailCode;
+    sComboLoadFailCode = 0;
+    return code;
+}
 // Drop any unconsumed return request. Called as MM is entered: one left over from the previous session
 // would immediately quit the new one.
 static void Combo_ClearReturnRequests(void) {
     sComboReturnPending = false;
     sComboResetReturnPending = false;
     sComboOwlSaveQuitPending = false;
+    sComboLoadFailPending = false;
+    sComboLoadFailCode = 0;
 }
 // MM's own ResourceManager, created at first boot and kept alive for the whole process. A combo
 // transition swaps the Context's active RM between MM's and OOT's, so each game keeps its archives +
@@ -1130,15 +1147,18 @@ extern "C" void InitOTR(int argc, char* argv[]) {
         }
     });
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameStateMainStart>([]() {
-        if (!sComboReturnPending && !sComboResetReturnPending && !sComboOwlSaveQuitPending)
+        if (!sComboReturnPending && !sComboResetReturnPending && !sComboOwlSaveQuitPending && !sComboLoadFailPending)
             return;
         const bool isReset = sComboResetReturnPending;
         const bool isOwlSaveQuit = sComboOwlSaveQuitPending;
+        const bool isLoadFail = sComboLoadFailPending;
         sComboReturnPending = false;
         sComboResetReturnPending = false;
         sComboOwlSaveQuitPending = false;
-        // An owl save quit lands on OOT's title, like Ctrl+R, rather than resuming OOT gameplay.
-        if (isOwlSaveQuit) {
+        sComboLoadFailPending = false;
+        // An owl save quit lands on OOT's title, like Ctrl+R, rather than resuming OOT gameplay. A refused
+        // save load has no session to resume either.
+        if (isOwlSaveQuit || isLoadFail) {
             static void (*sFn)(void) = nullptr;
             static bool sTried = false;
             if (!sTried) {
@@ -1151,12 +1171,13 @@ extern "C" void InitOTR(int argc, char* argv[]) {
         }
         // Portal return always persists MM; a reset persists only when autosave is enabled. Never
         // persist outside gameplay: the title/attract path wipes save first (Sram_InitNewSave). An owl
-        // save has already written itself through the flashrom seam.
-        if (!isOwlSaveQuit && (!isReset || CVarGetInteger("gEnhancements.Saving.Autosave", 0)) &&
+        // save has already written itself through the flashrom seam. A refused load must never persist —
+        // gSaveContext holds init defaults, so writing them would create the poison we just refused.
+        if (!isOwlSaveQuit && !isLoadFail && (!isReset || CVarGetInteger("gEnhancements.Saving.Autosave", 0)) &&
             gSaveContext.gameMode == GAMEMODE_NORMAL)
             SaveManager_SaveCurrentForCombo();
         if (gComboReturnCallback)
-            gComboReturnCallback(isOwlSaveQuit ? 2 : (isReset ? 1 : 0));
+            gComboReturnCallback(isLoadFail ? 3 : (isOwlSaveQuit ? 2 : (isReset ? 1 : 0)));
         if (auto fast3d = std::dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetRawInstance()->GetWindow())) {
             fast3d->SetIsRunning(false);
         }
@@ -2620,14 +2641,19 @@ extern "C" void Combo_AdoptOOTGlobalOptions(void) {
 }
 
 // C-callable wrapper used by title_setup.c (which is a C file) to load a MM save from disk.
-extern "C" void Combo_LoadMMSaveFile(int mmFileNum) {
-    SaveManager_LoadSaveFile(mmFileNum);
+// 0 = loaded; negative = the caller must refuse MM entry (SaveManager codes, plus -6 = not a rando save).
+extern "C" int Combo_LoadMMSaveFile(int mmFileNum) {
+    int result = SaveManager_LoadSaveFile(mmFileNum);
+    if (result != 0) {
+        return result;
+    }
     // No vanilla mode in ComboShip: a non-rando save means the slot was created wrong, and every
     // IS_RANDO hook stays unregistered (COND_HOOK tests the condition once, at OnSaveLoad).
     if (gSaveContext.save.shipSaveInfo.saveType != SAVETYPE_RANDO) {
-        SPDLOG_ERROR("[ComboShip] MM save file{} is not SAVETYPE_RANDO — rando behavior is disabled for this slot",
-                     mmFileNum);
+        SPDLOG_ERROR("[ComboShip] MM save file{} is not SAVETYPE_RANDO — refusing MM entry", mmFileNum);
+        return -6;
     }
+    return 0;
 }
 
 extern "C" void MM_RunMain(void);
@@ -2747,9 +2773,9 @@ extern "C" __declspec(dllexport) void MM_ResumeGame(int fileNum) {
 
 // ComboShip: bring the MM save for the given OOT slot (0-indexed) into MM's dormant gSaveContext, so
 // the tracker peek shows real items before MM is visited this session. Same headless load path
-// title_setup.c runs on resume (no gPlayState needed).
-extern "C" __declspec(dllexport) void MM_LoadSaveForCombo(int fileNum) {
-    Combo_LoadMMSaveFile(fileNum + 1); // shares the saveType tripwire
+// title_setup.c runs on resume (no gPlayState needed). Nonzero = nothing usable was loaded.
+extern "C" __declspec(dllexport) int MM_LoadSaveForCombo(int fileNum) {
+    return Combo_LoadMMSaveFile(fileNum + 1); // shares the saveType tripwire
 }
 
 static void Combo_MM_ApplyCheckPrices();
@@ -2853,11 +2879,14 @@ extern "C" __declspec(dllexport) int MM_InitRandoSaveFile(int fileNum, const cha
         };
         nlohmann::json checks = nlohmann::json::object();
         nlohmann::json rawPlacements = nlohmann::json::parse(placementJson); // bind before .items() (no dangling temp)
+        int unknownChecks = 0;
+        int unknownItems = 0;
         for (auto& [friendlyCheck, val] : rawPlacements.items()) {
             if (!val.is_string())
                 continue;
             RandoCheckId cid = Rando::StaticData::GetCheckIdFromDisplayName(stripMM(friendlyCheck).c_str());
             if (cid == RC_UNKNOWN) {
+                unknownChecks++;
                 SPDLOG_WARN("[ComboShip] MM_InitRandoSaveFile: unknown check '{}'", friendlyCheck);
                 continue;
             }
@@ -2866,10 +2895,18 @@ extern "C" __declspec(dllexport) int MM_InitRandoSaveFile(int fileNum, const cha
             if (iid == RI_UNKNOWN)
                 iid = Rando::StaticData::GetItemIdFromName(v.c_str()); // foreign sentinel / raw RI_
             if (iid == RI_UNKNOWN) {
+                unknownItems++;
                 SPDLOG_WARN("[ComboShip] MM_InitRandoSaveFile: unknown item '{}' at '{}'", v, friendlyCheck);
-                continue;
+                // Substitute junk rather than dropping the check: an omitted check reverts to its vanilla
+                // item, and a vanilla small key would take the vanilla give path and desync the key mirror.
+                iid = RI_JUNK;
             }
             checks[Rando::StaticData::Checks[cid].name] = Rando::StaticData::Items[iid].spoilerName;
+        }
+        if (unknownChecks != 0 || unknownItems != 0) {
+            SPDLOG_ERROR("[ComboShip] MM_InitRandoSaveFile: placement payload had {} unknown checks (dropped) and "
+                         "{} unknown items (junked) for slot {}",
+                         unknownChecks, unknownItems, fileNum);
         }
         spoiler["checks"] = std::move(checks);
 
@@ -3561,24 +3598,28 @@ static void GiveItemForOracle(RandoItemId ri) {
         // (DUNGEON_KEY_COUNT), so bump both like the real GiveItem — else every KEY_COUNT gate stays 0 and
         // key-locked dungeon rooms (Stone Tower/Snowhead/Great Bay deep) are unreachable.
         case RI_WOODFALL_SMALL_KEY:
-            DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_WOODFALL_TEMPLE) =
-                std::max(0, (int)DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_WOODFALL_TEMPLE)) + 1;
-            gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[DUNGEON_SCENE_INDEX_WOODFALL_TEMPLE]++;
+            Rando::AddSmallKey(DUNGEON_SCENE_INDEX_WOODFALL_TEMPLE);
             break;
         case RI_SNOWHEAD_SMALL_KEY:
-            DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_SNOWHEAD_TEMPLE) =
-                std::max(0, (int)DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_SNOWHEAD_TEMPLE)) + 1;
-            gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[DUNGEON_SCENE_INDEX_SNOWHEAD_TEMPLE]++;
+            Rando::AddSmallKey(DUNGEON_SCENE_INDEX_SNOWHEAD_TEMPLE);
             break;
         case RI_GREAT_BAY_SMALL_KEY:
-            DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_GREAT_BAY_TEMPLE) =
-                std::max(0, (int)DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_GREAT_BAY_TEMPLE)) + 1;
-            gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[DUNGEON_SCENE_INDEX_GREAT_BAY_TEMPLE]++;
+            Rando::AddSmallKey(DUNGEON_SCENE_INDEX_GREAT_BAY_TEMPLE);
             break;
         case RI_STONE_TOWER_SMALL_KEY:
-            DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_STONE_TOWER_TEMPLE) =
-                std::max(0, (int)DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_STONE_TOWER_TEMPLE)) + 1;
-            gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[DUNGEON_SCENE_INDEX_STONE_TOWER_TEMPLE]++;
+            Rando::AddSmallKey(DUNGEON_SCENE_INDEX_STONE_TOWER_TEMPLE);
+            break;
+        // ComboShip: the oracle had no Skeleton Key case at all, so key-gated regions stayed unreachable
+        // during fill. Same raise-both-counters body as Rando::GiveItem.
+        case RI_SKELETON_KEY:
+            for (auto& k : Rando::skeletonKeyCounts) {
+                if (DUNGEON_KEY_COUNT(k.dungeonSceneIndex) < k.count) {
+                    DUNGEON_KEY_COUNT(k.dungeonSceneIndex) = k.count;
+                }
+                if (gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[k.dungeonSceneIndex] < k.count) {
+                    gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[k.dungeonSceneIndex] = k.count;
+                }
+            }
             break;
 
         // Stray fairies

--- a/mm/2s2h/BenPort.h
+++ b/mm/2s2h/BenPort.h
@@ -187,10 +187,9 @@ extern int gComboEntryIsResume;
 void Combo_AdoptOOTGlobalOptions(void);
 // ComboShip (#89): owl save quits to OOT's title instead of MM's own file select.
 void Combo_RequestOwlSaveQuit(void);
-// Load an existing MM save from disk into gSaveContext (C-callable wrapper). 0 = ok, negative = refuse.
+// Load an existing MM save from disk into gSaveContext (C-callable wrapper). 0 = ok; negative = nothing
+// usable was loaded (logged; the load leaves the fail-closed sentinel behind and play still proceeds).
 int Combo_LoadMMSaveFile(int mmFileNum);
-// ComboShip: refuse MM entry for a missing/broken MM save — quits back to OOT's title with kind 3.
-void Combo_AbortMMEntry(int failCode);
 
 int32_t GetGIID(uint32_t itemID);
 #endif

--- a/mm/2s2h/BenPort.h
+++ b/mm/2s2h/BenPort.h
@@ -187,8 +187,10 @@ extern int gComboEntryIsResume;
 void Combo_AdoptOOTGlobalOptions(void);
 // ComboShip (#89): owl save quits to OOT's title instead of MM's own file select.
 void Combo_RequestOwlSaveQuit(void);
-// Load an existing MM save from disk into gSaveContext (C-callable wrapper).
-void Combo_LoadMMSaveFile(int mmFileNum);
+// Load an existing MM save from disk into gSaveContext (C-callable wrapper). 0 = ok, negative = refuse.
+int Combo_LoadMMSaveFile(int mmFileNum);
+// ComboShip: refuse MM entry for a missing/broken MM save — quits back to OOT's title with kind 3.
+void Combo_AbortMMEntry(int failCode);
 
 int32_t GetGIID(uint32_t itemID);
 #endif

--- a/mm/2s2h/DeveloperTools/DebugConsole.cpp
+++ b/mm/2s2h/DeveloperTools/DebugConsole.cpp
@@ -126,8 +126,14 @@ static bool ResetHandler(std::shared_ptr<Ship::Console> Console, std::vector<std
         return 1;
     }
 
+#ifdef COMBO_BUILD
+    // ComboShip: MM's boot path wipes the save (Sram_InitNewSave) and combo can't enter its file select.
+    // Reuse the Ctrl+R return instead — same semantics, and it persists only when autosave is on.
+    MM_RequestComboReturn();
+#else
     STOP_GAMESTATE(gGameState);
     SET_NEXT_GAMESTATE(gGameState, ConsoleLogo_Init, sizeof(ConsoleLogoState));
+#endif
     // GI-TODO
     // GameInteractor::Instance->ExecuteHooks<GameInteractor::OnExitGame>(gSaveContext.fileNum);
     return 0;

--- a/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.cpp
@@ -79,8 +79,9 @@ TrackerImageObject GetImageObject(TrackerItemType itemType, u32 itemId) {
     bool isSaveLoaded = gPlayState != NULL && gSaveContext.gameMode == GAMEMODE_NORMAL;
 #ifdef COMBO_BUILD
     // ComboShip peek: dormant MM has no play state, but the slot's save is loaded (see
-    // EnsureMmSaveLoadedForPeek / MM_LoadSaveForCombo) — use it for icon selection too.
-    isSaveLoaded = isSaveLoaded || (!Combo_MmIsForeground() && gSaveContext.fileNum >= 0);
+    // EnsureMmSaveLoadedForPeek / MM_LoadSaveForCombo) — use it for icon selection too. IS_RANDO is the
+    // real gate: a refused load parks fileNum at 0xFF, which is still >= 0, but clears saveType.
+    isSaveLoaded = isSaveLoaded || (!Combo_MmIsForeground() && IS_RANDO && gSaveContext.fileNum >= 0);
 #endif
     bool itemObtained = false;
     TrackerImageObject trackerImageObject = {

--- a/mm/2s2h/Network/Anchor/MMAnchor.cpp
+++ b/mm/2s2h/Network/Anchor/MMAnchor.cpp
@@ -866,8 +866,7 @@ void MMAnchor::HandlePacket_UpdateTeamState(nlohmann::json& payload) {
     s8 localDungeonKeys[ARRAY_COUNT(gSaveContext.save.saveInfo.inventory.dungeonKeys)];
     memcpy(localDungeonKeys, gSaveContext.save.saveInfo.inventory.dungeonKeys, sizeof(localDungeonKeys));
     s8 localFoundDungeonKeys[ARRAY_COUNT(gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys)];
-    memcpy(localFoundDungeonKeys, gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys,
-           sizeof(localFoundDungeonKeys));
+    memcpy(localFoundDungeonKeys, gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys, sizeof(localFoundDungeonKeys));
     s8 localStrayFairies[ARRAY_COUNT(gSaveContext.save.saveInfo.inventory.strayFairies)];
     memcpy(localStrayFairies, gSaveContext.save.saveInfo.inventory.strayFairies, sizeof(localStrayFairies));
     u8 localDungeonItems[ARRAY_COUNT(gSaveContext.save.saveInfo.inventory.dungeonItems)];

--- a/mm/2s2h/Network/Anchor/MMAnchor.cpp
+++ b/mm/2s2h/Network/Anchor/MMAnchor.cpp
@@ -86,6 +86,8 @@ void MMAnchor::Activate() {
 
 void MMAnchor::Deactivate() {
     isActive = false;
+    // Drop an unsent cycle-save broadcast: it would otherwise fire unsolicited on the next activation.
+    pendingCycleSaveBroadcast = false;
     SPDLOG_INFO("[MMAnchor] deactivated");
 }
 
@@ -148,6 +150,12 @@ void MMAnchor::RegisterHooks() {
             if (gMMComboPumpDormant) {
                 gMMComboPumpDormant();
             }
+            // GameState_Update runs main (where Sram_SaveEndOfCycle and every AfterEndOfCycleSave hook
+            // complete) before this hook, so the deferred send lands the same frame, after the restore.
+            if (pendingCycleSaveBroadcast && gPlayState != nullptr) {
+                pendingCycleSaveBroadcast = false;
+                SendPacket_UpdateTeamState(CVarGetString(kCvarTeamId, "default"));
+            }
         }
     });
 
@@ -159,7 +167,9 @@ void MMAnchor::RegisterHooks() {
     });
     GameInteractor::Instance->RegisterGameHook<GameInteractor::AfterEndOfCycleSave>([this]() {
         if (isActive && gPlayState != nullptr) {
-            SendPacket_UpdateTeamState(CVarGetString(kCvarTeamId, "default"));
+            // Defer: the rando key/check restore is another AfterEndOfCycleSave hook and may not have run
+            // yet. Losing this on a same-frame quit is harmless — peers re-request on connect.
+            pendingCycleSaveBroadcast = true;
         }
     });
 }
@@ -788,9 +798,23 @@ void MMAnchor::HandlePacket_UpdateTeamState(nlohmann::json& payload) {
     if (!payload["state"].contains("shipSaveInfo")) {
         return; // soh-shaped team state; from_json(Save) would throw
     }
+    // ComboShip: both guards must hold on the dormant path too (PumpDormant persists right after), so
+    // neither may be conditioned on IS_RANDO. No vanilla mode here: a non-rando local save means nothing
+    // usable is loaded, and preserving that saveType through the merge is the original key-eating bug.
+    if (!IS_RANDO) {
+        SPDLOG_WARN("[MMAnchor] dropping team state: local save is not SAVETYPE_RANDO");
+        return;
+    }
+    // A non-rando peer serializes a zeroed rando struct, and the wholesale shipSaveInfo assign below
+    // would wipe every RANDO_SAVE_CHECKS entry. No merge can recover that.
+    if (!payload["state"]["shipSaveInfo"].contains("rando")) {
+        SPDLOG_WARN("[MMAnchor] dropping team state with no rando block (peer is not in a rando save)");
+        return;
+    }
 
     // Unpack the compact rando check array back into the shape from_json(Save) expects.
-    if (IS_RANDO && payload["state"]["shipSaveInfo"].contains("rando")) {
+    // Both conditions are guaranteed by the guards above.
+    {
         auto stuff =
             payload["state"]["shipSaveInfo"]["rando"]["randoSaveChecksCopy"].get<std::vector<std::vector<s32>>>();
         for (int i = 0; i < RC_MAX; i++) {
@@ -837,6 +861,17 @@ void MMAnchor::HandlePacket_UpdateTeamState(nlohmann::json& payload) {
     u8 localTradeItems[3] = { gSaveContext.save.saveInfo.inventory.items[SLOT_TRADE_DEED],
                               gSaveContext.save.saveInfo.inventory.items[SLOT_TRADE_KEY_MAMA],
                               gSaveContext.save.saveInfo.inventory.items[SLOT_TRADE_COUPLE] };
+    // ComboShip: key/fairy/dungeon-item counters are monotonic too — a stale peer (or one mid-Song-of-Time,
+    // whose keys are momentarily zero) would otherwise truncate ours. -1 is the fresh sentinel; signed max.
+    s8 localDungeonKeys[ARRAY_COUNT(gSaveContext.save.saveInfo.inventory.dungeonKeys)];
+    memcpy(localDungeonKeys, gSaveContext.save.saveInfo.inventory.dungeonKeys, sizeof(localDungeonKeys));
+    s8 localFoundDungeonKeys[ARRAY_COUNT(gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys)];
+    memcpy(localFoundDungeonKeys, gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys,
+           sizeof(localFoundDungeonKeys));
+    s8 localStrayFairies[ARRAY_COUNT(gSaveContext.save.saveInfo.inventory.strayFairies)];
+    memcpy(localStrayFairies, gSaveContext.save.saveInfo.inventory.strayFairies, sizeof(localStrayFairies));
+    u8 localDungeonItems[ARRAY_COUNT(gSaveContext.save.saveInfo.inventory.dungeonItems)];
+    memcpy(localDungeonItems, gSaveContext.save.saveInfo.inventory.dungeonItems, sizeof(localDungeonItems));
 
     // Restore bottle contents (unless Deku Princess).
     for (int i = 0; i < 6; i++) {
@@ -855,6 +890,9 @@ void MMAnchor::HandlePacket_UpdateTeamState(nlohmann::json& payload) {
     // Restore receiver-local fields that shouldn't be synced.
     loadedData.saveInfo.checksum = gSaveContext.save.saveInfo.checksum;
     loadedData.shipSaveInfo.fileCreatedAt = gSaveContext.save.shipSaveInfo.fileCreatedAt;
+    // ComboShip: taking a peer's saveType would flip IS_RANDO and silently unregister every rando hook.
+    // Safe to preserve unconditionally: the guard above already refused a non-rando local save.
+    loadedData.shipSaveInfo.saveType = gSaveContext.save.shipSaveInfo.saveType;
     memcpy(loadedData.saveInfo.playerData.newf, gSaveContext.save.saveInfo.playerData.newf,
            sizeof(loadedData.saveInfo.playerData.newf));
     memcpy(&loadedData.shipSaveInfo.dpadEquips, &gSaveContext.save.shipSaveInfo.dpadEquips,
@@ -933,6 +971,26 @@ void MMAnchor::HandlePacket_UpdateTeamState(nlohmann::json& payload) {
         cur.unk_14 |= localPermSceneFlags[i].unk_14; // dungeon floors visited
         cur.rooms |= localPermSceneFlags[i].rooms;
     }
+    // Max/OR-merge the key + fairy + dungeon-item counters back (OOT precedent: UpdateTeamState.cpp).
+    // Accepted: a stale peer resync can re-grant a locally-spent small key.
+    for (int i = 0; i < ARRAY_COUNT(localDungeonKeys); i++) {
+        if (localDungeonKeys[i] > gSaveContext.save.saveInfo.inventory.dungeonKeys[i]) {
+            gSaveContext.save.saveInfo.inventory.dungeonKeys[i] = localDungeonKeys[i];
+        }
+    }
+    for (int i = 0; i < ARRAY_COUNT(localFoundDungeonKeys); i++) {
+        if (localFoundDungeonKeys[i] > gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[i]) {
+            gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[i] = localFoundDungeonKeys[i];
+        }
+    }
+    for (int i = 0; i < ARRAY_COUNT(localStrayFairies); i++) {
+        if (localStrayFairies[i] > gSaveContext.save.saveInfo.inventory.strayFairies[i]) {
+            gSaveContext.save.saveInfo.inventory.strayFairies[i] = localStrayFairies[i];
+        }
+    }
+    for (int i = 0; i < ARRAY_COUNT(localDungeonItems); i++) {
+        gSaveContext.save.saveInfo.inventory.dungeonItems[i] |= localDungeonItems[i];
+    }
 #ifdef COMBO_BUILD
     if (localTriforcePieces > gSaveContext.save.shipSaveInfo.rando.foundTriforcePieces) {
         gSaveContext.save.shipSaveInfo.rando.foundTriforcePieces = localTriforcePieces;
@@ -974,6 +1032,8 @@ void MMAnchor::HandlePacket_UpdateTeamState(nlohmann::json& payload) {
                 .message = "Save updated from team",
             });
         }
+        // Rando::MiscBehavior::OnFileLoad() is deliberately NOT called: it runs CheckQueueReset(), which
+        // would drop in-flight grants. Preserving the local saveType above keeps its hooks valid anyway.
         Rando::CheckTracker::OnFileLoad();
         Rando::ActorBehavior::OnFileLoad();
         ShipInit::Init("IS_RANDO");

--- a/mm/2s2h/Network/Anchor/MMAnchor.h
+++ b/mm/2s2h/Network/Anchor/MMAnchor.h
@@ -146,6 +146,9 @@ class MMAnchor {
 
     bool hooksRegistered = false;
     bool shouldRefreshActors = false;
+    // Deferred to OnGameStateUpdate: broadcasting from AfterEndOfCycleSave can beat the rando restore
+    // hook (hook order is an unordered_map, not registration order) and push zeroed keys to peers.
+    bool pendingCycleSaveBroadcast = false;
     std::queue<nlohmann::json> incomingQueue;
     std::mutex incomingMutex;
 };

--- a/mm/2s2h/Rando/CheckTracker/CheckTracker.cpp
+++ b/mm/2s2h/Rando/CheckTracker/CheckTracker.cpp
@@ -591,7 +591,8 @@ comboSkipVisibilityGates:;
 #ifdef COMBO_BUILD
     // ComboShip dormant peek: no play state, but the slot's save is loaded (see
     // EnsureMmSaveLoadedForPeek / MM_LoadSaveForCombo) — draw from it. The headless load never
-    // fires OnFileLoad, so build the scene-check map here.
+    // fires OnFileLoad, so build the scene-check map here. IS_RANDO is what rejects a refused load
+    // (fileNum parks at 0xFF, which is still >= 0, but saveType is cleared).
     if (comboPeek && IS_RANDO && gSaveContext.fileNum >= 0) {
         if (sceneChecks.empty()) {
             initializeSceneChecks();

--- a/mm/2s2h/Rando/GiveItem.cpp
+++ b/mm/2s2h/Rando/GiveItem.cpp
@@ -59,13 +59,7 @@ void Rando::GiveItem(RandoItemId randoItemId) {
                              DUNGEON_SCENE_INDEX_WOODFALL_TEMPLE);
             break;
         case RI_WOODFALL_SMALL_KEY:
-            if (DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_WOODFALL_TEMPLE) < 0) {
-                DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_WOODFALL_TEMPLE) = 1;
-                gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[DUNGEON_SCENE_INDEX_WOODFALL_TEMPLE] = 1;
-            } else {
-                DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_WOODFALL_TEMPLE)++;
-                gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[DUNGEON_SCENE_INDEX_WOODFALL_TEMPLE]++;
-            }
+            Rando::AddSmallKey(DUNGEON_SCENE_INDEX_WOODFALL_TEMPLE);
             break;
         case RI_SNOWHEAD_BOSS_KEY:
         case RI_SNOWHEAD_MAP:
@@ -74,13 +68,7 @@ void Rando::GiveItem(RandoItemId randoItemId) {
                              DUNGEON_SCENE_INDEX_SNOWHEAD_TEMPLE);
             break;
         case RI_SNOWHEAD_SMALL_KEY:
-            if (DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_SNOWHEAD_TEMPLE) < 0) {
-                DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_SNOWHEAD_TEMPLE) = 1;
-                gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[DUNGEON_SCENE_INDEX_SNOWHEAD_TEMPLE] = 1;
-            } else {
-                DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_SNOWHEAD_TEMPLE)++;
-                gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[DUNGEON_SCENE_INDEX_SNOWHEAD_TEMPLE]++;
-            }
+            Rando::AddSmallKey(DUNGEON_SCENE_INDEX_SNOWHEAD_TEMPLE);
             break;
         case RI_GREAT_BAY_BOSS_KEY:
         case RI_GREAT_BAY_MAP:
@@ -89,13 +77,7 @@ void Rando::GiveItem(RandoItemId randoItemId) {
                              DUNGEON_SCENE_INDEX_GREAT_BAY_TEMPLE);
             break;
         case RI_GREAT_BAY_SMALL_KEY:
-            if (DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_GREAT_BAY_TEMPLE) < 0) {
-                DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_GREAT_BAY_TEMPLE) = 1;
-                gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[DUNGEON_SCENE_INDEX_GREAT_BAY_TEMPLE] = 1;
-            } else {
-                DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_GREAT_BAY_TEMPLE)++;
-                gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[DUNGEON_SCENE_INDEX_GREAT_BAY_TEMPLE]++;
-            }
+            Rando::AddSmallKey(DUNGEON_SCENE_INDEX_GREAT_BAY_TEMPLE);
             break;
         case RI_STONE_TOWER_BOSS_KEY:
         case RI_STONE_TOWER_MAP:
@@ -104,33 +86,22 @@ void Rando::GiveItem(RandoItemId randoItemId) {
                              DUNGEON_SCENE_INDEX_STONE_TOWER_TEMPLE);
             break;
         case RI_STONE_TOWER_SMALL_KEY:
-            if (DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_STONE_TOWER_TEMPLE) < 0) {
-                DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_STONE_TOWER_TEMPLE) = 1;
-                gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[DUNGEON_SCENE_INDEX_STONE_TOWER_TEMPLE] = 1;
-            } else {
-                DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_STONE_TOWER_TEMPLE)++;
-                gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[DUNGEON_SCENE_INDEX_STONE_TOWER_TEMPLE]++;
-            }
+            Rando::AddSmallKey(DUNGEON_SCENE_INDEX_STONE_TOWER_TEMPLE);
             break;
         // Grants the max small keys for every dungeon at once (Woodfall 1, Snowhead 3, Great Bay 1, Stone Tower 4)
-        case RI_SKELETON_KEY:
-            if (DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_WOODFALL_TEMPLE) < 1) {
-                DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_WOODFALL_TEMPLE) = 1;
-                gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[DUNGEON_SCENE_INDEX_WOODFALL_TEMPLE] = 1;
-            }
-            if (DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_SNOWHEAD_TEMPLE) < 3) {
-                DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_SNOWHEAD_TEMPLE) = 3;
-                gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[DUNGEON_SCENE_INDEX_SNOWHEAD_TEMPLE] = 3;
-            }
-            if (DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_GREAT_BAY_TEMPLE) < 1) {
-                DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_GREAT_BAY_TEMPLE) = 1;
-                gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[DUNGEON_SCENE_INDEX_GREAT_BAY_TEMPLE] = 1;
-            }
-            if (DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_STONE_TOWER_TEMPLE) < 4) {
-                DUNGEON_KEY_COUNT(DUNGEON_SCENE_INDEX_STONE_TOWER_TEMPLE) = 4;
-                gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[DUNGEON_SCENE_INDEX_STONE_TOWER_TEMPLE] = 4;
+        case RI_SKELETON_KEY: {
+            // ComboShip: raise the inventory count and the rando mirror INDEPENDENTLY, so a -1 sentinel or a
+            // desync (vanilla Item_Give bumps only the inventory) heals instead of blocking the other counter.
+            for (auto& k : Rando::skeletonKeyCounts) {
+                if (DUNGEON_KEY_COUNT(k.dungeonSceneIndex) < k.count) {
+                    DUNGEON_KEY_COUNT(k.dungeonSceneIndex) = k.count;
+                }
+                if (gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[k.dungeonSceneIndex] < k.count) {
+                    gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[k.dungeonSceneIndex] = k.count;
+                }
             }
             break;
+        }
         case RI_TRIFORCE_PIECE:
         case RI_TRIFORCE_PIECE_PREVIOUS:
             gSaveContext.save.shipSaveInfo.rando.foundTriforcePieces++;

--- a/mm/2s2h/Rando/MiscBehavior/MiscBehavior.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/MiscBehavior.cpp
@@ -27,6 +27,24 @@ void Rando::MiscBehavior::OnFileLoad() {
     COND_HOOK(OnSceneInit, IS_RANDO, Rando::MiscBehavior::OnSceneInit);
     COND_ID_HOOK(OnActorUpdate, ACTOR_PLAYER, IS_RANDO, [](Actor* actor) { Rando::MiscBehavior::CheckQueue(); });
 
+#ifdef COMBO_BUILD
+    // ComboShip: a key delivered by vanilla Item_Give (an unshuffled small-key check) bumps only
+    // inventory.dungeonKeys, and the Song of Time restore then truncates keys to the stale rando mirror.
+    COND_ID_HOOK(OnItemGive, ITEM_KEY_SMALL, IS_RANDO, [](u8 item) {
+        // Outside a dungeon/boss scene mapIndex is the overworld minimap index, which aliases key indices.
+        if (gPlayState == NULL || !Map_IsInDungeonOrBossScene(gPlayState)) {
+            return;
+        }
+        s32 index = gSaveContext.mapIndex;
+        if (index < 0 || index > DUNGEON_SCENE_INDEX_STONE_TOWER_TEMPLE) {
+            return;
+        }
+        if (gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[index] < DUNGEON_KEY_COUNT(index)) {
+            gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[index] = DUNGEON_KEY_COUNT(index);
+        }
+    });
+#endif
+
     // This overrides the ocarina condition for Termina Field
     COND_VB_SHOULD(VB_TERMINA_FIELD_BE_EMPTY, IS_RANDO, { *should = false; });
 

--- a/mm/2s2h/Rando/Rando.h
+++ b/mm/2s2h/Rando/Rando.h
@@ -15,6 +15,26 @@ namespace Rando {
 void Init();
 void DrawItem(RandoItemId randoItemId, RandoCheckId randoCheckId = RC_UNKNOWN, Actor* actor = nullptr);
 void GiveItem(RandoItemId randoItemId);
+// ComboShip: a small key lives in TWO counters — inventory.dungeonKeys and the rando mirror that
+// logic's KEY_COUNT reads — and both are -1 when fresh. Normalize each sentinel independently before
+// bumping, so a pre-existing desync heals instead of leaving the mirror permanently one behind.
+inline void AddSmallKey(s32 dungeonSceneIndex) {
+    s8& inventory = DUNGEON_KEY_COUNT(dungeonSceneIndex);
+    s8& mirror = gSaveContext.save.shipSaveInfo.rando.foundDungeonKeys[dungeonSceneIndex];
+    inventory = (s8)((inventory < 0 ? 0 : inventory) + 1);
+    mirror = (s8)((mirror < 0 ? 0 : mirror) + 1);
+}
+// ComboShip: Skeleton Key's per-dungeon small-key maxima, shared with the headless oracle give.
+struct SkeletonKeyCount {
+    s32 dungeonSceneIndex;
+    s8 count;
+};
+inline constexpr SkeletonKeyCount skeletonKeyCounts[] = {
+    { DUNGEON_SCENE_INDEX_WOODFALL_TEMPLE, 1 },
+    { DUNGEON_SCENE_INDEX_SNOWHEAD_TEMPLE, 3 },
+    { DUNGEON_SCENE_INDEX_GREAT_BAY_TEMPLE, 1 },
+    { DUNGEON_SCENE_INDEX_STONE_TOWER_TEMPLE, 4 },
+};
 #ifdef COMBO_BUILD
 // ComboShip: set while GiveItem delivers into a dormant MM save (gPlayState==NULL).
 extern bool gComboDormantGive;

--- a/mm/2s2h/Rando/Spoiler/Apply.cpp
+++ b/mm/2s2h/Rando/Spoiler/Apply.cpp
@@ -35,6 +35,21 @@ void ApplyToSaveContext(nlohmann::json spoiler) {
         }
 
         if (!spoiler["checks"].contains(randoStaticCheck.name)) {
+#ifdef COMBO_BUILD
+            // ComboShip: never let a small-key check revert to vanilla delivery — that bumps only
+            // inventory.dungeonKeys and desyncs the rando mirror. Junk it like GeneratePools does an
+            // excluded check (shuffled + skipped), which is also how a player exclusion lands here.
+            auto iit = Rando::StaticData::Items.find(randoStaticCheck.randoItemId); // find, not [] — std::map
+            if (iit != Rando::StaticData::Items.end() && iit->second.randoItemType == RITYPE_SMALL_KEY) {
+                SPDLOG_WARN("[ComboShip] small key check not in the placement payload (excluded or broken), "
+                            "forcing shuffled junk: {}",
+                            randoStaticCheck.name);
+                RANDO_SAVE_CHECKS[randoCheckId].randoItemId = RI_JUNK;
+                RANDO_SAVE_CHECKS[randoCheckId].shuffled = true;
+                RANDO_SAVE_CHECKS[randoCheckId].skipped = true;
+                continue;
+            }
+#endif
             RANDO_SAVE_CHECKS[randoCheckId].randoItemId = randoStaticCheck.randoItemId;
             RANDO_SAVE_CHECKS[randoCheckId].shuffled = false;
             continue;

--- a/mm/2s2h/SaveManager/SaveManager.cpp
+++ b/mm/2s2h/SaveManager/SaveManager.cpp
@@ -218,6 +218,10 @@ void SaveManager_InitNewSaveForSlot(int mmFileNum, const unsigned char* ootName8
     SET_WEEKEVENTREG(WEEKEVENTREG_ENTERED_EAST_CLOCK_TOWN);
     SET_WEEKEVENTREG(WEEKEVENTREG_ENTERED_WEST_CLOCK_TOWN);
     SET_WEEKEVENTREG(WEEKEVENTREG_ENTERED_NORTH_CLOCK_TOWN);
+    // ComboShip: stamp RANDO before the write, not after. Every caller re-stamps it moments later, but
+    // this function PERSISTS, so leaving it VANILLA opened a window where the container briefly held a
+    // vanilla MM save, which silently disables every IS_RANDO hook. Combo has no vanilla mode.
+    gSaveContext.save.shipSaveInfo.saveType = SAVETYPE_RANDO;
 #endif
     nlohmann::json j;
     j["newCycleSave"]["save"] = gSaveContext.save;
@@ -249,8 +253,9 @@ static int SaveManager_LoadFailedForCombo(int code) {
 }
 
 // ComboShip: loading never creates or persists. A missing/broken MM half used to be replaced with a
-// fresh SAVETYPE_VANILLA save, permanently poisoning the slot; now every failure returns a code and the
-// MM-entry seam refuses instead. 0 ok, -1 missing, -2 unreadable, -3 migrate, -4 no newCycleSave, -5 parse.
+// fresh SAVETYPE_VANILLA save, permanently poisoning the slot; now every failure just returns a code,
+// loudly. Nothing repairs the slot — re-create the file. 0 ok, -1 missing, -2 unreadable, -3 migrate,
+// -4 no newCycleSave, -5 parse.
 int SaveManager_LoadSaveFile(int mmFileNum) {
     std::string fileName = SaveManager_GetFileName(mmFileNum);
     nlohmann::json j;

--- a/mm/2s2h/SaveManager/SaveManager.cpp
+++ b/mm/2s2h/SaveManager/SaveManager.cpp
@@ -237,7 +237,21 @@ void SaveManager_SaveCurrentForCombo() {
 
 int SaveManager_ReadSaveFile(const std::filesystem::path& fileName, nlohmann::json& j);
 
-void SaveManager_LoadSaveFile(int mmFileNum) {
+// ComboShip: nothing usable was loaded, so leave gSaveContext pointing at NO slot. 0xFF is the "no save"
+// sentinel every dormant writer tests (Combo_MM_GiveDormantResolved, MM_MarkForeignObtained, MMAnchor's
+// PumpDormant), so a stray write lands nowhere instead of persisting the PREVIOUS slot's save — or
+// zeroed vanilla BSS — into the failed slot. Clearing saveType makes IS_RANDO false for the same reason:
+// the peek trackers must not keep drawing the previous slot's save as if it were this one.
+static int SaveManager_LoadFailedForCombo(int code) {
+    gSaveContext.fileNum = 0xFF;
+    gSaveContext.save.shipSaveInfo.saveType = SAVETYPE_VANILLA;
+    return code;
+}
+
+// ComboShip: loading never creates or persists. A missing/broken MM half used to be replaced with a
+// fresh SAVETYPE_VANILLA save, permanently poisoning the slot; now every failure returns a code and the
+// MM-entry seam refuses instead. 0 ok, -1 missing, -2 unreadable, -3 migrate, -4 no newCycleSave, -5 parse.
+int SaveManager_LoadSaveFile(int mmFileNum) {
     std::string fileName = SaveManager_GetFileName(mmFileNum);
     nlohmann::json j;
     int result = SaveManager_ReadSaveFile(fileName, j);
@@ -250,22 +264,17 @@ void SaveManager_LoadSaveFile(int mmFileNum) {
                 std::filesystem::absolute(savesFolderPath).string());
 #endif
     if (result != 0) {
-        // No MM save yet for this slot (e.g. the OOT->MM new-save callback never fired because the
-        // player loaded an existing OOT save rather than creating one). Create and persist a fresh
-        // MM save now so the transition runs on a valid, saved file instead of an uninitialized one.
-        SPDLOG_WARN("[ComboShip] MM save file {} missing; creating a new one", fileName);
-        SaveManager_InitNewSaveForSlot(mmFileNum);
-        gSaveContext.fileNum = (s16)(mmFileNum - 1);
-        return;
+        SPDLOG_ERROR("[ComboShip] MM save file {} missing or unreadable (read result={})", fileName, result);
+        return SaveManager_LoadFailedForCombo(result); // ReadSaveFile only returns 0/-1/-2
     }
     result = SaveManager_MigrateSave(j);
     if (result != 0) {
         SPDLOG_ERROR("[ComboShip] Failed to migrate MM save file: {}", fileName);
-        return;
+        return SaveManager_LoadFailedForCombo(-3);
     }
     if (!j.contains("newCycleSave")) {
         SPDLOG_ERROR("[ComboShip] MM save file missing newCycleSave: {}", fileName);
-        return;
+        return SaveManager_LoadFailedForCombo(-4);
     }
     try {
         Save save = j["newCycleSave"]["save"];
@@ -275,7 +284,12 @@ void SaveManager_LoadSaveFile(int mmFileNum) {
         gSaveContext.fileNum = (s16)(mmFileNum - 1);
     } catch (nlohmann::json::exception& je) {
         SPDLOG_ERROR("[ComboShip] Failed to parse MM save: {}", je.what());
-    } catch (...) { SPDLOG_ERROR("[ComboShip] Failed to parse MM save"); }
+        return SaveManager_LoadFailedForCombo(-5);
+    } catch (...) {
+        SPDLOG_ERROR("[ComboShip] Failed to parse MM save");
+        return SaveManager_LoadFailedForCombo(-5);
+    }
+    return 0;
 }
 
 void SaveManager_DeleteSaveFile(const std::filesystem::path& fileName) {
@@ -305,7 +319,7 @@ void SaveManager_DeleteSaveFile(const std::filesystem::path& fileName) {
 int SaveManager_ReadSaveFile(const std::filesystem::path& fileName, nlohmann::json& j) {
 #ifdef COMBO_BUILD
     // ComboShip: read the main per-slot section from the .combosav container; "" -> same code as the
-    // file-missing path below (feeds LoadSaveFile's "missing -> init fresh" fallback).
+    // file-missing path below, which makes LoadSaveFile refuse the slot (it never creates one).
     if (gComboReadGameSave) {
         bool isBackup, isGlobal;
         int n = SaveManager_ClassifySaveFile(fileName, isBackup, isGlobal);
@@ -679,6 +693,17 @@ extern "C" void SaveManager_SysFlashrom_WriteData(u8* saveBuffer, u32 pageNum, u
 
             if (IS_VALID_FILE(saveContext.save)) {
                 j["owlSave"] = saveContext;
+#ifdef COMBO_BUILD
+                // ComboShip: if the pre-read failed, this would write an owlSave-only section, which the
+                // load path can only refuse. Seed newCycleSave from the owl snapshot — resumed a little
+                // late beats a dead slot. Guarded: upstream's file select reads owl-only files legitimately.
+                if (!j.contains("newCycleSave")) {
+                    SPDLOG_ERROR("[ComboShip] owl save for {} had no new cycle save to preserve; seeding one from the "
+                                 "owl snapshot",
+                                 fileName);
+                    j["newCycleSave"]["save"] = saveContext.save;
+                }
+#endif
                 j["version"] = CURRENT_SAVE_VERSION;
                 j["type"] = "2S2H_SAVE";
 

--- a/mm/2s2h/SaveManager/SaveManager.h
+++ b/mm/2s2h/SaveManager/SaveManager.h
@@ -19,7 +19,8 @@ void SaveManager_WriteSaveFile(const std::filesystem::path& fileName, nlohmann::
 void SaveManager_PersistSariaHintsAvailable();
 // ComboShip: cross-game save activation/persistence entry points
 void SaveManager_InitNewSaveForSlot(int mmFileNum, const unsigned char* ootName8 = nullptr);
-// 0 = loaded; negative = refuse MM entry (see the definition for the codes).
+// 0 = loaded; negative = nothing usable was loaded (codes at the definition). Never creates or persists:
+// a failure is logged and leaves the fail-closed sentinel behind, and play still proceeds.
 int SaveManager_LoadSaveFile(int mmFileNum);
 void SaveManager_SaveCurrentForCombo();
 #else

--- a/mm/2s2h/SaveManager/SaveManager.h
+++ b/mm/2s2h/SaveManager/SaveManager.h
@@ -19,7 +19,8 @@ void SaveManager_WriteSaveFile(const std::filesystem::path& fileName, nlohmann::
 void SaveManager_PersistSariaHintsAvailable();
 // ComboShip: cross-game save activation/persistence entry points
 void SaveManager_InitNewSaveForSlot(int mmFileNum, const unsigned char* ootName8 = nullptr);
-void SaveManager_LoadSaveFile(int mmFileNum);
+// 0 = loaded; negative = refuse MM entry (see the definition for the codes).
+int SaveManager_LoadSaveFile(int mmFileNum);
 void SaveManager_SaveCurrentForCombo();
 #else
 void SaveManager_SysFlashrom_WriteData(u8* addr, u32 pageNum, u32 pageCount);

--- a/mm/src/code/title_setup.c
+++ b/mm/src/code/title_setup.c
@@ -65,17 +65,9 @@ void Setup_InitImpl(SetupState* this) {
         Combo_AdoptOOTGlobalOptions();
         // Set flashSaveAvailable so Sram_Alloc allocates saveBuf (normally set by the title screen).
         gSaveContext.flashSaveAvailable = true;
-        // Load the MM save that matches the OOT slot (OOT slot N → MM file N+1).
-        // ComboShip: a missing/broken MM half is never recreated here — entering Play on init defaults
-        // would persist a vanilla save over the slot. Refuse and hand control back to OOT instead.
-        s32 loadResult = Combo_LoadMMSaveFile(gComboStartFileNum + 1);
-        if (loadResult != 0) {
-            Combo_AbortMMEntry(loadResult);
-            gComboStartFileNum = -1;
-            STOP_GAMESTATE(&this->state);
-            SET_NEXT_GAMESTATE(&this->state, ConsoleLogo_Init, sizeof(ConsoleLogoState));
-            return;
-        }
+        // Load the MM save that matches the OOT slot (OOT slot N → MM file N+1). ComboShip never blocks
+        // entry: a nonzero result is logged inside and leaves the fail-closed sentinel, and play proceeds.
+        Combo_LoadMMSaveFile(gComboStartFileNum + 1);
         // South Clock Town is the default arrival for both portal entry and a resume. Only a resume
         // with Remember Save Location on returns to the stored spot (set by SavingEnhancements).
         if (gComboEntryIsResume && CVarGetInteger("gEnhancements.Saving.RememberSaveLocation", 0) &&

--- a/mm/src/code/title_setup.c
+++ b/mm/src/code/title_setup.c
@@ -66,7 +66,16 @@ void Setup_InitImpl(SetupState* this) {
         // Set flashSaveAvailable so Sram_Alloc allocates saveBuf (normally set by the title screen).
         gSaveContext.flashSaveAvailable = true;
         // Load the MM save that matches the OOT slot (OOT slot N → MM file N+1).
-        Combo_LoadMMSaveFile(gComboStartFileNum + 1);
+        // ComboShip: a missing/broken MM half is never recreated here — entering Play on init defaults
+        // would persist a vanilla save over the slot. Refuse and hand control back to OOT instead.
+        s32 loadResult = Combo_LoadMMSaveFile(gComboStartFileNum + 1);
+        if (loadResult != 0) {
+            Combo_AbortMMEntry(loadResult);
+            gComboStartFileNum = -1;
+            STOP_GAMESTATE(&this->state);
+            SET_NEXT_GAMESTATE(&this->state, ConsoleLogo_Init, sizeof(ConsoleLogoState));
+            return;
+        }
         // South Clock Town is the default arrival for both portal entry and a resume. Only a resume
         // with Remember Save Location on returns to the stored spot (set by SavingEnhancements).
         if (gComboEntryIsResume && CVarGetInteger("gEnhancements.Saving.RememberSaveLocation", 0) &&

--- a/mm/src/code/z_sram_NES.c
+++ b/mm/src/code/z_sram_NES.c
@@ -1276,7 +1276,8 @@ void Sram_ResetSaveFromMoonCrash(SramContext* sramCtx) {
             sramCtx->saveBuf,
             gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET],
             gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET]);
-        memcpy(&gSaveContext, sramCtx->saveBuf, sizeof(Save));
+        // ComboShip: the backup read fills the save, not the whole SaveContext (matches :1273).
+        memcpy(&gSaveContext.save, sramCtx->saveBuf, sizeof(Save));
     }
     gSaveContext.save.cutsceneIndex = cutsceneIndex;
 

--- a/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope_NES.c
+++ b/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope_NES.c
@@ -3715,8 +3715,15 @@ void KaleidoScope_Update(PlayState* play) {
                             R_PAUSE_BG_PRERENDER_STATE = PAUSE_BG_PRERENDER_UNK4;
                             Object_LoadAll(&play->objectCtx);
                             BgCheck_InitCollisionHeaders(&play->colCtx, play);
+#ifdef COMBO_BUILD
+                            // ComboShip: MM's title path wipes the save (Sram_InitNewSave) and combo can't
+                            // enter its file select — quit to OOT instead. Unreachable in this tree; guarded
+                            // defensively so it can't resurface as a save wipe.
+                            Combo_RequestOwlSaveQuit();
+#else
                             STOP_GAMESTATE(&play->state);
                             SET_NEXT_GAMESTATE(&play->state, TitleSetup_Init, sizeof(TitleSetupState));
+#endif
                             Audio_MuteAllSeqExceptSystemAndOcarina(20);
                             gSaveContext.seqId = NA_BGM_DISABLED;
                             gSaveContext.ambienceId = AMBIENCE_ID_DISABLED;
@@ -3960,8 +3967,14 @@ void KaleidoScope_Update(PlayState* play) {
                         gSaveContext.save.saveInfo.playerData.magicLevel = 0;
                         gSaveContext.save.saveInfo.playerData.magic = 0;
                     } else { // PAUSE_PROMPT_NO
+#ifdef COMBO_BUILD
+                        // ComboShip: same as the owl-save quit — MM's title path wipes the save. Vanilla
+                        // discards unsaved progress here too, so the semantics match.
+                        Combo_RequestOwlSaveQuit();
+#else
                         STOP_GAMESTATE(&play->state);
                         SET_NEXT_GAMESTATE(&play->state, TitleSetup_Init, sizeof(TitleSetupState));
+#endif
                     }
                 }
             }

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1633,8 +1633,6 @@ bool VerifyArchiveVersion(OTRVersion version) {
 extern "C" void (*gComboSceneSwitchCallback)(int fileNum);
 // Launcher poll: returns the next save slot backed up for a release mismatch, or -1 if none.
 extern "C" int (*gComboOutdatedSaveNotice)();
-// Launcher poll: returns the next slot whose MM half was refused (writes its failure code), or -1.
-extern "C" int (*gComboMMEntryFailNotice)(int*);
 
 // ComboShip: InitOTR is split so the launcher can create the shared window (which needs only the
 // bundled soh.o2r, not a ROM) BEFORE the ROM archives exist, run its own unified extraction screen,
@@ -1843,20 +1841,6 @@ static void Combo_FinishInit() {
             SohGui::RegisterPopup("Outdated ComboShip Save",
                                   "The save in slot " + std::to_string(slot + 1) +
                                       " was made by a different ComboShip version and has been backed up.");
-        }
-    });
-
-    // ComboShip: MM refused to load a slot's MM half, so MM entry was cancelled — say so here, since the
-    // player is dropped back into OOT. Never auto-recreated: that is what poisoned the slot before.
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameFrameUpdate>([]() {
-        if (!gComboMMEntryFailNotice)
-            return;
-        int code = 0;
-        for (int slot; (slot = gComboMMEntryFailNotice(&code)) >= 0;) {
-            SohGui::RegisterPopup("Majora's Mask Save Unavailable",
-                                  "Slot " + std::to_string(slot + 1) + "'s MM save is missing or invalid (error " +
-                                      std::to_string(code) +
-                                      ") - MM entry was cancelled for this slot. Re-create the file to fix it.");
         }
     });
 #endif
@@ -2843,12 +2827,6 @@ extern "C" __declspec(dllexport) void SOH_SetOnLoadSaveCallback(void (*cb)(int f
 extern "C" int (*gComboOutdatedSaveNotice)() = nullptr;
 extern "C" __declspec(dllexport) void SOH_SetOutdatedSaveNotice(int (*fn)()) {
     gComboOutdatedSaveNotice = fn;
-}
-
-// ComboShip: same seam for a slot whose MM save MM refused to load — OOT is where the player lands.
-extern "C" int (*gComboMMEntryFailNotice)(int*) = nullptr;
-extern "C" __declspec(dllexport) void SOH_SetMMEntryFailNotice(int (*fn)(int*)) {
-    gComboMMEntryFailNotice = fn;
 }
 
 // ComboShip: Anchor transport seam. The persistent socket lives in ComboShip.exe; these exports

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -1633,6 +1633,8 @@ bool VerifyArchiveVersion(OTRVersion version) {
 extern "C" void (*gComboSceneSwitchCallback)(int fileNum);
 // Launcher poll: returns the next save slot backed up for a release mismatch, or -1 if none.
 extern "C" int (*gComboOutdatedSaveNotice)();
+// Launcher poll: returns the next slot whose MM half was refused (writes its failure code), or -1.
+extern "C" int (*gComboMMEntryFailNotice)(int*);
 
 // ComboShip: InitOTR is split so the launcher can create the shared window (which needs only the
 // bundled soh.o2r, not a ROM) BEFORE the ROM archives exist, run its own unified extraction screen,
@@ -1841,6 +1843,20 @@ static void Combo_FinishInit() {
             SohGui::RegisterPopup("Outdated ComboShip Save",
                                   "The save in slot " + std::to_string(slot + 1) +
                                       " was made by a different ComboShip version and has been backed up.");
+        }
+    });
+
+    // ComboShip: MM refused to load a slot's MM half, so MM entry was cancelled — say so here, since the
+    // player is dropped back into OOT. Never auto-recreated: that is what poisoned the slot before.
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameFrameUpdate>([]() {
+        if (!gComboMMEntryFailNotice)
+            return;
+        int code = 0;
+        for (int slot; (slot = gComboMMEntryFailNotice(&code)) >= 0;) {
+            SohGui::RegisterPopup("Majora's Mask Save Unavailable",
+                                  "Slot " + std::to_string(slot + 1) + "'s MM save is missing or invalid (error " +
+                                      std::to_string(code) +
+                                      ") - MM entry was cancelled for this slot. Re-create the file to fix it.");
         }
     });
 #endif
@@ -2827,6 +2843,12 @@ extern "C" __declspec(dllexport) void SOH_SetOnLoadSaveCallback(void (*cb)(int f
 extern "C" int (*gComboOutdatedSaveNotice)() = nullptr;
 extern "C" __declspec(dllexport) void SOH_SetOutdatedSaveNotice(int (*fn)()) {
     gComboOutdatedSaveNotice = fn;
+}
+
+// ComboShip: same seam for a slot whose MM save MM refused to load — OOT is where the player lands.
+extern "C" int (*gComboMMEntryFailNotice)(int*) = nullptr;
+extern "C" __declspec(dllexport) void SOH_SetMMEntryFailNotice(int (*fn)(int*)) {
+    gComboMMEntryFailNotice = fn;
 }
 
 // ComboShip: Anchor transport seam. The persistent socket lives in ComboShip.exe; these exports


### PR DESCRIPTION
Fixes the reported small-key loss on Song of Time. The SoT wipe of keys/fairies/boss keys is vanilla behaviour; only the rando `AfterEndOfCycleSave` hook restores them, and small keys come back from `rando.foundDungeonKeys`. This closes every remaining way that restore could be missing or restore a stale count.

## Key-mirror integrity (the actual key loss)

- **`OnItemGive` safety net**: a small-key check left `shuffled == false` keeps its vanilla `GI_KEY_SMALL` chest and grants through raw `Item_Give`, which bumps `inventory.dungeonKeys` but not the rando mirror — the next SoT then truncated keys to the stale-low mirror. An `IS_RANDO`-gated per-item hook now raises the mirror to the inventory count (gated on being in a dungeon/boss scene, `mapIndex` 0..3).
- **Loud placement apply**: an absent small-key check in the combo payload is forced to shuffled junk (parity with `GeneratePools`' exclusion handling) instead of silently reverting to a vanilla key chest; unknown check/item names in the payload are counted and reported, and an unknown item substitutes junk rather than dropping the check.
- **Skeleton Key self-heals**: shared sentinel-safe `AddSmallKey` / `skeletonKeyCounts` raise inventory and mirror **independently** to `max(current, N)` — never lowering either, healing a pre-existing desync and the `-1` sentinel. The four per-dungeon key grants use the same helper. The fill oracle gained its missing `RI_SKELETON_KEY` case, which previously left key-gated regions unreachable during skeleton-key fills (this can change placements of *newly generated* skeleton-key seeds — that is the correction, stored seeds re-apply saved placements).

## Save-load integrity (restore hook never registering)

A `SAVETYPE_VANILLA` MM save silently disables every `IS_RANDO` hook, including the restore.

- `SaveManager_LoadSaveFile` no longer creates **and persists** a fresh vanilla save when the container's `mm` section is missing or broken — the path that permanently poisoned a slot, reachable from the dormant peek merely by loading an OOT save whose MM half was absent. It returns a failure code and fails closed (`fileNum = 0xFF`, in-memory saveType cleared) so dormant writers can't persist another slot's save and the trackers show blank instead of the previous slot's data.
- `SaveManager_InitNewSaveForSlot` stamps `SAVETYPE_RANDO` before its write, so the legitimate creation path never leaves a vanilla MM save in the container even transiently.
- Owl-save writes reconstruct a missing `newCycleSave` from the owl snapshot instead of emitting an `owlSave`-only section that could never load again.
- **No refusal and no runtime repair**: MM entry is never blocked. A missing/unloadable `mm` section means the file was created with no seed bound (already refused loudly at creation, writing no section) or the file is damaged — it logs an error, the sentinel keeps stray writes and tracker draws off the slot, and play proceeds. Remedy is re-creating the file.
- **`COMBO_RELEASE_VERSION` 0.2.1 → 0.3.0** so the container major.minor gate retires the legacy population of poisoned sections. ⚠️ **Existing `.combosav` files are invalidated** (renamed to `.bak` with the usual outdated-save popup) — intended, and the reason no runtime migration exists.

## Anchor (co-op)

- `UpdateTeamState` apply: drop peer states without a rando block (a rando-less peer state deserializes a zeroed rando struct and would wipe `RANDO_SAVE_CHECKS`), never adopt the peer's `saveType`, and max/OR-merge `dungeonKeys`, `foundDungeonKeys`, `strayFairies` and `dungeonItems` instead of wholesale replacement — matching OOT's precedent, so a teammate who is behind can no longer regress key counts.
- The post-SoT team-state broadcast is deferred to `OnGameStateUpdate` so it always carries post-restore counts. Note hook execution order is `unordered_map` order, so registration order cannot be relied on — hence deferral rather than reordering. Pending flag cleared on deactivate.

## Hardening

- Pause save-prompt, game-over "Continue → No" and the debug `reset` now route through the combo quit/return seams instead of MM's title screen, which wipes the save to `SAVETYPE_VANILLA` and unregisters every `IS_RANDO` hook. Defensive: the save-prompt state is dead code in this tree, and the game-over path was not observed misbehaving before.
- Moon-crash backup read `memcpy` targets `gSaveContext.save` explicitly.

## Notes

- Vendored delta: `mm/src` +17/−2 across three files (`title_setup.c` is comment-only); **`soh/` unchanged**. Everything else is in `mm/2s2h` port code or `combo/`. Deviations documented in `docs/deviations/{rando,anchor,boot-shutdown}.md`.
- All four targets build clean (Debug).
- **Playtested**: small keys survive Song of Time; Skeleton Key keys survive Song of Time; game-over "No" and console `reset` both return to OOT with MM's save loading fine afterward; the 0.3.0 gate invalidates old containers as intended.
- **Not playtested**: the Anchor changes (built and code-reviewed, two-client verification deferred per project policy until a report comes in).
- Release reminder: the `v0.3.0` tag must be set to match the bump — nothing in `release.yml` enforces it.


<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9502726074.zip)
<!--- section:artifacts:end -->