### PR TITLE
fix(combo): mod order survives a restart

### DIFF
--- a/docs/deviations/ui-menu.md
+++ b/docs/deviations/ui-menu.md
@@ -268,3 +268,72 @@ empty array into null; `GetStartingItemsFromConfig` treats null as empty.)
 **Vendored:** `libultraship/src/ship/config/Config.cpp` (`SetBlock`) — create missing intermediate
 objects and descend; a non-object in the path keeps the old silent no-op (`ComboShip:` comment at
 site).
+
+## Mod ordering never survived a restart (2026-08-24)
+
+**Why:** two independent defects, both combo-only.
+
+(a) Both mod menus stored the user's mod order in the SAME CVar, `gSettings.EnabledMods` — soh via
+`CVAR_SETTING("EnabledMods")`, MM via a hardcoded literal, and `CVAR_PREFIX_SETTING` is `gSettings`
+in both games. In combo MM reuses OOT's Context and skips `InitConsoleVariables()`, so
+ConsoleVariables is shared. `UpdateModFiles(init=true)` erases every listed name it can't find in
+*its own* mods dir and rewrites the key; OOT scans `./mods/soh`, MM scans `./mods/2ship`, so each
+wiped the other's names. OOT boots first and MM writes last, so after every launch the key held only
+MM's mods (or `""`, since `./mods/2ship` is auto-created even when empty) and the order was rebuilt
+path-sorted on the next boot. Same shared key also crashed OOT's Mod Menu: Edit -> Cancel re-reads
+the CVar without pruning (`init == false`), then `DrawMods` hit `filePaths.at()` on an MM name.
+
+(b) MM's `BenModalWindow` registered as `"Modal Window"`, which OOT already owns, so
+`Gui::AddGuiWindow` rejected it and it was never drawn. MM's Mod Menu "Clear List" and "Apply &
+Close" queue into a `BenModals` global vector that only that window drains — both buttons did nothing
+at all, so an MM order could never be saved.
+
+**Vendored (additive, `COMBO_BUILD`-guarded unless noted):**
+- `mm/2s2h/Enhancements/ModMenu/ModMenu.cpp` — MM's key becomes `gSettings.EnabledModsMM`. A SIBLING
+  leaf, never a child: `gSettings.EnabledMods.MM` would put a leaf and a subtree at one path, the
+  failure behind `CVAR_LINK_VOICE_FREQ_MULTIPLIER`. Since `Config::TryUnflatten` now logs instead of
+  throwing, that would silently drop every config write rather than crash.
+- `mm/2s2h/BenGui/BenGui.cpp` — `"Modal Window" COMBO_MM_TRACKER_SUFFIX`. Nothing resolves MM's modal
+  by name (MM uses the `BenGui::mModalWindow` static), and the visibility CVars already differed
+  (`gWindows.ModalWindow` vs OOT's `gOpenWindows.ModalWindow`).
+- `mm/2s2h/BenGui/Menu.cpp` — seed `menuThemeIndex` in the ctor (mirroring
+  `soh/soh/SohGui/Menu.cpp`) **and** clamp it in `GetMenuThemeColor()`. Required: registering the
+  modal makes it draw every frame from the Gui loop, and `THEME_COLOR` resolves to a member that only
+  `UpdateElement()` sets — which under comboui runs only once MM's tab is drawn — so `ColorValues.at()`
+  would throw out of 2ship.dll across the DLL boundary. The ctor seed alone is not enough:
+  `MM_MenuDrawCustom` calls `Update()`, which re-reads the CVar unclamped, so the clamp belongs at the
+  `GetMenuThemeColor()` funnel where every `THEME_COLOR` read passes. Also fixes a live crash for
+  anyone with `gWindows.InputViewerSettings=1` (`InputViewerSettingsWindow::DrawElement` uses
+  `THEME_COLOR`; `InputViewer::DrawElement` does not).
+- `mm/2s2h/BenGui/BenModals.cpp` — `ImGuiPopupFlags_NoOpenOverExistingPopup` plus a `PushID("MM")`
+  scope. Neither modal window calls `Begin()`, so both open at popup level 0 and hash their popup ids
+  against the same window. Both games use the exact titles "Clear List" and "Apply & Close", so
+  without the `PushID` MM would draw its message and buttons into OOT's popup with colliding button
+  ids — one click could run the other game's callback. The flag is the level tie-break: it is
+  one-way (OOT's `OpenPopup` stays unflagged), so OOT wins and MM retries next frame.
+- `soh/soh/Enhancements/mod_menu.cpp` + `mm/.../ModMenu.cpp` — a plain "Apply" that writes the CVar
+  and leaves edit mode without closing. `SetEnabledModsCVarValue` already calls
+  `SaveConsoleVariablesNextFrame()`, so no explicit `Save()`; "Apply & Close" needs its own only
+  because it closes before the next frame. Upstream's "Apply & Close" is unchanged, and in combo it
+  takes both games down.
+- Both mod menus, **not** guarded — a `filePaths.find()` skip at the top of `DrawMods`' loop. A
+  genuine upstream bug (a file deleted mid-session throws out of the inline-menu draw path, and
+  neither `SOH_MenuDrawCustom` nor `MM_MenuDrawCustom` has a try/catch); correct in standalone too,
+  and an `#ifdef` around one `continue` would be worse than the line. The doc entry is the only
+  record, since the line carries no `ComboShip:` marker — re-check it after upstream merges.
+
+**Residuals, accepted:** OOT's Presets "Settings" block bulk-clears the whole `gSettings` subtree, so
+an OOT settings-preset apply clears both mod lists — benign, they rebuild from disk. The
+`GetMenuThemeColor()` clamp covers every `THEME_COLOR` read, but a dozen MM sites read
+`gSettings.Menu.Theme` directly with `CVarGetInteger` and stay unclamped; soh's `Menu` is unclamped
+throughout, unchanged here because OOT's modal was always registered. If a game's mods dir doesn't
+exist, `UpdateModFiles` skips its whole body and leaves the list unpruned and unwritten. When a mod
+file vanishes mid-session the skipped row leaves the up/down arrows working on raw vector indices, so
+a swap with a skipped neighbour changes the list without changing what is drawn (and a shift-range
+selection can pick up the invisible name) — cosmetic, in an already-degraded state.
+
+**On future merges:** the theme seeding relies on soh's and MM's `UIWidgets::Colors` enums and
+`ColorValues` maps being identical (`soh/soh/SohGui/UIWidgetOptions.hpp` vs
+`mm/2s2h/BenGui/UIWidgets.hpp`) because `gSettings.Menu.Theme` is shared. If a merge diverges them,
+the shared key becomes unsafe. Also re-check the `Modal Window` suffix and the "Apply" button if
+upstream reworks the mod menu.

--- a/mm/2s2h/BenGui/BenGui.cpp
+++ b/mm/2s2h/BenGui/BenGui.cpp
@@ -40,8 +40,8 @@
 // ComboShip: in the combo build, OOT (soh) registers identically-named tracker windows FIRST into
 // the single shared libultraship Gui. Gui::AddGuiWindow keys by display name and rejects duplicates,
 // so any MM window whose name matches an OOT one (trackers, plus dev tools like "Save Editor",
-// "Actor Viewer", "Audio Editor", "Mod Menu", "Input Viewer"...) would be silently dropped and never
-// drawn — that is why MM's "Save Editor" used to show OOT's. Suffix MM's window keys with "##MM":
+// "Actor Viewer", "Audio Editor", "Mod Menu", "Input Viewer", "Modal Window") would be silently
+// dropped and never drawn — that is why MM's "Save Editor" used to show OOT's. Suffix the keys "##MM":
 // ImGui shows only the text before "##", so the visible title stays "Save Editor", but the map key
 // (and ImGui window ID) is unique and both games coexist. The popout WindowName() references in
 // BenMenu.cpp / 2s2h/Rando/Menu.cpp use the same suffix. The active-game gating in
@@ -107,7 +107,9 @@ void SetupMenu() {
     style.ItemSpacing = ImVec2(8.0f, 6.0f);
     style.Colors[ImGuiCol_MenuBarBg] = UIWidgets::ColorValues.at(UIWidgets::Colors::DarkGray);
 
-    mModalWindow = std::make_shared<BenModalWindow>("gWindows.ModalWindow", "Modal Window");
+    // ComboShip: OOT registers "Modal Window" first, so an unsuffixed MM one is rejected and never
+    // drawn — every BenGui::RegisterPopup would queue a popup nothing can show or dismiss.
+    mModalWindow = std::make_shared<BenModalWindow>("gWindows.ModalWindow", "Modal Window" COMBO_MM_TRACKER_SUFFIX);
     gui->AddGuiWindow(mModalWindow);
     mModalWindow->Show();
 }

--- a/mm/2s2h/BenGui/BenModals.cpp
+++ b/mm/2s2h/BenGui/BenModals.cpp
@@ -29,8 +29,19 @@ void BenModalWindow::Draw() {
 void BenModalWindow::DrawElement() {
     if (modals.size() > 0) {
         BenModal curModal = modals.at(0);
+#ifdef COMBO_BUILD
+        // ComboShip: neither modal window calls Begin(), so both hash popup ids against the same
+        // window — OOT uses these exact titles too, and MM would draw into OOT's popup.
+        ImGui::PushID("MM");
+#endif
         if (!ImGui::IsPopupOpen(curModal.title_.c_str())) {
+#ifdef COMBO_BUILD
+            // ComboShip: OOT's modal shares this popup level and re-opens every frame; without this
+            // it would evict ours mid-frame. One-way tie-break: OOT wins, we retry next frame.
+            ImGui::OpenPopup(curModal.title_.c_str(), ImGuiPopupFlags_NoOpenOverExistingPopup);
+#else
             ImGui::OpenPopup(curModal.title_.c_str());
+#endif
         }
         if (closePopup) {
             ImGui::CloseCurrentPopup();
@@ -66,6 +77,9 @@ void BenModalWindow::DrawElement() {
             }
             ImGui::EndPopup();
         }
+#ifdef COMBO_BUILD
+        ImGui::PopID();
+#endif
     }
 }
 

--- a/mm/2s2h/BenGui/Menu.cpp
+++ b/mm/2s2h/BenGui/Menu.cpp
@@ -119,12 +119,23 @@ bool Menu::IsMenuPopped() {
 }
 
 UIWidgets::Colors Menu::GetMenuThemeColor() {
+#ifdef COMBO_BUILD
+    // ComboShip: every THEME_COLOR read funnels through here, and UpdateElement() re-reads the CVar
+    // unclamped — an out-of-range value would throw from ColorValues.at() across the DLL boundary.
+    return UIWidgets::ColorValues.contains(menuThemeIndex) ? menuThemeIndex : defaultThemeIndex;
+#else
     return menuThemeIndex;
+#endif
 }
 
 Menu::Menu(const std::string& cVar, const std::string& name, uint8_t searchSidebarIndex_,
            UIWidgets::Colors defaultThemeIndex_)
     : GuiWindow(cVar, name), searchSidebarIndex(searchSidebarIndex_), defaultThemeIndex(defaultThemeIndex_) {
+#ifdef COMBO_BUILD
+    // ComboShip: comboui owns the Gui menu slot, so UpdateElement() only runs once MM's tab is drawn.
+    // Seed the theme now so the always-drawn modal window starts in the user's colour, not garbage.
+    menuThemeIndex = static_cast<UIWidgets::Colors>(CVarGetInteger("gSettings.Menu.Theme", defaultThemeIndex_));
+#endif
 }
 
 void Menu::InitElement() {

--- a/mm/2s2h/Enhancements/ModMenu/ModMenu.cpp
+++ b/mm/2s2h/Enhancements/ModMenu/ModMenu.cpp
@@ -25,7 +25,13 @@ extern std::shared_ptr<BenMenu> mBenMenu;
 static WidgetInfo enableModsWidget;
 static WidgetInfo tabHotkeyWidget;
 
+// ComboShip: OOT owns gSettings.EnabledMods and prunes every name missing from ./mods/soh, so one
+// shared key means each game wipes the other's list every boot. Sibling leaf, never a child.
+#ifdef COMBO_BUILD
+#define CVAR_ENABLED_MODS_NAME "gSettings.EnabledModsMM"
+#else
 #define CVAR_ENABLED_MODS_NAME "gSettings.EnabledMods"
+#endif
 #define CVAR_ENABLED_MODS_DEFAULT ""
 #define CVAR_ENABLED_MODS_VALUE CVarGetString(CVAR_ENABLED_MODS_NAME, CVAR_ENABLED_MODS_DEFAULT)
 
@@ -220,6 +226,11 @@ void DrawMods(bool enabled) {
 
     for (size_t i = selectedModFiles.size() - 1; i != SIZE_MAX; i--) {
         std::string file = selectedModFiles[i];
+        // A file deleted mid-session stays listed but unmapped; skip it, at() would throw.
+        auto pathIt = filePaths.find(file);
+        if (pathIt == filePaths.end()) {
+            continue;
+        }
         if (enabled) {
             ImGui::BeginGroup();
         }
@@ -264,7 +275,7 @@ void DrawMods(bool enabled) {
             }
         }
 
-        DrawModInfo(filePaths.at(file).filename().generic_string());
+        DrawModInfo(pathIt->second.filename().generic_string());
         if (enabled) {
             ImGui::EndGroup();
             ModsHandleDragAndDrop(selectedModFiles, i, file);
@@ -324,6 +335,17 @@ void ModMenuWindow::DrawElement() {
                                       AfterModChange();
                                   });
         }
+#ifdef COMBO_BUILD
+        // ComboShip: save the order without closing — "Apply & Close" takes both games down with it.
+        ImGui::SameLine();
+        if (UIWidgets::Button("Apply", UIWidgets::ButtonOptions()
+                                           .Size(UIWidgets::Sizes::Inline)
+                                           .Color(THEME_COLOR)
+                                           .Tooltip("Saves the mod order now; takes effect on next launch."))) {
+            SetEnabledModsCVarValue();
+            editing = false;
+        }
+#endif
         ImGui::SameLine();
         if (UIWidgets::Button("Apply & Close",
                               UIWidgets::ButtonOptions().Size(UIWidgets::Sizes::Inline).Color(THEME_COLOR))) {

--- a/soh/soh/Enhancements/mod_menu.cpp
+++ b/soh/soh/Enhancements/mod_menu.cpp
@@ -337,6 +337,11 @@ void DrawMods(bool enabled) {
 
     for (size_t i = selectedModFiles.size() - 1; i != SIZE_MAX; i--) {
         std::string file = selectedModFiles[i];
+        // A file deleted mid-session stays listed but unmapped; skip it, at() would throw.
+        auto pathIt = filePaths.find(file);
+        if (pathIt == filePaths.end()) {
+            continue;
+        }
         if (enabled) {
             ImGui::BeginGroup();
         }
@@ -382,7 +387,7 @@ void DrawMods(bool enabled) {
         }
 
         ImGui::SameLine();
-        std::string displayName = filePaths.at(file).filename().generic_string();
+        std::string displayName = pathIt->second.filename().generic_string();
         if (enabled) {
             ImGui::PushID(file.c_str());
             float selectableWidth =
@@ -468,6 +473,18 @@ void ModMenuWindow::DrawElement() {
                                       AfterModChange();
                                   });
         }
+#ifdef COMBO_BUILD
+        // ComboShip: save the order without closing — "Apply & Close" takes both games down with it.
+        ImGui::SameLine();
+        if (UIWidgets::Button("Apply", UIWidgets::ButtonOptions()
+                                           .Size(UIWidgets::Sizes::Inline)
+                                           .Color(THEME_COLOR)
+                                           .Tooltip("Saves the mod order now; takes effect on next launch."))) {
+            SetEnabledModsCVarValue();
+            ClearSelectedMods();
+            editing = false;
+        }
+#endif
         ImGui::SameLine();
         if (UIWidgets::Button("Apply & Close",
                               UIWidgets::ButtonOptions().Size(UIWidgets::Sizes::Inline).Color(THEME_COLOR))) {


### PR DESCRIPTION
Reported as "mod ordering doesn't work". Two combo-only causes.

**Both mod menus shared one CVar.** OOT and MM both stored the order in `gSettings.EnabledMods`, and in combo the config is shared (MM reuses OOT's Context and skips `InitConsoleVariables`). Each boot, `UpdateModFiles` erases every name missing from *its own* mods dir and rewrites the key — OOT scans `./mods/soh`, MM scans `./mods/2ship`, so each wiped the other's list. MM boots last, so after every launch the key held only MM's mods (or nothing, since `./mods/2ship` is auto-created even when empty) and the order was rebuilt alphabetically. MM now uses `gSettings.EnabledModsMM`.

**MM's modal window was never registered.** It registered as `"Modal Window"`, which OOT already owns, and `Gui::AddGuiWindow` drops duplicate display names. MM's Mod Menu "Clear List" and "Apply & Close" queue into a vector only that window drains, so both buttons did nothing at all — an MM order could never be saved. Now `"Modal Window##MM"`.

Three things fall out of registering it, all handled:
- It draws every frame, which made a latent `THEME_COLOR` crash live — `menuThemeIndex` is only set by `UpdateElement()`, which under comboui runs just once MM's tab is drawn. Seeded in the ctor and clamped in `GetMenuThemeColor()`, the funnel every read passes through (the ctor alone isn't enough: `MM_MenuDrawCustom` calls `Update()`, which re-reads the CVar unclamped).
- Neither modal calls `Begin()`, so both hash popup ids against the same window — and both games use the titles "Clear List" and "Apply & Close". Without a `PushID`, MM would draw into OOT's popup with colliding button ids, where one click could fire the other game's callback.
- Both also open at popup level 0 and re-open every frame, so they evicted each other and neither became clickable. `ImGuiPopupFlags_NoOpenOverExistingPopup` makes it a one-way tie-break: OOT wins, MM retries next frame.

Also here:
- A combo-only **Apply** button that saves the order without closing. "Apply & Close" is unchanged, but in combo it takes both games down.
- `DrawMods` skips rows whose file vanished instead of `filePaths.at()` throwing out of the inline-menu draw path — neither `SOH_MenuDrawCustom` nor `MM_MenuDrawCustom` has a try/catch, so it unwound across the C ABI. The shared key made this reachable just by opening OOT's Mod Menu and pressing Cancel.

Deviations documented in `docs/deviations/ui-menu.md`, including a merge tripwire: the theme clamp relies on both games' `UIWidgets::Colors` enums staying identical, because `gSettings.Menu.Theme` is shared.

MM's drag-and-drop is deliberately untouched — it is correct, it just lacks OOT's multi-select and insertion lines.

## Testing help wanted

Built clean (Debug, both DLLs) and reviewed, but **not playtested — I have no mods to test with.** If you have mods installed, the useful reports are:

1. Reorder mods in the OOT tab, hit **Apply**, restart twice. Does the order stick? (Before this, it reverted to alphabetical.)
2. Same in the MM tab.
3. In the MM tab, does **Apply & Close** now show a confirmation dialog at all? Is it the right colour?
4. Anything in the log mentioning `duplicate window name`, `out_of_range`, or `unflatten`.


<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9513938388.zip)
<!--- section:artifacts:end -->