### PR TITLE
fix(combo): notes box uses the default frame color (#186)

### DIFF
--- a/combo/gui/ComboNotesWindow.cpp
+++ b/combo/gui/ComboNotesWindow.cpp
@@ -1,6 +1,5 @@
 // combo/gui/ComboNotesWindow.cpp — see ComboNotesWindow.h
 #include "ComboNotesWindow.h"
-#include "ComboWidgetStyle.h"   // themed input styling (comboui cannot call the games' UIWidgets)
 #include "ComboTrackerCommon.h" // ComboTracker::OotActiveSlot + SetTracker
 #include <imgui.h>
 #include <misc/cpp/imgui_stdlib.h>     // InputTextMultiline over a std::string (vendored with ImGui)
@@ -69,10 +68,9 @@ void ComboNotesWindow::Draw() {
 }
 
 void ComboNotesWindow::DrawElement() {
-    ComboRando::ComboMenu_PushInput(ComboRando::ComboMenu_ThemeColor());
+    // No style push: upstream soh DrawNotes leaves the notes box at ImGui's default frame colors (#186).
     bool edited = ImGui::InputTextMultiline("##ComboNotes", &sBuf, ImVec2(-FLT_MIN, ImGui::GetContentRegionAvail().y),
                                             ImGuiInputTextFlags_AllowTabInput);
-    ComboRando::ComboMenu_PopInput();
 
     if (edited) {
         sDirty = true;


### PR DESCRIPTION
Closes #186.

The Personal Notes box was wrapped in `ComboMenu_PushInput(ComboMenu_ThemeColor())`, the themed stepper-input style. That paints `ImGuiCol_FrameBg` with the menu theme at full alpha — bright blue on the default LightBlue theme — plus a 5px black border and `(10,6)` padding.

`ComboMenu_PushInput` itself is a faithful mirror of `UIWidgets::PushStyleInput`; the mistake was using it where upstream doesn't. Shipwright's `DrawNotes` (`randomizer_item_tracker.cpp:1406`) pushes no style colors or vars, so the box falls through to ImGui's default dark `FrameBg`.

Dropped the push/pop pair and the now-unused include. Upstream reserves `PushStyleInput` for single-line fields (seed entry, console, debug viewers), which is what our other call sites already do — those are unchanged.

Playtested on Debug.


<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9583217291.zip)
<!--- section:artifacts:end -->