### PR TITLE
fix(mm): flash-save tables indexed with a raw or sentinel fileNum (#184)

### DIFF
--- a/combo/ComboShip.cpp
+++ b/combo/ComboShip.cpp
@@ -507,6 +507,9 @@ static void Combo_CopyContainer(int from, int to) {
 // Launcher-provided save IO, pushed into each DLL. game: 0=OOT,1=MM (GameId); fileNum 0-based.
 // Returns the section JSON in a thread_local buffer (OOT may read off the main thread), "" if absent.
 static const char* Combo_ReadGameSave(int game, int fileNum) {
+    // No container exists for a sentinel fileNum - see ComboIsValidSlot.
+    if (!ComboIsValidSlot(fileNum))
+        return "";
     thread_local std::string buf;
     std::lock_guard<std::mutex> lk(g_containerMutex);
     auto& c = LoadOrCreateContainer(fileNum);
@@ -521,6 +524,17 @@ static const char* Combo_ReadGameSave(int game, int fileNum) {
 static void Combo_WriteGameSave(int game, int fileNum, const char* json) {
     if (!json)
         return;
+    // Same guard as the read: a sentinel fileNum must never create a phantom container. Say so once —
+    // the session this fires in drops every save, and the load failure may be hours back in the log.
+    if (!ComboIsValidSlot(fileNum)) {
+        static bool warned = false;
+        if (!warned) {
+            warned = true;
+            std::cerr << "[ComboShip] dropping save write for game " << game << ": no slot loaded (fileNum " << fileNum
+                      << ")" << std::endl;
+        }
+        return;
+    }
     std::lock_guard<std::mutex> lk(g_containerMutex);
     auto& c = LoadOrCreateContainer(fileNum);
     const char* key = (game == ComboRando::GAME_OOT) ? "oot" : "mm";

--- a/docs/deviations/boot-shutdown.md
+++ b/docs/deviations/boot-shutdown.md
@@ -511,3 +511,85 @@ the return hook drives the handoff — so none of these sites may `STOP_GAMESTAT
 Nor is it repaired: an unusable MM half is logged loudly, the fail-closed load sentinel keeps stray writes
 and tracker draws off the slot, and play proceeds — re-creating the file is the remedy, and the legacy
 population is retired by the 0.3.0 container gate. See `rando.md` for the load-side failure codes.
+
+## Flash-save tables indexed with a raw or sentinel `fileNum` (issue #184, 2026-08-26)
+
+**Why:** MM addresses save storage through the `gFlashSave*` / `gFlashOwlSave*` lookup tables in
+`z_sram_NES.c`, whose correct index is `fileNum * FLASH_SAVE_MAIN_MULTIPLIER` (+
+`FLASH_SAVE_BACKUP_OFFSET` for the backup row) — each slot owns two consecutive rows. Two kaleido
+sites dropped the multiplier, so the index still resolved to a *valid but wrong* row: slot 2 wrote
+`file1backup.json` (which `SaveManager_WriteSaveFile` drops under `COMBO_BUILD`, so the save vanished)
+and slot 3 wrote `file2.json`, i.e. slot 2's `mm` section. Upstream's backup write is real, so only a
+ComboShip build loses the write. Separately, four sites indexed with `gSaveContext.fileNum` without
+testing the `0xFF` "no slot" sentinel, reading 255 or 510 entries past 14- and 6-entry arrays. That
+usually just fails the `SaveManager_GetFlashSaveFromPages` reverse lookup and drops the write, but if
+the garbage happens to alias a real (startPage, numPages) pair it resolves a valid `FlashSave` and
+overwrites another slot's `mm` section — deterministic per build, so it can flip on any unrelated
+`.data` change.
+
+ComboShip reaches `0xFF` deliberately: `SaveManager_LoadFailedForCombo` sets it whenever a
+container's `mm` half fails to load, because a failed half is never refused and never repaired — play
+proceeds (see the entry above). `gSaveContext.flashSaveAvailable` is true in that session, so the
+existing `!flashSaveAvailable` guards do not cover it; the `fileNum` test is the only thing that can.
+Playing the Song of Time was enough to hit it: `Sram_SaveEndOfCycle` fires `BeforeEndOfCycleSave` →
+`DeleteOwlSave` → `func_80147314(0xFF)` → two synchronous writes off `gFlashOwlSaveStartPages[510]` on
+a six-entry array. Upstream 2S2H is exposed too (map select and BootToWarpPoint both play with
+`fileNum == 0xFF`), which is why the sibling guards are already commented "Don't let them save if they
+are in debug save" — so these are correctness fixes, not deviations, and none is fenced.
+
+**`mm/src/code/z_sram_NES.c` (unguarded, `// ComboShip:`):** a `fileNum != 0xFF` test around the
+storage access only — never the function entry — in `Sram_SaveSpecialEnterClockTown`,
+`Sram_SaveSpecialNewDay`, `Sram_ResetSaveFromMoonCrash`, and `func_80147314` (which tests its
+`fileNum` argument, so one guard covers both callers). The in-memory transitions these functions
+perform first all still run: the `isFirstCycle`/`isOwlSave` sets, `Sram_SaveEndOfCycle`, the `newf`
+zero-and-restore dance, and the cycle-flag and timer resets. All four use synchronous writes and never
+touch `sramCtx->status`, so skipping leaves only a stale `curPage`/`numPages` that nothing reads while
+`status` is 0 — no save state machine can observe the skip. `Sram_ResetSaveFromMoonCrash` is a
+read/restore rather than a write, so its post-guard invariant is stated explicitly: the live save is
+left exactly as it was and no restore is attempted, since there is nothing to restore from. That
+replaces the old behaviour, where both reads failed and the function still copied the zeroed buffer
+over `gSaveContext.save` — blanking the player's items, hearts and masks in RAM.
+
+**`mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope_NES.c` (unguarded,
+`// ComboShip:`):** the missing multiplier on the pause-menu save (Pause Menu Save off) and on the
+game-over "Save" prompt, plus a `fileNum == 255` term added to the game-over prompt's existing
+`!flashSaveAvailable` condition — its pause-save sibling already had that test, this one did not.
+Extending that condition rather than nesting a new `if` routes the skip to `PAUSE_STATE_GAMEOVER_8` —
+the exact state the pre-existing `!flashSaveAvailable` skip already used, so the guard introduces no
+new state. `GAMEOVER_7` would be wrong: it polls `sramCtx->status`, which a skipped write leaves at 0.
+Note that `GAMEOVER_8` does draw the "Saved!" banner (`gPauseSaveConfirmationENGTex`, and
+`GAMEOVER_7` is drawn nowhere), so a no-slot game over claims a save it never made — an upstream quirk
+inherited here, shared with the `!flashSaveAvailable` path and `PAUSE_SAVEPROMPT_STATE_5`, not
+something this guard introduces. Both
+branches are unreachable in this tree — the pause save prompt is only entered behind
+`VB_SAVE_ON_B_BUTTON_IN_PAUSE_MENU`, whose sole hook requires the very CVar the buggy branch tests as
+off, and the game-over prompt needs `GAMEOVER_INACTIVE`, which `z_game_over.c` clears on the frame it
+starts the sequence. Fixed anyway so they cannot resurface as a cross-slot write. Both calls re-wrap
+under clang-format; the formatter was run, nothing was hand-wrapped.
+
+**`combo/ComboShip.cpp` (combo-owned, no fence):** `Combo_ReadGameSave` and `Combo_WriteGameSave` now
+early-out on `!ComboIsValidSlot(fileNum)` like every other container callback. They were the only two
+that skipped it, despite `ComboIsValidSlot`'s own comment saying callbacks reached from a game's
+`gSaveContext.fileNum` must never create a phantom container. With `fileNum == 0xFF`,
+`SaveManager_SaveCurrentForCombo` targeted `file256.json` → slot 255 → a real
+`Save/file256.combosav` on disk; two MM callers reached it unguarded (`BenPort.cpp`'s portal-return
+persist and `CheckQueue.cpp`'s per-check save), while every other caller already tested the sentinel.
+Guarding the boundary closes all of them, present and future, so neither MM caller needed touching.
+
+**Declined residuals.** `Sram_OpenSave`'s `0xFF` branch never assigns `phi_t1`, which then feeds a
+`memcpy` length twice — real, but dead code: its only caller assigns 0-2 one line earlier and combo
+never enters MM file select, and any fix would have to invent the intended index. `func_80147414`
+only ever receives file-select indices, never `gSaveContext.fileNum`. The backup write in
+`func_80147314` uses `gFlashOwlSaveNumPages[...MAIN_MULTIPLIER]` without `+ FLASH_SAVE_BACKUP_OFFSET`
+(upstream's own `//!` note flags it) — a no-op, since both entries are `0x80`, and an upstream
+decomp-accuracy question. The guards test `0xFF` equality rather than a `FILE_NUM_MAX` range, matching
+the six pre-existing sibling guards in `z_message.c`, `MoonCrashSave.cpp` and the pause-save prompt:
+`0xFE` only exists inside a three-statement window in `WarpPoint.cpp` and `0xFEDC` is commented out in
+`z_title.c`, so neither is observable by a save path, and the one place that does want a range check is
+the launcher boundary, where `ComboIsValidSlot` already is one. No assert was added: the obvious
+candidate — checking in `Sram_StartWriteToFlashDefault` that `curPage` matches `gSaveContext.fileNum` —
+would false-fire, because file-select copy/erase/nameset legitimately call it for `copyDestFileIndex`,
+`selectedFileIndex` and the SRAM header. The dead kaleido branches were left in place rather than
+removed, matching the quit-to-title seams above. Also noticed but not touched: the comment at
+`BenPort.cpp`'s `Combo_LoadMMSaveFile` claims the caller rebuilds on a negative code — `title_setup.c`
+discards the return and rebuilds nothing. Not sent upstream.

--- a/docs/deviations/boot-shutdown.md
+++ b/docs/deviations/boot-shutdown.md
@@ -512,7 +512,62 @@ Nor is it repaired: an unusable MM half is logged loudly, the fail-closed load s
 and tracker draws off the slot, and play proceeds — re-creating the file is the remedy, and the legacy
 population is retired by the 0.3.0 container gate. See `rando.md` for the load-side failure codes.
 
-<<<<<<< HEAD
+## MM owl saves on combo resume (issue #182, 2026-08-24)
+
+**Why:** ComboShip enters MM without a file select — `Setup_InitImpl`'s `COMBO_BUILD` block
+(`mm/src/code/title_setup.c`) hand-rolls a subset of `Sram_OpenSave` and loads through
+`SaveManager_LoadSaveFile`, which read only the `newCycleSave` key. Owl saves (owl statue, Pause Save,
+Autosave) are still written correctly into the sibling `owlSave` key, so both coexist and the resume
+always took the stale one — discarding everything since the last cycle save. Vanilla is fine:
+`Sram_OpenSave` picks the owl page when `fileSelect->isOwlSave[...]` is set, then consumes it.
+
+**The invariant:** *if `owlSave` exists, it is at least as new as `newCycleSave`.* Vanilla holds it
+with `VB_DELETE_OWL_SAVE` on continue plus the `DeleteOwlSave()` hooks on `BeforeEndOfCycleSave` /
+`BeforeMoonCrash`. Combo breaks it because `SaveManager_SaveCurrentForCombo` writes `newCycleSave` from
+11 call sites — four of them while MM is **dormant** and the player is in OOT (cross-item grants,
+Anchor, dormant Triforce credits).
+
+**Fix:** `gComboOwlBlobSlot` (`SaveManager.cpp`, declared in `BenPort.h`'s C-only region) records the
+slot whose owl blob `gSaveContext` descends from.
+
+- `SaveManager_LoadSaveFile` prefers `owlSave` when the key is present — a whole `SaveContext`, so it
+  restores the cycle extras (`eventInf`, bottle timers, `pictoPhotoI5`) that `newCycleSave` lacks.
+  Presence of the key is the discriminator; `save.isOwlSave` is **not** reliable, every owl writer
+  restores it in RAM afterwards. Stays a pure read — the dormant tracker peek shares this function.
+  Its owl branches return the load-failure codes like every other page: a slot with neither key, or an
+  unparseable `owlSave` and no `newCycleSave`, is `-4` (fail-closed sentinel; entry still proceeds).
+- `SaveManager_SaveCurrentForCombo` read-modify-writes: it **refreshes** the blob when the flag matches,
+  otherwise **erases** it. Never leaves it untouched — blanket preservation would let a dormant grant
+  write a newer `newCycleSave` behind a stale blob, and the granted item would vanish. The refresh
+  rewrites the **whole** `SaveContext`, the same shape the owl writer emits: refreshing only `["save"]`
+  would leave the blob's `eventInf` and bottle timers frozen while `save` moved on, a mix no vanilla
+  writer can produce (a bottle timer would then resume against a start time from an earlier process).
+- The new-cycle branch of `SaveManager_SysFlashrom_WriteData` preserves `owlSave`, so it gets the same
+  erase-unless-it-is-ours treatment. Reached by the game-over save prompt and by a pause save with
+  Pause Menu Save off — Song of Time and moon crash are already safe via `DeleteOwlSave`.
+- `MM_InvalidateOwlBlobSlot` clears the flag when the launcher replaces a slot's `mm` section behind
+  MM's back (`EraseComboContainer`, `Combo_CopyContainer`) — it cannot reach a DLL global otherwise.
+- A portal entry arrives in South Clock Town, which runs neither owl-arrival path, so `title_setup.c`
+  clears `save.isOwlSave` there. Left set it would persist into `newCycleSave` and keep owl-save write
+  timing armed for the whole session (a 2s stall and an `eventInf` wipe on every cycle reset).
+- `Combo_ApplyOwlSaveOpen` (`z_sram_NES.c`, next to `Sram_OpenSave` because `sOwlWarpEntrances` is
+  static there) mirrors the owl branch: pause entrance beats owl warp id, the `owlWarpId > OWL_WARP_MAX`
+  quirk is kept verbatim, post-temple swamp/mountain rewrites, scarecrow song.
+- `Combo_MMDropOwlSaveBlob` consumes the blob on continue. `func_80147314` can't be used — it needs
+  `sramCtx->saveBuf` and `gPlayState`, neither of which exists at `Setup_InitImpl`.
+
+**Entry kinds:** an owl blob wins on both, but only a resume follows it to where it was saved; a portal
+entry still arrives at South Clock Town.
+
+**Not a gap:** the combo block never zeroes `eventInf` or resets the timers the way `Sram_OpenSave`'s
+non-owl branch does — it doesn't need to. `Setup_InitImpl` calls `SaveContext_Init()`, which `memset`s
+all of `gSaveContext` on every MM entry. Vanilla only needs those resets because its file select
+re-uses a dirty `gSaveContext`.
+
+**Known hole, left alone:** with Autosave on and Pause Menu Save off, a pause save takes
+`Sram_SetFlashPagesDefault` into the new-cycle branch, which preserves `owlSave` — so a stale autosave
+blob shadows it until the next combo write. Vanilla 2S2H has the identical bug through its file select.
+
 ## Flash-save tables indexed with a raw or sentinel `fileNum` (issue #184, 2026-08-26)
 
 **Why:** MM addresses save storage through the `gFlashSave*` / `gFlashOwlSave*` lookup tables in
@@ -594,61 +649,3 @@ would false-fire, because file-select copy/erase/nameset legitimately call it fo
 removed, matching the quit-to-title seams above. Also noticed but not touched: the comment at
 `BenPort.cpp`'s `Combo_LoadMMSaveFile` claims the caller rebuilds on a negative code — `title_setup.c`
 discards the return and rebuilds nothing. Not sent upstream.
-=======
-## MM owl saves on combo resume (issue #182, 2026-08-24)
-
-**Why:** ComboShip enters MM without a file select — `Setup_InitImpl`'s `COMBO_BUILD` block
-(`mm/src/code/title_setup.c`) hand-rolls a subset of `Sram_OpenSave` and loads through
-`SaveManager_LoadSaveFile`, which read only the `newCycleSave` key. Owl saves (owl statue, Pause Save,
-Autosave) are still written correctly into the sibling `owlSave` key, so both coexist and the resume
-always took the stale one — discarding everything since the last cycle save. Vanilla is fine:
-`Sram_OpenSave` picks the owl page when `fileSelect->isOwlSave[...]` is set, then consumes it.
-
-**The invariant:** *if `owlSave` exists, it is at least as new as `newCycleSave`.* Vanilla holds it
-with `VB_DELETE_OWL_SAVE` on continue plus the `DeleteOwlSave()` hooks on `BeforeEndOfCycleSave` /
-`BeforeMoonCrash`. Combo breaks it because `SaveManager_SaveCurrentForCombo` writes `newCycleSave` from
-11 call sites — four of them while MM is **dormant** and the player is in OOT (cross-item grants,
-Anchor, dormant Triforce credits).
-
-**Fix:** `gComboOwlBlobSlot` (`SaveManager.cpp`, declared in `BenPort.h`'s C-only region) records the
-slot whose owl blob `gSaveContext` descends from.
-
-- `SaveManager_LoadSaveFile` prefers `owlSave` when the key is present — a whole `SaveContext`, so it
-  restores the cycle extras (`eventInf`, bottle timers, `pictoPhotoI5`) that `newCycleSave` lacks.
-  Presence of the key is the discriminator; `save.isOwlSave` is **not** reliable, every owl writer
-  restores it in RAM afterwards. Stays a pure read — the dormant tracker peek shares this function.
-  Its owl branches return the load-failure codes like every other page: a slot with neither key, or an
-  unparseable `owlSave` and no `newCycleSave`, is `-4` (fail-closed sentinel; entry still proceeds).
-- `SaveManager_SaveCurrentForCombo` read-modify-writes: it **refreshes** the blob when the flag matches,
-  otherwise **erases** it. Never leaves it untouched — blanket preservation would let a dormant grant
-  write a newer `newCycleSave` behind a stale blob, and the granted item would vanish. The refresh
-  rewrites the **whole** `SaveContext`, the same shape the owl writer emits: refreshing only `["save"]`
-  would leave the blob's `eventInf` and bottle timers frozen while `save` moved on, a mix no vanilla
-  writer can produce (a bottle timer would then resume against a start time from an earlier process).
-- The new-cycle branch of `SaveManager_SysFlashrom_WriteData` preserves `owlSave`, so it gets the same
-  erase-unless-it-is-ours treatment. Reached by the game-over save prompt and by a pause save with
-  Pause Menu Save off — Song of Time and moon crash are already safe via `DeleteOwlSave`.
-- `MM_InvalidateOwlBlobSlot` clears the flag when the launcher replaces a slot's `mm` section behind
-  MM's back (`EraseComboContainer`, `Combo_CopyContainer`) — it cannot reach a DLL global otherwise.
-- A portal entry arrives in South Clock Town, which runs neither owl-arrival path, so `title_setup.c`
-  clears `save.isOwlSave` there. Left set it would persist into `newCycleSave` and keep owl-save write
-  timing armed for the whole session (a 2s stall and an `eventInf` wipe on every cycle reset).
-- `Combo_ApplyOwlSaveOpen` (`z_sram_NES.c`, next to `Sram_OpenSave` because `sOwlWarpEntrances` is
-  static there) mirrors the owl branch: pause entrance beats owl warp id, the `owlWarpId > OWL_WARP_MAX`
-  quirk is kept verbatim, post-temple swamp/mountain rewrites, scarecrow song.
-- `Combo_MMDropOwlSaveBlob` consumes the blob on continue. `func_80147314` can't be used — it needs
-  `sramCtx->saveBuf` and `gPlayState`, neither of which exists at `Setup_InitImpl`.
-
-**Entry kinds:** an owl blob wins on both, but only a resume follows it to where it was saved; a portal
-entry still arrives at South Clock Town.
-
-**Not a gap:** the combo block never zeroes `eventInf` or resets the timers the way `Sram_OpenSave`'s
-non-owl branch does — it doesn't need to. `Setup_InitImpl` calls `SaveContext_Init()`, which `memset`s
-all of `gSaveContext` on every MM entry. Vanilla only needs those resets because its file select
-re-uses a dirty `gSaveContext`.
-
-**Known hole, left alone:** with Autosave on and Pause Menu Save off, a pause save takes
-`Sram_SetFlashPagesDefault` into the new-cycle branch, which preserves `owlSave` — so a stale autosave
-blob shadows it until the next combo write. Vanilla 2S2H has the identical bug through its file select.
-
->>>>>>> 9eb7ade79910ca4397c30161e5e9053a6372e0e5

--- a/mm/src/code/z_sram_NES.c
+++ b/mm/src/code/z_sram_NES.c
@@ -1261,23 +1261,28 @@ void Sram_ResetSaveFromMoonCrash(SramContext* sramCtx) {
     s32 i;
     s32 cutsceneIndex = gSaveContext.save.cutsceneIndex;
 
-    memset(sramCtx->saveBuf, 0, SAVE_BUFFER_SIZE);
+    // ComboShip: 0xFF means no slot is loaded (MM debug save, or a .combosav mm half that failed to
+    // load). It has no row in the page tables, so read nothing and leave the live save alone.
+    if (gSaveContext.fileNum != 0xFF) {
+        memset(sramCtx->saveBuf, 0, SAVE_BUFFER_SIZE);
 
-    if (SysFlashrom_ReadData(sramCtx->saveBuf, gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
-                             gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]) != 0) {
-        SysFlashrom_ReadData(
-            sramCtx->saveBuf,
-            gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET],
-            gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET]);
-    }
-    memcpy(&gSaveContext.save, sramCtx->saveBuf, sizeof(Save));
-    if (CHECK_NEWF(gSaveContext.save.saveInfo.playerData.newf)) {
-        SysFlashrom_ReadData(
-            sramCtx->saveBuf,
-            gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET],
-            gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET]);
-        // ComboShip: the backup read fills the save, not the whole SaveContext (matches :1273).
+        if (SysFlashrom_ReadData(sramCtx->saveBuf,
+                                 gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
+                                 gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]) != 0) {
+            SysFlashrom_ReadData(
+                sramCtx->saveBuf,
+                gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET],
+                gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET]);
+        }
         memcpy(&gSaveContext.save, sramCtx->saveBuf, sizeof(Save));
+        if (CHECK_NEWF(gSaveContext.save.saveInfo.playerData.newf)) {
+            SysFlashrom_ReadData(
+                sramCtx->saveBuf,
+                gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET],
+                gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET]);
+            // ComboShip: the backup read fills the save, not the whole SaveContext (matches the read above).
+            memcpy(&gSaveContext.save, sramCtx->saveBuf, sizeof(Save));
+        }
     }
     gSaveContext.save.cutsceneIndex = cutsceneIndex;
 
@@ -2069,8 +2074,12 @@ void Sram_SaveSpecialEnterClockTown(PlayState* play) {
     // 2S2H [Enhancement] Store playtime before saving
     SavingEnhancements_AdvancePlaytime();
     func_80145698(sramCtx);
-    SysFlashrom_WriteDataSync(sramCtx->saveBuf, gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
-                              gFlashSpecialSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
+    // ComboShip: no slot loaded, so skip the write (see Sram_ResetSaveFromMoonCrash).
+    if (gSaveContext.fileNum != 0xFF) {
+        SysFlashrom_WriteDataSync(sramCtx->saveBuf,
+                                  gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
+                                  gFlashSpecialSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
+    }
 }
 
 /**
@@ -2091,9 +2100,12 @@ void Sram_SaveSpecialNewDay(PlayState* play) {
     gSaveContext.save.day = day;
     gSaveContext.save.time = time;
     gSaveContext.save.cutsceneIndex = cutsceneIndex;
-    SysFlashrom_WriteDataSync(play->sramCtx.saveBuf,
-                              gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
-                              gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
+    // ComboShip: no slot loaded, so skip the write (see Sram_ResetSaveFromMoonCrash).
+    if (gSaveContext.fileNum != 0xFF) {
+        SysFlashrom_WriteDataSync(play->sramCtx.saveBuf,
+                                  gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
+                                  gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
+    }
 }
 
 void Sram_SetFlashPagesDefault(SramContext* sramCtx, u32 curPage, u32 numPages) {
@@ -2187,12 +2199,15 @@ void func_80147314(SramContext* sramCtx, s32 fileNum) {
     gSaveContext.save.saveInfo.checksum = Sram_CalcChecksum(&gSaveContext, offsetof(SaveContext, fileNum));
 
     memcpy(sramCtx->saveBuf, &gSaveContext, offsetof(SaveContext, fileNum));
-    Sram_SyncWriteToFlash(sramCtx, gFlashOwlSaveStartPages[fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
-                          gFlashOwlSaveNumPages[fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
-    //! Note: should be `gFlashOwlSaveNumPages[fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET]`?
-    Sram_SyncWriteToFlash(sramCtx,
-                          gFlashOwlSaveStartPages[fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET],
-                          gFlashOwlSaveNumPages[fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
+    // ComboShip: no slot loaded, so skip the write (see Sram_ResetSaveFromMoonCrash).
+    if (fileNum != 0xFF) {
+        Sram_SyncWriteToFlash(sramCtx, gFlashOwlSaveStartPages[fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
+                              gFlashOwlSaveNumPages[fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
+        //! Note: should be `gFlashOwlSaveNumPages[fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET]`?
+        Sram_SyncWriteToFlash(sramCtx,
+                              gFlashOwlSaveStartPages[fileNum * FLASH_SAVE_MAIN_MULTIPLIER + FLASH_SAVE_BACKUP_OFFSET],
+                              gFlashOwlSaveNumPages[fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
+    }
 
     gSaveContext.save.isOwlSave = true;
 

--- a/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope_NES.c
+++ b/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope_NES.c
@@ -3604,8 +3604,11 @@ void KaleidoScope_Update(PlayState* play) {
                                     gSaveContext.save.isOwlSave = currentOwlSaveState;
                                     SavingEnhancements_ClearSaveEntranceInfo();
                                 } else {
-                                    Sram_SetFlashPagesDefault(sramCtx, gFlashSaveStartPages[gSaveContext.fileNum],
-                                                              gFlashSaveNumPages[gSaveContext.fileNum]);
+                                    // ComboShip: without the multiplier this indexed another slot's pages.
+                                    Sram_SetFlashPagesDefault(
+                                        sramCtx,
+                                        gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
+                                        gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
                                     Sram_StartWriteToFlashDefault(sramCtx);
                                 }
                                 pauseCtx->savePromptState = PAUSE_SAVEPROMPT_STATE_4;
@@ -3886,11 +3889,14 @@ void KaleidoScope_Update(PlayState* play) {
                     gSaveContext.save.saveInfo.playerData.savedSceneId = play->sceneId;
                     gSaveContext.save.saveInfo.playerData.health = 0x30;
                     func_8014546C(sramCtx);
-                    if (!gSaveContext.flashSaveAvailable) {
+                    // ComboShip: no slot loaded, so don't save - same as the pause-save prompt above.
+                    if (!gSaveContext.flashSaveAvailable || gSaveContext.fileNum == 255) {
                         pauseCtx->state = PAUSE_STATE_GAMEOVER_8;
                     } else {
-                        Sram_SetFlashPagesDefault(sramCtx, gFlashSaveStartPages[gSaveContext.fileNum],
-                                                  gFlashSaveNumPages[gSaveContext.fileNum]);
+                        // ComboShip: without the multiplier this indexed another slot's pages.
+                        Sram_SetFlashPagesDefault(
+                            sramCtx, gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
+                            gFlashSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
                         Sram_StartWriteToFlashDefault(sramCtx);
                         pauseCtx->state = PAUSE_STATE_GAMEOVER_7;
                     }


### PR DESCRIPTION
Closes #184 — and widens it, because the re-check found the same indexing mistake in a reachable form.

MM's flash page tables need `fileNum * FLASH_SAVE_MAIN_MULTIPLIER` (=2): each slot owns two rows, main + backup.

## Family A — missing multiplier (the reported bug)

Two kaleido sites indexed with a raw `gSaveContext.fileNum`. The bad index still resolves to a **valid** row, so `SaveManager_GetFlashSaveFromPages` succeeds and the write lands somewhere real — slot 2 → `file1backup.json` (dropped under `COMBO_BUILD`), slot 3 → slot 2's `mm` section.

**Both branches are dead in this tree**, so this half is preventative: the pause-save prompt is only entered behind `VB_SAVE_ON_B_BUTTON_IN_PAUSE_MENU`, whose sole hook requires the very CVar the buggy `else` tests as off; the game-over Save prompt needs `GAMEOVER_INACTIVE`, which `z_game_over.c:88` clears on the frame it starts the sequence. The issue's "dying on slot 2 does nothing" symptom and its three-slot playtest matrix were wrong — corrected in the issue.

The game-over site also lacked the `fileNum == 255` guard its pause-save sibling already had; that term is now added to its existing `!flashSaveAvailable` condition, which routes the skip to `PAUSE_STATE_GAMEOVER_8` — exactly what the pre-existing `!flashSaveAvailable` skip already used, so no new state.

## Family B — the `0xFF` no-slot sentinel (reachable)

Four sites indexed with `gSaveContext.fileNum` without testing `0xFF`, reading well past 14- and 6-entry arrays. ComboShip reaches `0xFF` **deliberately**: `SaveManager_LoadFailedForCombo` sets it when a `.combosav` `mm` half fails to load, and play proceeds by design. `flashSaveAvailable` is true in that session, so no existing guard covered it.

Playing the Song of Time was enough — `Sram_SaveEndOfCycle` fires `BeforeEndOfCycleSave` → `DeleteOwlSave` → `func_80147314(0xFF)` → two synchronous writes off `gFlashOwlSaveStartPages[510]` on a six-entry array. `Sram_ResetSaveFromMoonCrash` was worse than a no-op: both reads failed and it still copied the zeroed buffer over the live save, blanking items, hearts and masks in RAM.

Each guard wraps **the storage access only**, never the function entry — these functions do real in-memory work first (`Sram_SaveEndOfCycle`, the `isFirstCycle`/`isOwlSave` sets, the `newf` zero-and-restore dance), and skipping that would change behavior in the failed-load state. All four use synchronous writes and never touch `sramCtx->status`, so nothing can observe the skip.

## Family C — phantom container

`Combo_ReadGameSave` / `Combo_WriteGameSave` were the only container callbacks that skipped `ComboIsValidSlot`, despite that helper's own comment saying callbacks reached from a game's `fileNum` must never create one. With `0xFF`, `SaveManager_SaveCurrentForCombo` targeted `file256.json` → a real `Save/file256.combosav` on disk. Guarding the boundary closes both MM callers that reached it, so neither needed touching. The dropped write now logs once.

## Notes

- Unguarded with `// ComboShip:` comments, no `#ifdef COMBO_BUILD`: upstream 2S2H reaches `fileNum == 0xFF` during gameplay too (map select, BootToWarpPoint), so these are correctness fixes rather than deviations — which is why the sibling guards are already commented "Don't let them save if they are in debug save". Not sent upstream.
- Rationale, post-guard invariants and declined residuals are in `docs/deviations/boot-shutdown.md`. Notable residual: `Sram_OpenSave`'s `0xFF` branch never assigns `phi_t1`, which feeds a `memcpy` length twice — real UB, but dead (combo never enters MM file select).
- Follow-up not in this PR: `Combo_OnOOTSaveLoad` has no `ComboIsValidSlot` guard, so OOT's debug map select poisons MM's dormant save and leaves `g_MmSaveInMemorySlot` stale.

## Testing

Built clean, Debug, `2ship` + `ComboShip`. clang-format clean and idempotent.

Not playtested, deliberately: Family A's branches cannot execute, and Family B needs a deliberately corrupted `mm` half — a session where the zeroed save leaves `health == 0` and Link cannot move. Reviewed instead, with the reachability of every guarded site traced to its trigger.

`grep "gFlash[A-Za-z]*Pages\[gSaveContext\.fileNum\]"` over `mm/` now returns zero hits (four before).


<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9669197659.zip)
<!--- section:artifacts:end -->