### PR TITLE
fix: clear foreign-anim caches via CrossRMRegistry teardown listeners

### DIFF
--- a/combo/menu/ComboForeignAnim.h
+++ b/combo/menu/ComboForeignAnim.h
@@ -301,6 +301,39 @@ struct CfaTexAnimEntry {
     const CfaMatEntry* mat = nullptr;
 };
 
+struct CfaStaticTexAnim {
+    bool ok = false;
+    std::shared_ptr<Ship::IResource> res; // held so the resource stays alive in the RM cache
+    const CfaMatEntry* mat = nullptr;
+};
+
+// Hoisted out of their functions so CfaClearCaches can clear them. The shared_ptrs point
+// at FOREIGN-game resources: their control blocks and IResource vtables live in the OTHER game's
+// DLL. Left populated, these maps die in THIS DLL's static destructors — after the launcher has
+// already FreeLibrary'd the foreign DLL — and ~shared_ptr dispatches _Destroy() through an unmapped
+// vtable. See docs/deviations/boot-shutdown.md.
+inline std::unordered_map<std::string, CfaSkelEntry> sCfaSkelCache;
+inline std::unordered_map<std::string, CfaTexAnimEntry> sCfaTexAnimCache;
+inline std::unordered_map<std::string, CfaStaticTexAnim> sCfaStaticTexAnimCache;
+
+// Module-local cache clear, registered as a CrossRMRegistry teardown listener the first time a
+// cache is touched (CfaEnsureTeardownHook below): ANY RM unregister — both games' DeinitOTR, which
+// run before every FreeLibrary — empties the caches, so the borrowed refs structurally cannot
+// outlive the owning DLL. Listeners stay registered and re-fire on the second Unregister, which
+// just clears empty maps.
+inline void CfaClearCaches() {
+    sCfaSkelCache.clear();
+    sCfaTexAnimCache.clear();
+    sCfaStaticTexAnimCache.clear();
+}
+
+// Register-once guard. Lazy on purpose: it runs from the cache-miss paths, so a module that never
+// draws a foreign item never registers (and its empty caches need no teardown).
+inline void CfaEnsureTeardownHook() {
+    static bool sRegistered = (Ship::CrossRMRegistry::RegisterTeardownListener(&CfaClearCaches), true);
+    (void)sRegistered;
+}
+
 // The foreign game whose limb DLs the in-flight DrawFlex is submitting (single-threaded draw).
 inline const char* sCfaCurrentGame = nullptr;
 
@@ -650,15 +683,14 @@ inline int32_t ComboForeignAnim_Draw(const CwItemAnimDrawInfo* info, const char*
         return 0; // owning game not resident: bail before any Gfx is emitted
     }
 
-    static std::unordered_map<std::string, CfaSkelEntry> sSkelCache;
-    static std::unordered_map<std::string, CfaTexAnimEntry> sTexAnimCache;
+    CfaEnsureTeardownHook();
 
     // -- skeleton + animation (keyed by skel+anim; all variants sharing a pair share one instance,
     //    so like MM's single-instance approach all on-screen copies animate in unison) --
     std::string skelKey = std::string(info->skelPath) + "|" + info->animPath;
-    auto skelIt = sSkelCache.find(skelKey);
-    if (skelIt == sSkelCache.end()) {
-        skelIt = sSkelCache.emplace(skelKey, CfaSkelEntry{}).first;
+    auto skelIt = sCfaSkelCache.find(skelKey);
+    if (skelIt == sCfaSkelCache.end()) {
+        skelIt = sCfaSkelCache.emplace(skelKey, CfaSkelEntry{}).first;
         CfaSkelEntry& e = skelIt->second;
         if (auto rm = Ship::CrossRMRegistry::Get(game)) {
             // The foreign game's Skeleton/Animation factories nested-load their limbs/tables via
@@ -705,9 +737,9 @@ inline int32_t ComboForeignAnim_Draw(const CwItemAnimDrawInfo* info, const char*
     // -- texanim (keyed by texAnimPath; the per-area coloring lives here) --
     CfaTexAnimEntry* texAnim = nullptr;
     if (info->texAnimPath != NULL) {
-        auto taIt = sTexAnimCache.find(info->texAnimPath);
-        if (taIt == sTexAnimCache.end()) {
-            taIt = sTexAnimCache.emplace(info->texAnimPath, CfaTexAnimEntry{}).first;
+        auto taIt = sCfaTexAnimCache.find(info->texAnimPath);
+        if (taIt == sCfaTexAnimCache.end()) {
+            taIt = sCfaTexAnimCache.emplace(info->texAnimPath, CfaTexAnimEntry{}).first;
             CfaTexAnimEntry& e = taIt->second;
             if (auto rm = Ship::CrossRMRegistry::Get(game)) {
                 // Scoped like the skel/anim load: today's validated types don't nested-load, but
@@ -882,15 +914,11 @@ inline bool ComboForeignTexAnim_Run(PlayState* play, const char* game, const cha
     if (play == NULL || game == NULL || texAnimPath == NULL) {
         return false;
     }
-    struct CfaStaticTexAnim {
-        bool ok = false;
-        std::shared_ptr<Ship::IResource> res; // held so the resource stays alive in the RM cache
-        const CfaMatEntry* mat = nullptr;
-    };
-    static std::unordered_map<std::string, CfaStaticTexAnim> sCache; // one attempt per path, then cached
-    auto it = sCache.find(texAnimPath);
-    if (it == sCache.end()) {
-        it = sCache.emplace(texAnimPath, CfaStaticTexAnim{}).first;
+    CfaEnsureTeardownHook();
+    // one attempt per path, then cached
+    auto it = sCfaStaticTexAnimCache.find(texAnimPath);
+    if (it == sCfaStaticTexAnimCache.end()) {
+        it = sCfaStaticTexAnimCache.emplace(texAnimPath, CfaStaticTexAnim{}).first;
         CfaStaticTexAnim& e = it->second;
         if (auto rm = Ship::CrossRMRegistry::Get(game)) {
             Ship::ResourceManagerScope rmScope(rm); // as above: scope the load, not the draw

--- a/docs/deviations/boot-shutdown.md
+++ b/docs/deviations/boot-shutdown.md
@@ -154,6 +154,39 @@ join) dies while everything is mapped, then installs a lus-owned null-sink defau
 late `SPDLOG_*` call stays safe; `luslog()` also null-guards `default_logger_raw()`. Must live in
 lus code — the registry singleton is per-module.
 
+## Foreign-anim caches: cross-DLL shared_ptr teardown (5th X-close crash class, 2026-08-25)
+
+Quitting after a session that DREW at least one foreign MM item model in OOT crashed post-`main()`
+(only the late-crash log showed it). `combo/menu/ComboForeignAnim.h` cached foreign resources in
+function-local statics (`sSkelCache`/`sTexAnimCache`/`sCache`) holding `shared_ptr<Ship::IResource>`
+loaded through the FOREIGN game's RM — so in soh.dll's copy the control blocks and IResource vtables
+live in 2ship.dll (its factories `make_shared` them). The launcher frees 2ship.dll before soh.dll,
+so when soh's static dtors destroyed the caches, `_Ref_count_base::_Decref`'s virtual `_Destroy()`
+dispatched through an unmapped vtable (AV at the `call` through the control-block vtable). Same
+class as the spdlog-registry crash above — a cross-module vtable outliving `FreeLibrary` — held by
+combo-owned code this time.
+
+Fixed entirely in combo-owned code, tied to the registry so no deinit call site can forget it: the
+three caches are hoisted to header scope, and the first cache touch registers a module-local clear
+(`CfaClearCaches`) as a `CrossRMRegistry` teardown listener (`RegisterTeardownListener`, new —
+exported automatically by the generated lus .def). Every `Unregister` — i.e. both games'
+`DeinitOTR`, which run before any `FreeDll` — fires ALL listeners before dropping the RM, so each
+module releases its cross-module refs while every game DLL is still mapped; the second Unregister
+re-fires them onto already-empty maps. Listeners are raw fn pointers into the game DLLs, valid
+because `Unregister` only ever runs during deinit; they fire outside the registry lock (a released
+resource's destructor may re-enter `Get()`). No vendored-file churn.
+
+Diagnosis note: the player's soh.dll was still MAPPED at process exit (its static dtors ran under
+`LdrShutdownProcess`, not at `FreeDll`), i.e. something holds an extra loader ref on soh.dll — prime
+suspect is the statically-linked SDL's `WH_KEYBOARD_LL` hook (`WIN_UpdateKeyboardHook`, the DLL's
+only `SetWindowsHookExW` site), unconfirmed. Immaterial to this fix — the FreeDll order (2ship
+before soh) crashes either way — but it means soh.dll static dtors can ALWAYS run at process exit:
+never let them depend on another game DLL. Frames were recovered without PDBs by downloading the
+matching nightly `ComboShip-windows` artifact, adding the logged displacements to the export RVAs
+(`SOH_NotifyComboReturn`/`SOH_RunGameLoop`), and `objdump -d --start-address` at each RVA; the
+log's unresolved frames sit BELOW the lowest export RVA (dbghelp's nearest-export synthesis fails
+there), which also pins the module base (64K-aligned) and thus the crash PC's RVA.
+
 ## Cross-game erase: deleting a slot wipes both OOT and MM saves (issue #1, 2026-06-19)
 
 **Why:** a ComboShip save *slot* (file 1/2/3) is one combined OOT+MM playthrough, but each game's

--- a/libultraship/include/ship/resource/CrossRMRegistry.h
+++ b/libultraship/include/ship/resource/CrossRMRegistry.h
@@ -14,6 +14,13 @@ class CrossRMRegistry {
   public:
     static void Register(const std::string& name, std::shared_ptr<ResourceManager> rm);
     static void Unregister(const std::string& name);
+    // Modules that borrow shared_ptrs from a registered RM (the foreign-anim caches) register a
+    // teardown listener; every Unregister fires ALL listeners before dropping the RM, so each
+    // module releases its cross-module refs while every game DLL is still mapped. Idempotent per
+    // pointer; listeners stay registered, so a re-fire must be a safe no-op (clearing an empty
+    // cache). Raw fn pointers into game DLLs: valid because Unregister only runs during deinit,
+    // before any FreeLibrary (see docs/deviations/boot-shutdown.md).
+    static void RegisterTeardownListener(void (*listener)());
     static std::shared_ptr<ResourceManager> Get(const std::string& name);
     // Get(name), falling back to the Context's active RM when not registered. For code that must
     // always use its own game's RM (e.g. audio threads racing active-RM swaps on other threads).

--- a/libultraship/src/ship/resource/CrossRMRegistry.cpp
+++ b/libultraship/src/ship/resource/CrossRMRegistry.cpp
@@ -5,7 +5,9 @@
 #include "ship/resource/CrossRMRegistry.h"
 #include "ship/Context.h"
 
+#include <algorithm>
 #include <shared_mutex>
+#include <vector>
 
 namespace Ship {
 
@@ -21,15 +23,42 @@ static std::unordered_map<std::string, std::shared_ptr<ResourceManager>>& CrossR
     return sMap;
 }
 
+static std::vector<void (*)()>& CrossRMTeardownListeners() {
+    static std::vector<void (*)()> sListeners;
+    return sListeners;
+}
+
 void CrossRMRegistry::Register(const std::string& name, std::shared_ptr<ResourceManager> rm) {
     std::unique_lock lock(CrossRMMutex());
     CrossRMMap()[name] = std::move(rm);
+}
+
+void CrossRMRegistry::RegisterTeardownListener(void (*listener)()) {
+    if (listener == nullptr) {
+        return;
+    }
+    std::unique_lock lock(CrossRMMutex());
+    auto& listeners = CrossRMTeardownListeners();
+    if (std::find(listeners.begin(), listeners.end(), listener) == listeners.end()) {
+        listeners.push_back(listener);
+    }
 }
 
 // Games unregister at deinit so the RM is destroyed on the main thread (its thread pool joins its
 // workers in the destructor); leaving it in this static map defers destruction to DLL unload,
 // where joining under the loader lock deadlocks.
 void CrossRMRegistry::Unregister(const std::string& name) {
+    // Fire teardown listeners FIRST: each module drops shared_ptrs whose control blocks live in
+    // another game DLL (all still mapped during deinit) before that RM's resources go away.
+    // Copied out of the lock — a released resource's destructor may re-enter Get().
+    std::vector<void (*)()> listeners;
+    {
+        std::shared_lock lock(CrossRMMutex());
+        listeners = CrossRMTeardownListeners();
+    }
+    for (auto listener : listeners) {
+        listener();
+    }
     std::shared_ptr<ResourceManager> removed;
     {
         std::unique_lock lock(CrossRMMutex());


### PR DESCRIPTION
A streamer was having an issue when trying to load back into OOT would crash the game. I have a save file that can reproduce this.

I tried to keep this entirely in combo code so 1) less merge concerns and 2) any other teardown items could potentially reuse the listener in the future.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9586136248.zip)
<!--- section:artifacts:end -->