### PR TITLE
fix(combo): submit the owning game's setup DL for foreign item draws

### DIFF
--- a/combo/menu/ComboForeignDrawMM.h
+++ b/combo/menu/ComboForeignDrawMM.h
@@ -64,6 +64,9 @@ struct ComboForeignDrawInfoOOT {
     int32_t layerPrimMask = 0;
     int32_t layerEnvMask = 0;
     const char* dls[CW_DRAW_MAX_DLISTS] = { nullptr }; // interned "__OTR__@oot:..." routed paths
+    // OOT's own setup DL for each stream (raw Gfx* in soh.dll), or null for our 25 Opa/Xlu.
+    const void* setupDlOpa = nullptr;
+    const void* setupDlXlu = nullptr;
     // ComboShip: animated class (no static DL row — OOT boss souls' real skeletons). When animOk,
     // anim describes the item and ComboForeignAnim_Draw renders it; paths point at soh.dll statics.
     bool animOk = false;
@@ -146,6 +149,8 @@ inline ComboForeignResolveOOT ComboFillForeignDrawInfoOOT(RandoCheckId rc, Combo
     info.count = n;
     info.xluStart = raw.xluStartIndex;
     info.scale = raw.scale;
+    info.setupDlOpa = raw.setupDlOpa;
+    info.setupDlXlu = raw.setupDlXlu;
     info.hasEnvColor = raw.hasEnvColor != 0;
     info.drawKind = raw.drawKind;
     info.stateDependent = raw.stateDependent != 0;
@@ -244,7 +249,14 @@ inline void MM_DrawForeignSimple(const ComboForeignDrawInfoOOT* info) {
         Matrix_Scale(info->scale, info->scale, info->scale, MTXMODE_APPLY);
     }
     if (xs > 0) {
-        Gfx_SetupDL25_Opa(gfxCtx);
+        // OOT's own setup when the row uses one other than 25 (masks/bombchu/medallions = 26, which
+        // is 1-CYCLE without fog). Under MM's 2-cycle 25 those lists' duplicated second cycle wins
+        // and samples TEXEL1 — whatever tile MM last bound — instead of the item's own texture.
+        if (info->setupDlOpa != nullptr) {
+            gSPDisplayList(POLY_OPA_DISP++, (Gfx*)info->setupDlOpa);
+        } else {
+            Gfx_SetupDL25_Opa(gfxCtx);
+        }
         MM_FOREIGN_PIN_OPA();
         MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, gfxCtx);
         if (info->hasEnvColor) {
@@ -255,7 +267,11 @@ inline void MM_DrawForeignSimple(const ComboForeignDrawInfoOOT* info) {
         }
     }
     if (xs < n) {
-        Gfx_SetupDL25_Xlu(gfxCtx);
+        if (info->setupDlXlu != nullptr) { // sold-out sign / compass glass: setup 5, not 25
+            gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->setupDlXlu);
+        } else {
+            Gfx_SetupDL25_Xlu(gfxCtx);
+        }
         MM_FOREIGN_PIN_XLU();
         MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
         if (info->hasEnvColor) {
@@ -601,15 +617,19 @@ inline void MM_DrawForeignBossSoul(const ComboForeignDrawInfoOOT* info) {
 }
 
 // Per-DL prim/env colored layers: the rando map/compass/small-key/boss-key/key-ring/jabber-nut/
-// bombchu-bag/overworld-key funcs, which only differ in which DLs they tint and with what. OOT's
-// 26Opa funcs are approximated as 25Opa (same convention as GetItem_GetDrawTableEntry).
+// bombchu-bag/overworld-key funcs, which only differ in which DLs they tint and with what. Rows
+// authored for another setup (26 Opa, 5 Xlu) carry it in the recipe and it is submitted below.
 inline void MM_DrawForeignColorLayers(const ComboForeignDrawInfoOOT* info) {
     int32_t n = info->count;
     int32_t xs = (info->xluStart < 0 || info->xluStart > n) ? n : info->xluStart;
     GraphicsContext* gfxCtx = gPlayState->state.gfxCtx;
     OPEN_DISPS(gfxCtx);
     if (xs > 0) {
-        Gfx_SetupDL25_Opa(gfxCtx);
+        if (info->setupDlOpa != nullptr) { // Jabber Nut / Bombchu Bag: 26 Opa, 1-cycle
+            gSPDisplayList(POLY_OPA_DISP++, (Gfx*)info->setupDlOpa);
+        } else {
+            Gfx_SetupDL25_Opa(gfxCtx);
+        }
         MM_FOREIGN_PIN_OPA();
         MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, gfxCtx);
         for (int32_t i = 0; i < xs; i++) {
@@ -625,7 +645,11 @@ inline void MM_DrawForeignColorLayers(const ComboForeignDrawInfoOOT* info) {
         }
     }
     if (xs < n) {
-        Gfx_SetupDL25_Xlu(gfxCtx);
+        if (info->setupDlXlu != nullptr) { // compass glass: 5 Xlu
+            gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->setupDlXlu);
+        } else {
+            Gfx_SetupDL25_Xlu(gfxCtx);
+        }
         MM_FOREIGN_PIN_XLU();
         MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gfxCtx);
         for (int32_t i = xs; i < n; i++) {

--- a/combo/menu/ComboForeignDrawOOT.h
+++ b/combo/menu/ComboForeignDrawOOT.h
@@ -58,6 +58,9 @@ struct ComboForeignDrawInfo {
     int32_t opCount = 0;                      // CW_DRAW_KIND_OPS payload
     CwDrawOp ops[CW_DRAW_MAX_OPS] = {};
     const char* dls[CW_DRAW_MAX_DLISTS] = { nullptr }; // interned "__OTR__@mm:..." routed paths
+    // MM's own setup DL for each stream (raw Gfx* in 2ship.dll), or null for our 25 Opa/Xlu.
+    const void* setupDlOpa = nullptr;
+    const void* setupDlXlu = nullptr;
     // ComboShip: animated class (no static DL row — MM stray fairies). When animOk, anim describes
     // the item and ComboForeignAnim_Draw renders it; path strings point at 2ship.dll statics.
     bool animOk = false;
@@ -141,6 +144,8 @@ inline ComboForeignResolve ComboFillForeignDrawInfo(RandomizerCheck rc, int slot
     info.count = n;
     info.xluStart = raw.xluStartIndex;
     info.scale = raw.scale;
+    info.setupDlOpa = raw.setupDlOpa;
+    info.setupDlXlu = raw.setupDlXlu;
     info.hasEnvColor = raw.hasEnvColor != 0;
     info.xluSeg8TexScroll = raw.xluSeg8TexScroll != 0;
     info.matAnimPath = raw.matAnimPath; // 2ship static literal (process-lifetime); loaded, not emitted
@@ -527,7 +532,14 @@ inline void OOT_DrawForeignSimple(PlayState* play, const ComboForeignDrawInfo* i
     // Mirror MM's GetItem_DrawOpa*/Xlu* structure: one 25Opa setup + matrix for the OPA layers,
     // then one 25Xlu setup + matrix for the XLU layers.
     if (xs > 0) {
-        Gfx_SetupDL_25Opa(play->state.gfxCtx);
+        // MM's own setup when the row uses one other than 25 (bombchu = 23, which is 1-CYCLE without
+        // fog). Under OOT's 2-cycle 25 the list's duplicated second cycle wins and samples TEXEL1 —
+        // whatever tile OOT last bound — instead of the item's own texture.
+        if (info->setupDlOpa != nullptr) {
+            gSPDisplayList(POLY_OPA_DISP++, (Gfx*)info->setupDlOpa);
+        } else {
+            Gfx_SetupDL_25Opa(play->state.gfxCtx);
+        }
         OOT_FOREIGN_PIN_OPA();
         COMBO_FOREIGN_MTX(POLY_OPA_DISP++);
         if (info->hasEnvColor) {
@@ -538,7 +550,11 @@ inline void OOT_DrawForeignSimple(PlayState* play, const ComboForeignDrawInfo* i
         }
     }
     if (xs < n) {
-        Gfx_SetupDL_25Xlu(play->state.gfxCtx);
+        if (info->setupDlXlu != nullptr) { // compass glass: setup 5, not 25
+            gSPDisplayList(POLY_XLU_DISP++, (Gfx*)info->setupDlXlu);
+        } else {
+            Gfx_SetupDL_25Xlu(play->state.gfxCtx);
+        }
         OOT_FOREIGN_PIN_XLU();
         // ComboShip: MM's GetItem_DrawSkullToken inlines this seg-8 flame scroll (no texanim
         // resource to carry), so it is hardcoded here. See docs/deviations/rando.md.

--- a/combo/menu/ComboItemDrawABI.h
+++ b/combo/menu/ComboItemDrawABI.h
@@ -129,6 +129,13 @@ typedef struct {
     /* ComboShip: CW_DRAW_KIND_OPS payload. */
     int32_t opCount;
     CwDrawOp ops[CW_DRAW_MAX_OPS];
+
+    /* ComboShip: the owner's setup DL for each stream (raw Gfx* in the owner's module — state-only
+     * commands, no resource refs), or NULL for the consumer's own 25 Opa/Xlu. Items authored for a
+     * different setup (OOT's 26 = 1-cycle, no fog) render through the wrong combiner under 25: the
+     * dead second cycle wins and samples TEXEL1, i.e. whatever tile the HOST last left bound. */
+    const void* setupDlOpa;
+    const void* setupDlXlu;
 } CwItemDrawInfo;
 
 /* Returns 1 and fills out on success; 0 if the item is unknown/undrawable; CW_DRAW_NOT_READY if the

--- a/combo/menu/ComboItemDrawMM.h
+++ b/combo/menu/ComboItemDrawMM.h
@@ -68,6 +68,9 @@
 extern "C" s32 GetItem_GetDrawTableEntry(s32 drawId, void** outDlists, s32 maxDlists, s32* outXluStart, f32* outScale,
                                          s32* outXluSeg8TexScroll, s32* outDrawKind);
 
+// Which setup DL the row's func emits (NULL = plain 25). The consumer must submit the same one.
+extern "C" void GetItem_GetDrawSetupDLs(s32 drawId, void** outOpa, void** outXlu);
+
 // --- CW_DRAW_KIND_OPS emitters. Bounds-checked; an overflowing recipe is truncated, never written
 // out of range (the consumer just draws fewer layers).
 static CwDrawOp* MM_Op(CwItemDrawInfo* out, int32_t op) {
@@ -888,6 +891,13 @@ static int32_t MM_FillItemDrawInfo(RandoItemId id, CwItemDrawInfo* out) {
     for (int32_t i = 0; i < n; i++) {
         out->dlists[i] = (const char*)dls[i];
     }
+    // Rows drawn under a setup other than 25 (bombchu = 23 Opa, compass glass = 5 Xlu): carry it so
+    // the consumer submits the same GPU state, not its own 25.
+    void* setupOpa = nullptr;
+    void* setupXlu = nullptr;
+    GetItem_GetDrawSetupDLs((s32)it->second.drawId, &setupOpa, &setupXlu);
+    out->setupDlOpa = setupOpa;
+    out->setupDlXlu = setupXlu;
     // ComboShip: some MM item bodies sample an animated segment-8 material their draw func binds via
     // AnimatedMat_Draw (Moon's Tear, fairy bottle). z_draw.c can't carry that across, so report the
     // texanim resource for the consumer to replicate (ComboForeignTexAnim_Run). Matched by DL string

--- a/combo/menu/ComboItemDrawOOT.h
+++ b/combo/menu/ComboItemDrawOOT.h
@@ -57,6 +57,10 @@ extern Color_RGB8 MapOrCompassColor[10];
 extern "C" s32 GetItem_GetDrawTableEntry(s32 drawId, void** outDlists, s32 maxDlists, s32* outXluStart, f32* outScale,
                                          s32* outDrawKind, uint8_t* outColors);
 
+// Which setup DL the row's func emits (NULL = plain 25). The consumer must submit the same one.
+extern "C" void GetItem_GetDrawSetupDLs(s32 drawId, void** outOpa, void** outXlu);
+extern "C" void* GetItem_GetSetupDL(s32 index); // by index, for the bespoke Randomizer_Draw* funcs
+
 // --- CW_DRAW_KIND_COLOR_LAYERS helpers: attach a prim/env color to one display list slot.
 static void CwLayerPrim(CwItemDrawInfo* out, int32_t i, Color_RGB8 c) {
     out->layerPrimColor[i][0] = c.r;
@@ -131,6 +135,7 @@ static int32_t OOT_DescribeCustomDraw(RandomizerGet rg, CwItemDrawInfo* out) {
     // Compasses: prim+half-env body (OPA) + glass (XLU) (Randomizer_DrawCompass).
     if (rg >= RG_DEKU_TREE_COMPASS && rg <= RG_ICE_CAVERN_COMPASS) {
         Color_RGB8 c = MapOrCompassColor[rg - RG_DEKU_TREE_COMPASS];
+        out->setupDlXlu = GetItem_GetSetupDL(SETUPDL_5); // the glass layer, as Randomizer_DrawCompass does
         out->drawKind = CW_DRAW_KIND_COLOR_LAYERS;
         out->dlistCount = 2;
         out->xluStartIndex = 1;
@@ -262,6 +267,7 @@ static int32_t OOT_DescribeCustomDraw(RandomizerGet rg, CwItemDrawInfo* out) {
         };
         int slot = rg - RG_SPEAK_DEKU;
         bool generic = CVarGetInteger(CVAR_RANDOMIZER_ENHANCEMENT("GenericJabberNutModel"), 0) != 0;
+        out->setupDlOpa = GetItem_GetSetupDL(SETUPDL_26); // Randomizer_DrawJabberNut uses 26Opa
         out->drawKind = CW_DRAW_KIND_COLOR_LAYERS;
         out->dlistCount = 1;
         out->xluStartIndex = -1;
@@ -323,8 +329,11 @@ static int32_t OOT_DescribeCustomDraw(RandomizerGet rg, CwItemDrawInfo* out) {
         // RG_BOMBCHU_20 only draws the bag when the bombchu-bag option is on (DrawBombchuBagInLogic).
         if (rg == RG_BOMBCHU_20 &&
             OTRGlobals::Instance->gRandoContext->GetOption(RSK_BOMBCHU_BAG).Is(RO_BOMBCHU_BAG_NONE)) {
-            return CwSimple(out, gGiBombchuDL, false, 0.0f);
+            CwSimple(out, gGiBombchuDL, false, 0.0f);
+            out->setupDlOpa = GetItem_GetSetupDL(SETUPDL_26); // Randomizer_DrawBombchuBag uses 26Opa
+            return 1;
         }
+        out->setupDlOpa = GetItem_GetSetupDL(SETUPDL_26);
         out->drawKind = CW_DRAW_KIND_COLOR_LAYERS;
         out->dlistCount = 2;
         out->xluStartIndex = -1;
@@ -443,6 +452,13 @@ static int32_t OOT_FillItemDrawInfo(RandomizerGet rg, CwItemDrawInfo* out) {
     for (int32_t i = 0; i < n; i++) {
         out->dlists[i] = (const char*)dls[i];
     }
+    // Rows drawn under a setup other than 25 (masks/bombchu/medallions = 26 Opa, sold-out/compass
+    // = 5 Xlu): carry it so the consumer submits the same GPU state, not its own 25.
+    void* setupOpa = nullptr;
+    void* setupXlu = nullptr;
+    GetItem_GetDrawSetupDLs((s32)gi.gid, &setupOpa, &setupXlu);
+    out->setupDlOpa = setupOpa;
+    out->setupDlXlu = setupXlu;
     return 1;
 }
 

--- a/libultraship/src/fast/interpreter.cpp
+++ b/libultraship/src/fast/interpreter.cpp
@@ -1030,7 +1030,11 @@ void Interpreter::ImportTextureCi4(int tile, bool importReplacement) {
     const uint8_t* palette;
 
     if (mRdp->palettes[palIdx / 8] == nullptr) {
-        SPDLOG_WARN("CI4: null palette slot {} for palIdx={}", palIdx / 8, palIdx);
+        // As in the CI8 path: a silent return leaves a stale GPU texture. Log once per address.
+        static std::unordered_set<const void*> sReportedNullPalettes4;
+        if (sReportedNullPalettes4.insert((const void*)addr).second) {
+            SPDLOG_ERROR("CI4: null palette slot {} for palIdx={}", palIdx / 8, palIdx);
+        }
         return;
     }
     palette = mRdp->palettes[palIdx / 8] + (palIdx % 8) * 16 * 2;
@@ -1120,8 +1124,13 @@ void Interpreter::ImportTextureCi8(int tile, bool importReplacement) {
     uint32_t lineSizeBytes = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].line_size_bytes;
 
     if (mRdp->palettes[0] == nullptr || mRdp->palettes[1] == nullptr) {
-        SPDLOG_WARN("CI8: null palette (pal0={}, pal1={})", static_cast<const void*>(mRdp->palettes[0]),
-                    static_cast<const void*>(mRdp->palettes[1]));
+        // Returning here leaves the GPU texture holding whatever was in it — visible as noise on an
+        // otherwise correct model, so say so loudly (once per address, this runs per frame).
+        static std::unordered_set<const void*> sReportedNullPalettes;
+        if (sReportedNullPalettes.insert((const void*)addr).second) {
+            SPDLOG_ERROR("CI8: null palette (pal0={}, pal1={})", static_cast<const void*>(mRdp->palettes[0]),
+                         static_cast<const void*>(mRdp->palettes[1]));
+        }
         return;
     }
 
@@ -4272,7 +4281,11 @@ bool gfx_set_timg_otr_hash_handler_custom(F3DGfx** cmd0) {
             gfx->GfxDpSetTextureImage(fmt, size, width, fileName, texFlags, rawTexMetadata, tex);
         }
     } else {
-        SPDLOG_ERROR("G_SETTIMG_OTR_HASH: Texture is null");
+        // ComboShip: name it and log once per path — this fires every frame the model is on screen.
+        static std::unordered_set<std::string> sReportedNullTextures;
+        if (sReportedNullTextures.insert(fileName).second) {
+            SPDLOG_ERROR("G_SETTIMG_OTR_HASH: Texture is null ({})", fileName);
+        }
     }
 
     (*cmd0)++;

--- a/mm/src/code/z_draw.c
+++ b/mm/src/code/z_draw.c
@@ -557,6 +557,36 @@ s32 GetItem_GetDrawTableEntry(s32 drawId, void** outDlists, s32 maxDlists, s32* 
     }
     return count;
 }
+
+// ComboShip: the setup DL a row's draw func emits before its display lists, for the funcs that don't
+// use plain 25. NULL = 25 Opa/Xlu (the consumer's own). The foreign consumer must submit the SAME
+// setup: 23 is 1-CYCLE without fog, and a list authored for it renders through the wrong combiner
+// under 2-cycle 25 — the second cycle wins and samples TEXEL1, i.e. the host's leftover tile.
+void GetItem_GetDrawSetupDLs(s32 drawId, void** outOpa, void** outXlu) {
+    void (*drawFunc)(PlayState*, s16);
+
+    if (outOpa != NULL) {
+        *outOpa = NULL;
+    }
+    if (outXlu != NULL) {
+        *outXlu = NULL;
+    }
+    if ((drawId < 0) || (drawId >= (s32)ARRAY_COUNT(sDrawItemTable))) {
+        return;
+    }
+
+    drawFunc = sDrawItemTable[drawId].drawFunc;
+    if (drawFunc == GetItem_DrawBombchu) {
+        if (outOpa != NULL) {
+            *outOpa = gSetupDLs[SETUPDL_23];
+        }
+    } else if (drawFunc == GetItem_DrawCompass) {
+        // Compass keeps 25 on OPA and draws its glass with SETUPDL_5.
+        if (outXlu != NULL) {
+            *outXlu = gSetupDLs[SETUPDL_5];
+        }
+    }
+}
 #endif
 
 void GetItem_DrawBombchu(PlayState* play, s16 drawId) {

--- a/soh/src/code/z_draw.c
+++ b/soh/src/code/z_draw.c
@@ -414,8 +414,9 @@ void GetItem_Draw(PlayState* play, s16 drawId) {
 // color, grayscale) that can't be baked into a DL list: they set *outDrawKind to a CwDrawKind value
 // (see combo/menu/ComboItemDrawABI.h) and fill outColors for JEWEL/MUSIC_NOTE, and the foreign game's
 // per-kind handler re-binds the segment(s) + replays the matrices in its own frame. For those,
-// outDlists carries the raw table row (identity order). The 26Opa funcs are exposed as 25Opa (close
-// approximation). outColors is 16 bytes: primXlu[4], envXlu[4], primOpa[4], envOpa[4] (RGBA).
+// outDlists carries the raw table row (identity order). Rows drawn under a setup other than 25 are
+// reported by GetItem_GetDrawSetupDLs below — the consumer must submit that same setup, not 25.
+// outColors is 16 bytes: primXlu[4], envXlu[4], primOpa[4], envOpa[4] (RGBA).
 // Returns the dlist count, or 0 if the row is unsupported/undrawable.
 s32 GetItem_GetDrawTableEntry(s32 drawId, void** outDlists, s32 maxDlists, s32* outXluStart, f32* outScale,
                               s32* outDrawKind, u8* outColors) {
@@ -669,6 +670,48 @@ s32 GetItem_GetDrawTableEntry(s32 drawId, void** outDlists, s32 maxDlists, s32* 
     *outXluStart = (xluStart > count) ? count : xluStart;
     *outDrawKind = kind;
     return count;
+}
+
+// ComboShip: one setup DL by index, for the bespoke Randomizer_Draw* funcs whose setup the gid-keyed
+// table can't express (Jabber Nut / Bombchu Bag use 26 Opa, the rando compass 5 Xlu).
+void* GetItem_GetSetupDL(s32 index) {
+    extern Gfx sSetupDL[SETUPDL_MAX][6]; // z_rcp.c; not declared in a header
+
+    if ((index < 0) || (index >= SETUPDL_MAX)) {
+        return NULL;
+    }
+    return sSetupDL[index];
+}
+
+// ComboShip: the setup DL a row's draw func emits before its display lists, for the funcs that don't
+// use plain 25. NULL = 25 Opa/Xlu (the consumer's own). The foreign consumer must submit the SAME
+// setup: 26 is 1-CYCLE without fog, and a list authored for it renders through the wrong combiner
+// under 2-cycle 25 — the second cycle wins and samples TEXEL1, i.e. the host's leftover tile.
+void GetItem_GetDrawSetupDLs(s32 drawId, void** outOpa, void** outXlu) {
+    extern Gfx sSetupDL[SETUPDL_MAX][6]; // z_rcp.c; not declared in a header
+    void (*drawFunc)(PlayState*, s16);
+
+    if (outOpa != NULL) {
+        *outOpa = NULL;
+    }
+    if (outXlu != NULL) {
+        *outXlu = NULL;
+    }
+    if ((drawId < 0) || (drawId >= (s32)(sizeof(sDrawItemTable) / sizeof(sDrawItemTable[0])))) {
+        return;
+    }
+
+    drawFunc = sDrawItemTable[drawId].drawFunc;
+    if ((drawFunc == GetItem_DrawMaskOrBombchu) || (drawFunc == GetItem_DrawEggOrMedallion)) {
+        if (outOpa != NULL) {
+            *outOpa = sSetupDL[SETUPDL_26];
+        }
+    } else if ((drawFunc == GetItem_DrawSoldOut) || (drawFunc == GetItem_DrawCompass)) {
+        // Both draw their XLU layer with Gfx_SetupDL(POLY_XLU_DISP, 5); Compass keeps 25 on OPA.
+        if (outXlu != NULL) {
+            *outXlu = sSetupDL[5];
+        }
+    }
 }
 #endif
 


### PR DESCRIPTION
Foreign OOT items rendered in MM (and vice versa) could draw with a garbled surface on otherwise correct geometry — reported for the Bombchu and the Goron Mask. The corruption changed between runs and between rooms, and the same items looked fine in their home game.

## Cause

Cross-game item draws always emitted the *consumer's* `Gfx_SetupDL25_*`. Some items are authored for a different setup: OOT's `SETUPDL_26` is **1-cycle without fog**, and MM's `SETUPDL_23` likewise.

Those items' display lists carry a colour combiner that repeats itself across both cycles. Submitted under 2-cycle 25, the interpreter correctly:

1. eliminates cycle 0 as dead, since cycle 1 never reads `COMBINED` (`interpreter.cpp` `GenerateCC`), and
2. applies the hardware texel swap that makes cycle 1's `TEXEL0` mean `TEXEL1`.

The only surviving texture reference is then tile 1 — which those lists never configure — so the model sampled whatever the host game last left in TMEM slot 1. In a grotto that was the wall texture. Geometry survived because vertex references are pointer-patched once and never re-resolved, while textures re-resolve every frame; hence "right shape, wrong surface, different every time".

Resource routing was never involved: the `@oot:` lists and every hash inside them resolved correctly from the owning game's ResourceManager throughout.

## Fix

The two games' setup tables are not index-aligned (MM's 26 carries 25's combiner), so the consumer cannot substitute its own index. The owner now reports its real setup display list and the consumer submits that:

- `soh/src/code/z_draw.c`, `mm/src/code/z_draw.c` — `GetItem_GetDrawSetupDLs` (per table row) and `GetItem_GetSetupDL` (by index, for the bespoke `Randomizer_Draw*` funcs)
- `ComboItemDrawABI.h` — `setupDlOpa` / `setupDlXlu`, appended
- `ComboItemDrawOOT.h` / `ComboItemDrawMM.h` — fill them
- `ComboForeignDrawMM.h` / `ComboForeignDrawOOT.h` — submit the owner's setup in the SIMPLE and COLOR_LAYERS paths

The old exporter comment described the substitution as a "close approximation"; it was not.

Affected items now corrected: Bombchu, Goron/Zora/Gerudo Mask, eggs, medallions, sold-out sign, compass, Jabber Nut, Bombchu Bag — plus MM's Bombchu and compass drawn in OOT, which had the identical fault.

## Also included

The CI4/CI8 null-palette bailouts and the null-texture case in `interpreter.cpp` now log at error level, deduplicated. All three returned silently leaving a stale GPU texture bound, which is what kept this invisible.

## Testing

Playtested in MM: Goron Mask, Zora Mask, medallion, Bombchu, Bombchu Bag, Jabber Nut — all correct. That exercises every OPA path (setup 26 via the table with one and two lists, and via custom colour layers).

Not yet exercised: the 5-Xlu branch (sold-out sign, compass glass) and the MM→OOT mirror direction.


<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9668882610.zip)
<!--- section:artifacts:end -->