### PR TITLE
fix(hints): Ganondorf hint variants + foreign item names

### DIFF
--- a/combo/gui/ComboHintTracker.cpp
+++ b/combo/gui/ComboHintTracker.cpp
@@ -230,7 +230,8 @@ void Rebuild(const std::string& hintsJson, const std::string& readJson) {
         }
         const nlohmann::json* msgs = Node(e, "messages");
         if (msgs && msgs->is_array() && !msgs->empty()) {
-            en.text = Sanitize((*msgs)[0].value("en", std::string()));
+            // CrossHints::Generate pushes a multi-message hint's most complete variant last.
+            en.text = Sanitize(msgs->back().value("en", std::string()));
         }
         en.read = readOot.count(en.key) != 0;
         Group& grp = sGroups[OotGroupForType(e.value("type", std::string()))];

--- a/combo/rando/CrossHints.h
+++ b/combo/rando/CrossHints.h
@@ -10,6 +10,7 @@
 #include <array>
 #include <cstdint>
 #include <iostream>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -412,6 +413,26 @@ inline nlohmann::json Generate(uint32_t masterSeed, const std::string& sohDumpJs
         return EnglishOnly(plain);
     };
 
+    // Area text for an OOT item wherever it landed, in either game. nullopt = the item is in no
+    // check at all (starting item, or not shuffled in), so no hint may name a location for it.
+    // yourPocket mirrors the native Hint flag: only hints that set it say "your pocket".
+    auto itemAreaText = [&](const char* itemName, bool yourPocket = false) -> std::optional<Tri> {
+        auto it = std::find_if(placements.begin(), placements.end(),
+                               [&](const CwPlacedItem& p) { return p.itemGame == GAME_OOT && p.item == itemName; });
+        if (it == placements.end())
+            return std::nullopt;
+        if (it->checkGame != GAME_OOT) {
+            auto mk = mmLocationHints.find(it->check);
+            return areaText("mm:" + (mk != mmLocationHints.end() ? mk->second : it->check));
+        }
+        if (yourPocket && it->check == "Link's Pocket")
+            return PickTemplate(tmpl("RHT_YOUR_POCKET"), hintClarity, rng);
+        auto ck = ootChecks.find(it->check);
+        if (ck == ootChecks.end())
+            return std::nullopt;
+        return areaText("oot:" + ck->second.area);
+    };
+
     // Weighted pick of a not-yet-used index from `pool` (indices into `candidates` or an area vector),
     // via a caller-supplied "already used" predicate. Returns -1 when nothing remains.
     auto pickUnused = [&](const std::vector<size_t>& idxs, const std::vector<std::string>& keys,
@@ -445,17 +466,32 @@ inline nlohmann::json Generate(uint32_t masterSeed, const std::string& sohDumpJs
         }
     }
 
-    // Ganondorf hint: find the Light Arrows placement (always an OOT item) wherever it landed.
+    // Ganondorf hint. BuildGanondorfHint (StaticHints.cpp) picks the message BY INDEX from live
+    // state, so a shuffled Master Sword needs all three variants, in native's hintKeys order.
     if (ganondorfHintOn) {
-        auto it = std::find_if(candidates.begin(), candidates.end(), [](const HintCandidate& c) {
-            return c.itemGame == GAME_OOT && c.itemKey == "Light Arrows";
-        });
-        if (it != candidates.end()) {
-            Tri msg = PickTemplate(tmpl("RHT_GANONDORF_HINT_LA_ONLY"), hintClarity, rng);
-            ReplacePlaceholder(msg, 1, areaText(it->areaKey));
-            ootHints.push_back({ { "checkName", kGanondorfHintKey },
-                                 { "type", "ganondorf" },
-                                 { "messages", { { { "en", msg.en }, { "de", msg.de }, { "fr", msg.fr } } } } });
+        const std::optional<Tri> laArea = itemAreaText("Light Arrows", true);
+        const std::optional<Tri> msArea = itemAreaText("Master Sword", true);
+        const bool msShuffled =
+            options.value("shuffleMasterSword", 0) != 0 && options.value("startingMasterSword", 0) == 0;
+        // Native reads index 1/2 whenever the sword is shuffled, so an unresolvable sword must skip
+        // the whole hint (native then fills it) rather than answer those reads with the arrows' text.
+        if (laArea && (!msShuffled || msArea)) {
+            auto render = [&](const char* key) {
+                Tri m = PickTemplate(tmpl(key), hintClarity, rng);
+                ReplacePlaceholder(m, 1, *laArea);
+                if (msArea)
+                    ReplacePlaceholder(m, 2, *msArea);
+                return m;
+            };
+            nlohmann::json msgs = nlohmann::json::array();
+            auto push = [&](const Tri& m) { msgs.push_back({ { "en", m.en }, { "de", m.de }, { "fr", m.fr } }); };
+            push(render("RHT_GANONDORF_HINT_LA_ONLY"));
+            if (msShuffled) {
+                push(render("RHT_GANONDORF_HINT_MS_ONLY"));
+                push(render("RHT_GANONDORF_HINT_LA_AND_MS"));
+            }
+            ootHints.push_back(
+                { { "checkName", kGanondorfHintKey }, { "type", "ganondorf" }, { "messages", std::move(msgs) } });
         }
     }
 
@@ -465,25 +501,10 @@ inline nlohmann::json Generate(uint32_t masterSeed, const std::string& sohDumpJs
     // literal "[[N]]" in the displayed hint. Resolving each reward via `candidates` (which spans both
     // games) fills every slot regardless of which game holds it.
     if (options.value("totAltarHint", 0) != 0) {
-        // Searches the FULL placement list (not the advancement-filtered `candidates`) — dungeon
-        // rewards are always progression, but a fixed/own-dungeon reward's advancement stamp in the
-        // dump isn't guaranteed, and a missed reward here would wrongly read as "an unknown place".
+        // An unresolvable reward reads as "an unknown place" (pre-existing fill gap, not an
+        // altar-composition bug — see UPSTREAM_MERGES.md); the altar text always fills every slot.
         auto rewardArea = [&](const char* itemName) -> Tri {
-            auto it = std::find_if(placements.begin(), placements.end(),
-                                   [&](const CwPlacedItem& p) { return p.itemGame == GAME_OOT && p.item == itemName; });
-            if (it == placements.end())
-                return EnglishOnly("an unknown place"); // graceful: seen when a reward isn't in the
-                                                        // placement dump at all (pre-existing fill gap,
-                                                        // not an altar-composition bug — see UPSTREAM_MERGES.md)
-            if (it->checkGame == GAME_OOT) {
-                auto ck = ootChecks.find(it->check);
-                if (ck != ootChecks.end())
-                    return areaText("oot:" + ck->second.area);
-            } else {
-                auto mk = mmLocationHints.find(it->check);
-                return areaText("mm:" + (mk != mmLocationHints.end() ? mk->second : it->check));
-            }
-            return EnglishOnly("an unknown place");
+            return itemAreaText(itemName).value_or(EnglishOnly("an unknown place"));
         };
         auto endClause = [&](const char* jsonKey) -> Tri {
             std::string key = options.value(jsonKey, "");

--- a/docs/deviations/rando.md
+++ b/docs/deviations/rando.md
@@ -737,10 +737,12 @@ out-of-range index. The seed had Master Sword shuffled, so the player could neve
   means the hint is not emitted, so native fills that slot from its own placement instead: a static
   hint never names a location for an item that isn't in the pool.
 - `soh/soh/OTRGlobals.cpp` — `SOH_DumpRandoHintData` exports `shuffleMasterSword`/`startingMasterSword`;
-  `Combo_IsUsedHintTemplate` allows the two extra Ganondorf templates plus `RHT_YOUR_POCKET`;
-  `Combo_WalkComboHints` pads any combo MESSAGE hint to the count its slot can be read with
-  (`Combo_RequiredHintMessages`), so a seed generated before this change can no longer render an empty
-  box.
+  `Combo_IsUsedHintTemplate` allows the two extra Ganondorf templates plus `RHT_YOUR_POCKET`.
+- `soh/soh/Enhancements/randomizer/hint.cpp` — `GetHintMessage` falls back to the LAST message when a
+  builder indexes past a MESSAGE hint's payload, so an old seed (or any short payload) shows the one
+  variant it has instead of a blank box. It has to sit here, not in the apply walk: `LoadRandomizer`
+  rebuilds every hint from the save's own `comboMessagesEn` array AFTER `SOH_ApplyComboHints` runs, so
+  anything the walk padded is thrown away on a save load.
 - `soh/soh/Enhancements/randomizer/hint.cpp` — `GetItemHintText` resolves `RG_COMBO_FOREIGN` through
   the foreign map. The sentinel's own hint key is `RHT_NONE`, which renders as the literal string
   "No Hint", so every item-naming hint pointing at a cross-placed check used to say "I will give you

--- a/docs/deviations/rando.md
+++ b/docs/deviations/rando.md
@@ -720,8 +720,45 @@ runtime lookups on either game's side, since only the combo layer sees both worl
 
 **Known v1 limitations (documented, not bugs):** trial/gossip text for cross entries is English-only
 (no translation source); MM can't exclude an already-obtained OOT item from its own gossip pool
-(only its own-game repeat-hint pool is protected); Ganondorf's combined-hint phrasing variant isn't
-mirrored.
+(only its own-game repeat-hint pool is protected). ~~Ganondorf's combined-hint phrasing variant isn't
+mirrored~~ — fixed 2026-08-29, see below.
+
+## Ganondorf hint variants + foreign item names in hints (2026-08-29)
+
+**Why:** a player's Ganondorf hint showed an EMPTY textbox. `BuildGanondorfHint` (StaticHints.cpp)
+picks the message by INDEX from live state — 1 or 2 while Master Sword is shuffled and unowned — but
+the combo payload carried a single message, and `Hint::GetHintMessage` returns empty text for an
+out-of-range index. The seed had Master Sword shuffled, so the player could never see a hint.
+
+- `combo/rando/CrossHints.h` — new `itemAreaText` resolver (an OOT item's area wherever it landed, in
+  either game), shared with the altar block's `rewardArea`. The Ganondorf hint now emits all three
+  variants in native's `hintKeys` order (LA_ONLY / MS_ONLY / LA_AND_MS) when the sword is shuffled and
+  isn't a starting item. `nullopt` (item in no check at all — starting item, or category not shuffled)
+  means the hint is not emitted, so native fills that slot from its own placement instead: a static
+  hint never names a location for an item that isn't in the pool.
+- `soh/soh/OTRGlobals.cpp` — `SOH_DumpRandoHintData` exports `shuffleMasterSword`/`startingMasterSword`;
+  `Combo_IsUsedHintTemplate` allows the two extra Ganondorf templates plus `RHT_YOUR_POCKET`;
+  `Combo_WalkComboHints` pads any combo MESSAGE hint to the count its slot can be read with
+  (`Combo_RequiredHintMessages`), so a seed generated before this change can no longer render an empty
+  box.
+- `soh/soh/Enhancements/randomizer/hint.cpp` — `GetItemHintText` resolves `RG_COMBO_FOREIGN` through
+  the foreign map. The sentinel's own hint key is `RHT_NONE`, which renders as the literal string
+  "No Hint", so every item-naming hint pointing at a cross-placed check used to say "I will give you
+  No Hint!" (Loach, HBA, Malon, Big Poes, Chickens, Biggoron, Frogs, OoT, Mask Shop). A lookup that
+  races the blob push falls back to "something", never to the sentinel.
+- `soh/soh/Enhancements/randomizer/hook_handlers.{h,cpp}` — `OOT_LookupForeignByCheck`, the same
+  lookup keyed by check for callers with no save/location context.
+- `combo/gui/ComboHintTracker.cpp` — shows a multi-message hint's last (most complete) variant.
+
+Verified headlessly: regenerating the reported seed changes only the Ganondorf entry (1 -> 3 messages,
+message 0 byte-identical); all 42 other OOT hints, the MM hints and both placement maps are unchanged,
+because the new templates have no clarity variants and so draw nothing from the RNG.
+
+**Known limitations (unchanged):** composed area names are English in all three languages, including
+for OOT areas that do have translations (`areaText` wraps them in `EnglishOnly`); warp-song hints still
+use native's OOT-only area resolution; the 12 area-type NPC static hints (Sheik, boss keys, Dampé,
+Greg, Saria, Mido, Fishing Pole) still say "an Isolated Place" for a cross-placed target — that is the
+follow-up branch.
 
 **Settings-persistence fix (2026-07-16):** the silent file-select auto-reload
 (`Combo_OnReloadRequest(NULL)`) was writing the pending seed's `gRando.*` CVars over the user's

--- a/soh/soh/Enhancements/randomizer/hint.cpp
+++ b/soh/soh/Enhancements/randomizer/hint.cpp
@@ -290,6 +290,13 @@ const CustomMessage Hint::GetHintMessage(MessageFormat format, size_t id) const 
     if (hintType == HINT_TYPE_MESSAGE) {
         if (id < messages.size()) {
             hintText = messages[id];
+#ifdef COMBO_BUILD
+            // ComboShip: native builders read these slots by index off live state (Ganondorf reads 1
+            // and 2, Saria reads 1), but a combo payload — or a save written by an older build —
+            // may carry fewer. Fall back to the last message instead of an empty textbox.
+        } else if (!messages.empty()) {
+            hintText = messages.back();
+#endif
         }
     } else if (hintType == HINT_TYPE_ALTAR_CHILD) {
         if (ctx->GetOption(RSK_TOT_ALTAR_HINT)) {

--- a/soh/soh/Enhancements/randomizer/hint.cpp
+++ b/soh/soh/Enhancements/randomizer/hint.cpp
@@ -4,6 +4,9 @@
 #include <spdlog/spdlog.h>
 #include "static_data.h"
 #include "rng.h"
+#ifdef COMBO_BUILD
+#include "soh/Enhancements/randomizer/hook_handlers.h" // ComboShip: OOT_LookupForeignByCheck
+#endif
 
 namespace Rando {
 Hint::Hint() {
@@ -520,6 +523,17 @@ const HintText Hint::GetItemHintText(uint8_t slot, bool mysterious) const {
         // item hints read as sentences, so the fake name needs its article like a real item's hint has
         return HintText(CustomMessage(
             { ctx->overrides[hintedCheck].GetTrickArticle() + ctx->overrides[hintedCheck].GetTrickName() }));
+#ifdef COMBO_BUILD
+    } else if (targetRG == RG_COMBO_FOREIGN) {
+        // ComboShip: the sentinel's own hint text is "No Hint" — name the real MM item instead.
+        // A foreign trap is hinted under its typo'd disguise name, like OOT's own ice traps.
+        const ComboRando::ForeignItem* fi = OOT_LookupForeignByCheck(hintedCheck);
+        std::string shown = fi == nullptr ? "" : (fi->fakeTrickName.empty() ? fi->displayName : fi->fakeTrickName);
+        if (shown.empty()) { // lookup raced the blob push: "something", never the sentinel's "No Hint"
+            return StaticData::hintTextTable[RHT_MYSTERIOUS_ITEM];
+        }
+        return HintText(CustomMessage(shown, shown, shown));
+#endif
     } else {
         return ctx->GetItemLocation(hintedCheck)->GetPlacedItem().GetHint();
     }

--- a/soh/soh/Enhancements/randomizer/hook_handlers.cpp
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.cpp
@@ -436,6 +436,12 @@ const ComboRando::ForeignItem* OOT_LookupForeign(int slot, const std::string& ch
     return it == g_ootForeignMap.end() ? nullptr : &it->second;
 }
 
+// ComboShip: the same lookup keyed by check, for callers with no save/location context of their own.
+const ComboRando::ForeignItem* OOT_LookupForeignByCheck(RandomizerCheck rc) {
+    const std::string& name = Rando::StaticData::GetLocation(rc)->GetName();
+    return name.empty() ? nullptr : OOT_LookupForeign(gSaveContext.fileNum, name);
+}
+
 // ComboShip: foreign[].category -> OOT container-art category. Unknown and MM-only (mask,
 // strayFairy) map to MAJOR — over-promising beats dressing a major item as junk.
 static GetItemCategory ForeignCategoryFromName(const std::string& name) {

--- a/soh/soh/Enhancements/randomizer/hook_handlers.h
+++ b/soh/soh/Enhancements/randomizer/hook_handlers.h
@@ -10,6 +10,8 @@
 #include "soh/Enhancements/item-tables/ItemTableTypes.h"
 // ComboShip: per-slot foreign-item lookup (defined in hook_handlers.cpp).
 const ComboRando::ForeignItem* OOT_LookupForeign(int slot, const std::string& checkName);
+// ComboShip: same lookup keyed by check, for callers that have no save/location context.
+const ComboRando::ForeignItem* OOT_LookupForeignByCheck(RandomizerCheck rc);
 // ComboShip: the foreign item's home-game container category, so Container Matches Contents doesn't
 // render every foreign check as the junk sentinel. Defined in hook_handlers.cpp.
 GetItemCategory OOT_GetForeignCategory(RandomizerCheck rc);

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -4543,21 +4543,6 @@ static bool sComboHintsPresent = false;
 static std::unordered_map<int, std::string> sComboHintKeys;
 static uint64_t sComboHintKeysGen = (uint64_t)-1; // OOT_ForeignMapGen() the map was built for
 
-// ComboShip: how many messages a hint slot may be read with — some builders index by live state.
-// Mirrors Hint::GetNumberOfMessages (hint.cpp), which can't be used here: the Hint doesn't exist yet.
-// Ganondorf's 3 variants are hardcoded because it's special-cased out of staticHintInfoMap.
-static size_t Combo_RequiredHintMessages(RandomizerHint rh) {
-    if (rh == RH_GANONDORF_HINT) {
-        return 3;
-    }
-    auto it = Rando::StaticData::staticHintInfoMap.find(rh);
-    if (it == Rando::StaticData::staticHintInfoMap.end()) {
-        return 1;
-    }
-    size_t n = it->second.hintKeys.size();
-    return n > 0 ? n : 1;
-}
-
 // ComboShip: one resolution walk over a combo hints payload, shared by apply and by the lazy map
 // replay. `isTaken` reports an already-claimed hint slot; `emit` receives each resolution in claiming
 // order. Both callers MUST walk this identically or the sentinel -> stone mapping drifts.
@@ -4612,12 +4597,6 @@ Combo_WalkComboHints(const nlohmann::json& hints, const std::function<bool(Rando
         if (rh == RH_NONE || isTaken(rh)) {
             ++skipped;
             continue;
-        }
-        // A payload with fewer messages than the slot can be read with would render an empty
-        // textbox (unshuffled Master Sword, or a seed generated before the 3-variant Ganondorf
-        // text existed), so pad with the first.
-        for (size_t need = Combo_RequiredHintMessages(rh); messages.size() < need;) {
-            messages.push_back(messages[0]);
         }
         emit(rh, checkName, messages);
         ++applied;

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -4244,6 +4244,9 @@ static bool Combo_IsUsedHintTemplate(const std::string& name) {
         "RHT_CAN_BE_FOUND_AT",
         "RHT_HOARDS",
         "RHT_GANONDORF_HINT_LA_ONLY",
+        "RHT_GANONDORF_HINT_MS_ONLY",
+        "RHT_GANONDORF_HINT_LA_AND_MS",
+        "RHT_YOUR_POCKET",
         // Altar templates + option-driven end clauses (Fix 3: combo composes altar hints itself).
         "RHT_CHILD_ALTAR_STONES",
         "RHT_CHILD_ALTAR_TEXT_END_DOTOPEN",
@@ -4404,6 +4407,9 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoHintData(void) {
             { "hintClarity", static_cast<int>(ctx->GetOption(RSK_HINT_CLARITY).Get()) },
             { "hintDistribution", static_cast<int>(ctx->GetOption(RSK_HINT_DISTRIBUTION).Get()) },
             { "ganondorfHint", static_cast<int>(ctx->GetOption(RSK_GANONDORF_HINT).Get()) },
+            // Ganondorf's hint text has three variants, chosen by these two (see CreateGanondorfHint).
+            { "shuffleMasterSword", static_cast<int>(ctx->GetOption(RSK_SHUFFLE_MASTER_SWORD).Get()) },
+            { "startingMasterSword", static_cast<int>(ctx->GetOption(RSK_STARTING_MASTER_SWORD).Get()) },
             { "warpSongHints", static_cast<int>(ctx->GetOption(RSK_WARP_SONG_HINTS).Get()) },
             { "totAltarHint", static_cast<int>(ctx->GetOption(RSK_TOT_ALTAR_HINT).Get()) },
             { "doorOfTimeTemplate", doorOfTimeKey },
@@ -4537,6 +4543,21 @@ static bool sComboHintsPresent = false;
 static std::unordered_map<int, std::string> sComboHintKeys;
 static uint64_t sComboHintKeysGen = (uint64_t)-1; // OOT_ForeignMapGen() the map was built for
 
+// ComboShip: how many messages a hint slot may be read with — some builders index by live state.
+// Mirrors Hint::GetNumberOfMessages (hint.cpp), which can't be used here: the Hint doesn't exist yet.
+// Ganondorf's 3 variants are hardcoded because it's special-cased out of staticHintInfoMap.
+static size_t Combo_RequiredHintMessages(RandomizerHint rh) {
+    if (rh == RH_GANONDORF_HINT) {
+        return 3;
+    }
+    auto it = Rando::StaticData::staticHintInfoMap.find(rh);
+    if (it == Rando::StaticData::staticHintInfoMap.end()) {
+        return 1;
+    }
+    size_t n = it->second.hintKeys.size();
+    return n > 0 ? n : 1;
+}
+
 // ComboShip: one resolution walk over a combo hints payload, shared by apply and by the lazy map
 // replay. `isTaken` reports an already-claimed hint slot; `emit` receives each resolution in claiming
 // order. Both callers MUST walk this identically or the sentinel -> stone mapping drifts.
@@ -4591,6 +4612,12 @@ Combo_WalkComboHints(const nlohmann::json& hints, const std::function<bool(Rando
         if (rh == RH_NONE || isTaken(rh)) {
             ++skipped;
             continue;
+        }
+        // A payload with fewer messages than the slot can be read with would render an empty
+        // textbox (unshuffled Master Sword, or a seed generated before the 3-variant Ganondorf
+        // text existed), so pad with the first.
+        for (size_t need = Combo_RequiredHintMessages(rh); messages.size() < need;) {
+            messages.push_back(messages[0]);
         }
         emit(rh, checkName, messages);
         ++applied;


### PR DESCRIPTION
A player's Ganondorf hint rendered as an **empty textbox**, even though the text was in their spoiler.

`BuildGanondorfHint` picks its message **by index** from live state — 1 or 2 while the Master Sword is
shuffled and unowned — but the combo payload carried a single message, and `Hint::GetHintMessage`
returns empty text for an out-of-range index. With Master Sword shuffled the player was permanently in
that branch, so Ganondorf never said anything.

## What changed

- **`combo/rando/CrossHints.h`** — new `itemAreaText` resolver: an OOT item's area wherever it landed,
  in either game, shared with the altar block. Ganondorf now emits all three variants in native's
  `hintKeys` order (LA_ONLY / MS_ONLY / LA_AND_MS) when the sword is shuffled and isn't a starting item.
  An item in no check at all (starting item, or category not shuffled) means the hint isn't emitted, so
  native fills that slot from its own placement — a static hint never names a location for an item
  that isn't in the pool.
- **`hint.cpp` — `GetHintMessage`** falls back to the *last* message when a builder indexes past a
  MESSAGE hint's payload. This has to sit at read time, not in the apply walk: `LoadRandomizer`
  rebuilds every combo hint from the save's own `comboMessagesEn` array **after**
  `SOH_ApplyComboHints` runs, so anything the walk fixes up is discarded on a save load. That is why
  seeds generated before this branch showed a blank box; they now show the one variant they have.
- **`hint.cpp` — `GetItemHintText`** resolves `RG_COMBO_FOREIGN` through the foreign map. The
  sentinel's hint key is `RHT_NONE`, which renders as the literal string "No Hint", so every
  item-naming static hint pointing at a cross-placed check used to say *"I will give you No Hint!"*
  (Loach, HBA, Malon, Big Poes, Chickens, Biggoron, Frogs, OoT, Mask Shop). Falls back to
  "something", never to the sentinel.
- **`hook_handlers.{h,cpp}`** — `OOT_LookupForeignByCheck`, the same lookup keyed by check.
- **`OTRGlobals.cpp`** — the dump exports `shuffleMasterSword`/`startingMasterSword`; the two extra
  Ganondorf templates and `RHT_YOUR_POCKET` are allowlisted.
- **`combo/gui/ComboHintTracker.cpp`** — shows a multi-message hint's most complete variant.

Vendored delta in `soh/` is 33 lines (`hint.cpp` +21, `OTRGlobals.cpp` +6, `hook_handlers.cpp` +6;
`hook_handlers.h` is combo-owned).

## Verification

Headless: regenerating the reported seed changes only the Ganondorf entry (1 -> 3 messages, message 0
byte-identical). All 42 other OOT hints, the MM hints and both placement maps are unchanged — the new
templates have no clarity variants, so they draw nothing from the RNG.

Playtested in Debug on a fresh seed with the Master Sword shuffled:

| Case | Result |
|---|---|
| Neither item owned | combined hint, Ice Cavern + Deku Tree |
| Light Arrows owned | sword-only hint |
| Master Sword owned | arrows-only hint |
| Pre-fix seed, no regeneration | shows its Light Arrows text instead of a blank box |

That seed also placed **MM's** Light Arrows at `Ganon's Castle Deku Scrub Left` while OOT's sat in
`Ice Cavern GS Push Block Room`. The hint named Ice Cavern: `ParseSpoilerPlacements` strips the
"(OOT)"/"(MM)" display suffix, so the two copies share a name and only `itemGame` separates them —
which is what the resolver matches on.

**Not covered:** the foreign item-name path has no playtest. It needs an MM item landing on Big Poes,
Biggoron, Frogs, Malon, Chickens, HBA, Loach or the Mask Shop, which no generated seed hit. The lookup
is the same one the skulltula hints already use.

## Known limitations (unchanged)

Composed area names are English in all three languages; warp-song hints still use native's OOT-only
area resolution; the 12 area-type NPC static hints (Sheik, boss keys, Dampé, Greg, Saria, Mido,
Fishing Pole) still say "an Isolated Place" for a cross-placed target — that is the follow-up branch.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9741870060.zip)
<!--- section:artifacts:end -->