### PR TITLE
fix(soh): pause name-panel crash after MM return (uninit __OTR__ path)

### DIFF
--- a/docs/deviations/resource-mgmt.md
+++ b/docs/deviations/resource-mgmt.md
@@ -198,10 +198,26 @@ Two alternatives were rejected and should stay rejected:
 **`mm/2s2h/BenPort.cpp` + `soh/soh/ResourceManagerHelpers.cpp` (COMBO_BUILD-guarded):**
 `ResourceMgr_LoadIfDListByName` returns null on a miss instead of dereferencing. Both callers already
 test the return (`stubs.c:163`, `GbiWrap.cpp:48`), so the function's contract already admitted null —
-it just failed to produce it. The sibling `ResourceMgr_LoadTexOrDListByName` has the identical
-unguarded deref but is left alone: no `Cfa*` path reaches it via `gSPSegmentLoadRes` today. The other
-~11 unchecked `GetResourceByName` sites in `BenPort.cpp` are a vendored 2Ship pattern whose callers
-deref unconditionally, so guarding them would relocate the crash rather than fix it.
+it just failed to produce it. The sibling `ResourceMgr_LoadTexOrDListByName` now carries the same
+guard on both hosts (see the pause name-panel entry below — `gSPInvalidateTexCache` reaches it). The
+other ~11 unchecked `GetResourceByName` sites in `BenPort.cpp` are a vendored 2Ship pattern whose
+callers deref unconditionally, so guarding them would relocate the crash rather than fix it.
+
+**`soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c` (COMBO_BUILD-guarded) +
+`ResourceMgr_LoadTexOrDListByName` on both hosts:** OOT's pause menu `malloc`s a fresh, never-freed
+`pauseCtx->nameSegment` on every open, and only `KaleidoScope_UpdateNamePanel` (gated to specific
+pause states) ever writes a name-texture path into it. `KaleidoScope_DrawEquipment` runs
+`gSPInvalidateTexCache(POLY_OPA_DISP++, pauseCtx->nameSegment)` every drawn frame — during the
+opening animation and page rotation too — and that wrapper (`GbiWrap.cpp`, `stubs.c`) sig-checks the
+buffer's **contents** for `__OTR__` and resolves them via `ResourceMgr_LoadTexOrDListByName`. In a
+single-game process a stale `__OTR__` string in recycled heap is at worst a valid host path; under
+ComboShip the same heap has just hosted an MM session, so it can hold an MM resource path that misses
+OOT's RM → `LoadResource` returns null → unguarded `GetInitData()` deref → 0xC0000005. Reproduced
+from a player crash report (v0.3.0, develop `2caad20`, DMC after an MM→OOT return, pause on the
+Equipment page; the export-approx frame `Ship::ControlPort::GetConnectedDevice+0xD` is an ICF alias of
+`IResource::GetInitData`). Fix: `calloc` the buffer so uninitialised memory can never pass the sig
+check, and give `LoadTexOrDListByName` the same null-on-miss contract as `LoadIfDListByName` — its
+GBI callers already tolerate a 0 address.
 
 ## MM transition-actor ids re-normalized on scene load (Woodfall door fix) (2026-08-05)
 

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -1672,6 +1672,13 @@ extern "C" uint16_t ResourceMgr_LoadTexHeightByName(char* texPath);
 extern "C" char* ResourceMgr_LoadTexOrDListByName(const char* filePath) {
     auto res = GetResourceByName(filePath);
 
+#ifdef COMBO_BUILD
+    // ComboShip: a miss returns null here (same as ResourceMgr_LoadIfDListByName). The GBI wrappers
+    // that reach this (stubs.c gSPInvalidateTexCache / gSPSegmentLoadRes) tolerate a null address.
+    if (res == nullptr) {
+        return nullptr;
+    }
+#endif
     if (res->GetInitData()->Type == static_cast<uint32_t>(Fast::ResourceType::DisplayList))
         return (char*)&((std::static_pointer_cast<Fast::DisplayList>(res))->Instructions[0]);
     else if (res->GetInitData()->Type == static_cast<uint32_t>(SOH::ResourceType::SOH_Array))

--- a/soh/soh/ResourceManagerHelpers.cpp
+++ b/soh/soh/ResourceManagerHelpers.cpp
@@ -349,6 +349,14 @@ extern "C" char* ResourceMgr_LoadJPEG(char* data, size_t dataSize) {
 extern "C" char* ResourceMgr_LoadTexOrDListByName(const char* filePath) {
     auto res = ResourceMgr_GetResourceByNameHandlingMQ(filePath);
 
+#ifdef COMBO_BUILD
+    // ComboShip: a miss returns null here (same as ResourceMgr_LoadIfDListByName). The GBI wrappers
+    // that reach this (gSPInvalidateTexCache / gSPSegmentLoadRes) tolerate a null address, so this
+    // turns a resolve miss into a no-op rather than an access violation on GetInitData().
+    if (res == nullptr) {
+        return nullptr;
+    }
+#endif
     if (res->GetInitData()->Type == static_cast<uint32_t>(Fast::ResourceType::DisplayList)) {
         return (char*)&((std::static_pointer_cast<Fast::DisplayList>(res))->Instructions[0]);
     }

--- a/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
+++ b/soh/src/overlays/misc/ovl_kaleido_scope/z_kaleido_scope_PAL.c
@@ -3974,7 +3974,15 @@ void KaleidoScope_Update(PlayState* play) {
 #endif
 
             // pauseCtx->nameSegment = (void*)(((uintptr_t)pauseCtx->iconItemLangSegment + size + 0xF) & ~0xF);
+#ifdef COMBO_BUILD
+            // ComboShip: zero the buffer. KaleidoScope_DrawEquipment runs gSPInvalidateTexCache on it (which
+            // sig-checks the CONTENTS for "__OTR__" and resolves them as a path) before UpdateNamePanel has
+            // ever written a name into it. Recycled heap here can hold an MM resource path left over from the
+            // other game's session, which misses OOT's RM — see docs/deviations/resource-mgmt.md.
+            pauseCtx->nameSegment = calloc(1, 0x400 + 0xA00); // OTRTODO: GET RID OF THIS
+#else
             pauseCtx->nameSegment = malloc(0x400 + 0xA00); // OTRTODO: GET RID OF THIS
+#endif
 
             osSyncPrintf("サイズ＝%x\n", size2 + size1 + size0 + size);
             osSyncPrintf("item_name I_N_PT=%x\n", 0x800);


### PR DESCRIPTION
Player crash report from nightly (v0.3.0, develop 2caad20): `0xC0000005 in soh.dll` while pausing on the Equipment page in DMC after an MM->OOT return. The export- approx frame "Ship::ControlPort::GetConnectedDevice+0xD" is an ICF alias of `IResource::GetInitData`; the real chain is `KaleidoScope_DrawEquipment` -> `gSPInvalidateTexCache(pauseCtx->nameSegment)` -> `ResourceMgr_LoadTexOrDListByName` -> null resource deref.

`pauseCtx->nameSegment` is `malloc`'d fresh (never freed) on every pause open and only `KaleidoScope_UpdateNamePanel` writes a texture path into it, while `DrawEquipment` sig-checks its CONTENTS for "__OTR__" every drawn frame, before the panel is ever populated. Recycled heap after an MM session can hold an MM resource path, which misses OOT's RM and returns null.

- `z_kaleido_scope_PAL.c`: calloc the buffer so uninitialized memory can never pass the OTR signature check.
- `ResourceMgr_LoadTexOrDListByName` (soh + 2ship): return null on a miss, the same contract `LoadIfDListByName` already has; both GBI wrapper callers tolerate a 0 address.
- `docs/deviations/resource-mgmt.md`: record the deviation.

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9828562114.zip)
<!--- section:artifacts:end -->