### PR TITLE
fix(hints): compose NPC item hints from the two-game placement list

### DIFF
--- a/combo/gui/ComboHintTracker.cpp
+++ b/combo/gui/ComboHintTracker.cpp
@@ -15,6 +15,7 @@
 #include <mutex>
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace ComboRando {
@@ -138,6 +139,26 @@ std::string LabelForOotKey(const std::string& key, int ordinal) {
     if (key == "__ALTAR_ADULT__") {
         return "Adult Altar";
     }
+    if (HasPrefix(key, "__STATIC__")) {
+        // "__STATIC__<RandomizerHint>" (CrossHints.h kStaticHintPrefix): the NPC that speaks it.
+        static const std::unordered_map<std::string, const char*> kNpcLabels = {
+            { "RH_SHEIK_HINT", "Sheik (Ganon's Castle)" },
+            { "RH_FOREST_BOSS_KEY_HINT", "Forest Temple Boss Door" },
+            { "RH_FIRE_BOSS_KEY_HINT", "Fire Temple Boss Door" },
+            { "RH_WATER_BOSS_KEY_HINT", "Water Temple Boss Door" },
+            { "RH_SPIRIT_BOSS_KEY_HINT", "Spirit Temple Boss Door" },
+            { "RH_SHADOW_BOSS_KEY_HINT", "Shadow Temple Boss Door" },
+            { "RH_GANONS_BOSS_KEY_HINT", "Ganon's Tower Boss Door" },
+            { "RH_DAMPES_DIARY", "Dampe's Diary" },
+            { "RH_GREG_RUPEE", "Treasure Chest Shop (Greg)" },
+            { "RH_SARIA_HINT", "Saria" },
+            { "RH_MIDO_HINT", "Mido" },
+            { "RH_FISHING_POLE", "Fishing Pond Owner" },
+        };
+        const std::string rh = key.substr(10);
+        auto it = kNpcLabels.find(rh);
+        return it != kNpcLabels.end() ? it->second : rh;
+    }
     if (HasPrefix(key, "__STONE__")) {
         return "Gossip Stone #" + std::to_string(ordinal);
     }
@@ -155,7 +176,17 @@ std::string LabelForOotKey(const std::string& key, int ordinal) {
 
 // Display group of an OOT hint, by its generator "type". Indices into the group list Rebuild lays
 // out; keep the two in sync.
-enum OotGroup { kGrpStones = 0, kGrpAltarChild, kGrpAltarAdult, kGrpGanondorf, kGrpTrials, kGrpAlways, kGrpJunk };
+enum OotGroup {
+    kGrpStones = 0,
+    kGrpAltarChild,
+    kGrpAltarAdult,
+    kGrpGanondorf,
+    kGrpNpc,
+    kGrpTrials,
+    kGrpAlways,
+    kGrpJunk,
+    kGrpCount
+};
 
 int OotGroupForType(const std::string& type) {
     if (type == "altarChild") {
@@ -166,6 +197,9 @@ int OotGroupForType(const std::string& type) {
     }
     if (type == "ganondorf") {
         return kGrpGanondorf;
+    }
+    if (type == "static") {
+        return kGrpNpc;
     }
     if (type == "trial") {
         return kGrpTrials;
@@ -182,11 +216,12 @@ int OotGroupForType(const std::string& type) {
 // Rebuild the display model from the pushed strings. Corrupt input -> empty (never throws).
 void Rebuild(const std::string& hintsJson, const std::string& readJson) {
     sGroups.clear();
-    sGroups.resize(7);
+    sGroups.resize(kGrpCount);
     sGroups[kGrpStones].title = "Gossip Stones";
     sGroups[kGrpAltarChild].title = "Temple of Time Altar (Child)";
     sGroups[kGrpAltarAdult].title = "Temple of Time Altar (Adult)";
     sGroups[kGrpGanondorf].title = "Ganondorf";
+    sGroups[kGrpNpc].title = "NPC Item Hints";
     sGroups[kGrpTrials].title = "Trials";
     sGroups[kGrpAlways].title = "Always Hints";
     sGroups[kGrpJunk].title = "Junk Hints";

--- a/combo/rando/CrossHints.h
+++ b/combo/rando/CrossHints.h
@@ -183,6 +183,9 @@ inline const std::array<Preset, 4>& HintPresets() {
 // Sentinel checkName SOH_ApplyComboHints recognizes for the Ganondorf hint (RH_GANONDORF_HINT) —
 // avoids needing a runtime string->RandomizerHint lookup for this one special-cased slot.
 inline constexpr const char* kGanondorfHintKey = "__GANONDORF__";
+// Sentinel prefix for the area-type NPC item hints (Sheik, boss doors, Dampé, Greg, Saria, Mido,
+// fishing pond): "__STATIC__<RandomizerHint enum name>", mapped back in SOH_ApplyComboHints.
+inline constexpr const char* kStaticHintPrefix = "__STATIC__";
 
 // masterSeed: same seed the fill used (all randomness here derives from it, seeded independently via
 // the XOR tag, so hint generation is deterministic without perturbing the fill's own RNG stream).
@@ -413,12 +416,16 @@ inline nlohmann::json Generate(uint32_t masterSeed, const std::string& sohDumpJs
         return EnglishOnly(plain);
     };
 
+    // First placement holding the OOT item, in either game (placements.end() = in no check).
+    auto findOotItem = [&](const char* itemName) {
+        return std::find_if(placements.begin(), placements.end(),
+                            [&](const CwPlacedItem& p) { return p.itemGame == GAME_OOT && p.item == itemName; });
+    };
     // Area text for an OOT item wherever it landed, in either game. nullopt = the item is in no
     // check at all (starting item, or not shuffled in), so no hint may name a location for it.
     // yourPocket mirrors the native Hint flag: only hints that set it say "your pocket".
     auto itemAreaText = [&](const char* itemName, bool yourPocket = false) -> std::optional<Tri> {
-        auto it = std::find_if(placements.begin(), placements.end(),
-                               [&](const CwPlacedItem& p) { return p.itemGame == GAME_OOT && p.item == itemName; });
+        auto it = findOotItem(itemName);
         if (it == placements.end())
             return std::nullopt;
         if (it->checkGame != GAME_OOT) {
@@ -492,6 +499,66 @@ inline nlohmann::json Generate(uint32_t masterSeed, const std::string& sohDumpJs
             }
             ootHints.push_back(
                 { { "checkName", kGanondorfHintKey }, { "type", "ganondorf" }, { "messages", std::move(msgs) } });
+        }
+    }
+
+    // Area-type NPC item hints (Sheik, boss doors, Dampé's diary, Greg, Saria, Mido, fishing pond):
+    // native CreateStaticHintFromData resolves each target item via FindItemsAndMarkHinted, which only
+    // searches OOT's own checks — an item cross-placed into MM comes back RC_UNKNOWN_CHECK, whose empty
+    // area set renders as RA_NONE, "an Isolated Place". Composed here from the two-game placement list
+    // instead (same resolution as the Ganondorf/altar hints above); SOH_ApplyComboHints maps each
+    // sentinel back to its RandomizerHint and native's builder then self-skips the enabled key. An
+    // item in no check at all (starting item, not shuffled) is left to native, so that case behaves
+    // exactly as before. None of these templates has clarity variants, so the block draws nothing from
+    // the RNG and the stone picks below are unchanged for existing seeds.
+    {
+        struct StaticItemHint {
+            const char* hint;                   // RandomizerHint enum name (sentinel suffix)
+            const char* option;                 // hint dump options[] key; 0 = NPC hint turned off
+            std::vector<const char*> templates; // one message per native hintKeys entry, same order
+            const char* item;                   // OOT item English name (placement item key)
+            bool yourPocket;                    // native StaticHintInfo yourPocket
+        };
+        // Mirrors StaticData::staticHintInfoMap (static_data.cpp) rows that carry targetItems.
+        static const std::vector<StaticItemHint> kStaticItemHints = {
+            { "RH_SHEIK_HINT", "sheikLaHint", { "RHT_SHEIK_HINT_LA_ONLY" }, "Light Arrows", true },
+            { "RH_FOREST_BOSS_KEY_HINT", "bossKeyHint", { "RHT_BOSS_KEY_HINT" }, "Forest Temple Boss Key", true },
+            { "RH_FIRE_BOSS_KEY_HINT", "bossKeyHint", { "RHT_BOSS_KEY_HINT" }, "Fire Temple Boss Key", true },
+            { "RH_WATER_BOSS_KEY_HINT", "bossKeyHint", { "RHT_BOSS_KEY_HINT" }, "Water Temple Boss Key", true },
+            { "RH_SPIRIT_BOSS_KEY_HINT", "bossKeyHint", { "RHT_BOSS_KEY_HINT" }, "Spirit Temple Boss Key", true },
+            { "RH_SHADOW_BOSS_KEY_HINT", "bossKeyHint", { "RHT_BOSS_KEY_HINT" }, "Shadow Temple Boss Key", true },
+            { "RH_GANONS_BOSS_KEY_HINT", "bossKeyHint", { "RHT_BOSS_KEY_HINT" }, "Ganon's Castle Boss Key", true },
+            { "RH_DAMPES_DIARY", "dampesDiaryHint", { "RHT_DAMPE_DIARY" }, "Progressive Hookshot", false },
+            { "RH_GREG_RUPEE", "gregHint", { "RHT_GREG_HINT" }, "Greg the Green Rupee", false },
+            { "RH_SARIA_HINT",
+              "sariaHint",
+              { "RHT_SARIA_TALK_HINT", "RHT_SARIA_SONG_HINT" },
+              "Progressive Magic Meter",
+              true },
+            { "RH_MIDO_HINT", "midoHint", { "RHT_MIDO_HINT" }, "Kokiri Sword", true },
+            { "RH_FISHING_POLE", "fishingPoleHint", { "RHT_FISHING_POLE_HINT" }, "Fishing Pole", true },
+        };
+        for (const StaticItemHint& sh : kStaticItemHints) {
+            if (options.value(sh.option, 0) == 0)
+                continue;
+            auto it = findOotItem(sh.item);
+            if (it == placements.end())
+                continue;
+            const std::optional<Tri> area = itemAreaText(sh.item, sh.yourPocket);
+            if (!area)
+                continue;
+            nlohmann::json msgs = nlohmann::json::array();
+            for (const char* key : sh.templates) {
+                Tri m = PickTemplate(tmpl(key), hintClarity, rng);
+                ReplacePlaceholder(m, 1, *area);
+                msgs.push_back({ { "en", m.en }, { "de", m.de }, { "fr", m.fr } });
+            }
+            ootHints.push_back({ { "checkName", std::string(kStaticHintPrefix) + sh.hint },
+                                 { "type", "static" },
+                                 { "messages", std::move(msgs) } });
+            // Native FindItemsAndMarkHinted marks the hinted check hint-accessible so the stones
+            // never re-target it; reserve it from the weighted loop the same way.
+            usedCheckKeys.insert((it->checkGame == GAME_OOT ? "oot:" : "mm:") + it->check);
         }
     }
 

--- a/docs/deviations/rando.md
+++ b/docs/deviations/rando.md
@@ -758,9 +758,9 @@ because the new templates have no clarity variants and so draw nothing from the 
 
 **Known limitations (unchanged):** composed area names are English in all three languages, including
 for OOT areas that do have translations (`areaText` wraps them in `EnglishOnly`); warp-song hints still
-use native's OOT-only area resolution; the 12 area-type NPC static hints (Sheik, boss keys, Dampé,
-Greg, Saria, Mido, Fishing Pole) still say "an Isolated Place" for a cross-placed target — that is the
-follow-up branch.
+use native's OOT-only area resolution; ~~the 12 area-type NPC static hints (Sheik, boss keys, Dampé,
+Greg, Saria, Mido, Fishing Pole) still say "an Isolated Place" for a cross-placed target~~ — fixed
+2026-09-02, see "NPC item hints resolve cross-placed items" below.
 
 **Settings-persistence fix (2026-07-16):** the silent file-select auto-reload
 (`Combo_OnReloadRequest(NULL)`) was writing the pending seed's `gRando.*` CVars over the user's
@@ -1731,3 +1731,41 @@ which retries until `2ship.dll` is loaded.
 - A hand-edited seed file with no `masterSeed` key falls back to 0 consistently on every path (latch,
   `SOH_SetComboRandoSeed`, the rolls), so all such seeds share one palette and one audio shuffle — the
   pre-existing behavior of `SOH_SetComboRandoSeed(0)`, not a new deviation.
+
+## NPC item hints resolve cross-placed items (2026-09-02)
+
+**Why:** a player's Greg hint (Treasure Chest Shop owner) said the rupee was "somewhere in an Isolated
+Place"; Greg was in a Snowhead Temple pot. Native `CreateStaticHintFromData` (hints.cpp) resolves each
+static hint's target item through `FindItemsAndMarkHinted`, which searches only `ctx->allLocations`
+(OOT's own checks). An item cross-placed into MM comes back `RC_UNKNOWN_CHECK`, whose empty area set
+is stored as `RA_NONE`, and `StaticData::areaNames[RA_NONE]` is `RHT_ISOLATED_PLACE`. The same path
+covered every area-type NPC hint with a target item: Sheik's Light Arrows, the six boss-door hints,
+Dampé's diary (hookshot), Greg, Saria (magic meter), Mido (Kokiri Sword) and the fishing pond owner.
+
+- `combo/rando/CrossHints.h` — new block after the Ganondorf hint composes those 12 hints from the
+  two-game placement list via the existing `itemAreaText` (Link's Pocket -> `RHT_YOUR_POCKET` for the
+  rows native flags `yourPocket`). Each is emitted as `"__STATIC__<RandomizerHint>"` with `type:
+  "static"`, one message per native `hintKeys` entry (Saria gets talk + song). The hinted check is
+  reserved in `usedCheckKeys`, mirroring native's `SetHintAccesible` (static hints are created before
+  stone/always hints natively, so stones never re-target them). An item in no check at all (starting
+  item, category not shuffled) is skipped and native fills the slot as before. These templates have no
+  clarity variants, so the block draws nothing from the RNG — existing seeds regenerate with identical
+  stone picks.
+- `soh/soh/OTRGlobals.cpp` — `SOH_DumpRandoHintData` exports the seven NPC hint options
+  (`sheikLaHint`, `bossKeyHint`, `dampesDiaryHint`, `gregHint`, `sariaHint`, `midoHint`,
+  `fishingPoleHint`); `Combo_IsUsedHintTemplate` allows the eight templates; `Combo_WalkComboHints`
+  maps the sentinel back to its `RandomizerHint` (checked BEFORE the generic `__` branch, which would
+  otherwise burn a gossip-stone slot on it). Native `CreateStaticHints()` then self-skips the enabled
+  key.
+- `soh/soh/Enhancements/randomizer/hint.cpp` — `GetHintMessage` re-stamps a MESSAGE-type Saria hint's
+  slot 1 as `TEXTBOX_TYPE_BLUE` (native's `RHT_SARIA_SONG_HINT` box type; the payload and the save
+  carry text only). Placed in the reader, not the apply walk, for the same reason as the last-message
+  fallback above it: `LoadRandomizer` rebuilds hints from the save arrays after the walk.
+- `combo/gui/ComboHintTracker.cpp` — new "NPC Item Hints" group, labelled by speaker.
+
+**Behavior change for OOT-placed targets too:** these hints are now composed by combo for every seed
+with the option on, not only cross-placed ones, so their area names follow the composer's conventions
+(English in all three languages, clear area name regardless of the obscure/ambiguous area-name pool
+native's `NamesChosen` draws from). Progressive items (hookshot, magic) hint the first copy in
+placement order, as native hinted the first copy in `allLocations` order — either copy is a valid
+target for both.

--- a/soh/soh/Enhancements/randomizer/hint.cpp
+++ b/soh/soh/Enhancements/randomizer/hint.cpp
@@ -298,6 +298,14 @@ const CustomMessage Hint::GetHintMessage(MessageFormat format, size_t id) const 
             hintText = messages.back();
 #endif
         }
+#ifdef COMBO_BUILD
+        // ComboShip: a combo-composed Saria hint's song message (slot 1) is natively a blue textbox
+        // (RHT_SARIA_SONG_HINT). The combo payload and the save carry text only, so restore it here —
+        // this is the one spot that survives LoadRandomizer rebuilding hints from the save arrays.
+        if (ownKey == RH_SARIA_HINT && id == 1) {
+            hintText.SetTextBoxType(TEXTBOX_TYPE_BLUE);
+        }
+#endif
     } else if (hintType == HINT_TYPE_ALTAR_CHILD) {
         if (ctx->GetOption(RSK_TOT_ALTAR_HINT)) {
             hintText = StaticData::hintTextTable[RHT_CHILD_ALTAR_STONES].GetHintMessage();

--- a/soh/soh/OTRGlobals.cpp
+++ b/soh/soh/OTRGlobals.cpp
@@ -4247,6 +4247,15 @@ static bool Combo_IsUsedHintTemplate(const std::string& name) {
         "RHT_GANONDORF_HINT_MS_ONLY",
         "RHT_GANONDORF_HINT_LA_AND_MS",
         "RHT_YOUR_POCKET",
+        // Area-type NPC item hints (combo composes these from the two-game placement list).
+        "RHT_SHEIK_HINT_LA_ONLY",
+        "RHT_BOSS_KEY_HINT",
+        "RHT_DAMPE_DIARY",
+        "RHT_GREG_HINT",
+        "RHT_SARIA_TALK_HINT",
+        "RHT_SARIA_SONG_HINT",
+        "RHT_MIDO_HINT",
+        "RHT_FISHING_POLE_HINT",
         // Altar templates + option-driven end clauses (Fix 3: combo composes altar hints itself).
         "RHT_CHILD_ALTAR_STONES",
         "RHT_CHILD_ALTAR_TEXT_END_DOTOPEN",
@@ -4412,6 +4421,15 @@ extern "C" __declspec(dllexport) const char* SOH_DumpRandoHintData(void) {
             { "startingMasterSword", static_cast<int>(ctx->GetOption(RSK_STARTING_MASTER_SWORD).Get()) },
             { "warpSongHints", static_cast<int>(ctx->GetOption(RSK_WARP_SONG_HINTS).Get()) },
             { "totAltarHint", static_cast<int>(ctx->GetOption(RSK_TOT_ALTAR_HINT).Get()) },
+            // Area-type NPC item hints (staticHintInfoMap rows with targetItems) the combo composer
+            // builds itself — native's FindItemsAndMarkHinted can't see an item cross-placed into MM.
+            { "sheikLaHint", static_cast<int>(ctx->GetOption(RSK_SHEIK_LA_HINT).Get()) },
+            { "bossKeyHint", static_cast<int>(ctx->GetOption(RSK_BOSS_KEY_HINT).Get()) },
+            { "dampesDiaryHint", static_cast<int>(ctx->GetOption(RSK_DAMPES_DIARY_HINT).Get()) },
+            { "gregHint", static_cast<int>(ctx->GetOption(RSK_GREG_HINT).Get()) },
+            { "sariaHint", static_cast<int>(ctx->GetOption(RSK_SARIA_HINT).Get()) },
+            { "midoHint", static_cast<int>(ctx->GetOption(RSK_MIDO_HINT).Get()) },
+            { "fishingPoleHint", static_cast<int>(ctx->GetOption(RSK_FISHING_POLE_HINT).Get()) },
             { "doorOfTimeTemplate", doorOfTimeKey },
             { "bridgeTemplate", bridge.first },
             { "bridgeCount", bridge.second },
@@ -4568,6 +4586,30 @@ Combo_WalkComboHints(const nlohmann::json& hints, const std::function<bool(Rando
             rh = RH_ALTAR_CHILD;
         } else if (checkName == "__ALTAR_ADULT__") {
             rh = RH_ALTAR_ADULT;
+        } else if (checkName.rfind("__STATIC__", 0) == 0) {
+            // "__STATIC__<RandomizerHint>": an area-type NPC item hint CrossHints.h composed from the
+            // two-game placement list (native's own builder only searches OOT checks). Once enabled
+            // here, CreateStaticHints() below self-skips the key.
+            static const std::unordered_map<std::string, RandomizerHint> kStaticHints = {
+                { "RH_SHEIK_HINT", RH_SHEIK_HINT },
+                { "RH_FOREST_BOSS_KEY_HINT", RH_FOREST_BOSS_KEY_HINT },
+                { "RH_FIRE_BOSS_KEY_HINT", RH_FIRE_BOSS_KEY_HINT },
+                { "RH_WATER_BOSS_KEY_HINT", RH_WATER_BOSS_KEY_HINT },
+                { "RH_SPIRIT_BOSS_KEY_HINT", RH_SPIRIT_BOSS_KEY_HINT },
+                { "RH_SHADOW_BOSS_KEY_HINT", RH_SHADOW_BOSS_KEY_HINT },
+                { "RH_GANONS_BOSS_KEY_HINT", RH_GANONS_BOSS_KEY_HINT },
+                { "RH_DAMPES_DIARY", RH_DAMPES_DIARY },
+                { "RH_GREG_RUPEE", RH_GREG_RUPEE },
+                { "RH_SARIA_HINT", RH_SARIA_HINT },
+                { "RH_MIDO_HINT", RH_MIDO_HINT },
+                { "RH_FISHING_POLE", RH_FISHING_POLE },
+            };
+            auto it = kStaticHints.find(checkName.substr(10));
+            if (it == kStaticHints.end()) {
+                ++skipped;
+                continue;
+            }
+            rh = it->second;
         } else if (checkName.rfind("__", 0) == 0) {
             // "__STONE__N"/"__TRIAL__.../"__JUNK__...": CrossHints.h assigns these to an abstract
             // stone SLOT (count only, not a specific check — combo doesn't pick which physical


### PR DESCRIPTION
OoT's NPC item hints (Sheik's Light Arrow hint, the six boss-door key hints, Dampé's diary, Greg, Saria's magic hint, Mido's Kokiri Sword hint and the fishing pond owner) resolved their target item through native `FindItemsAndMarkHinted`, which only searches OoT's own checks, so any of those items cross-placed into Majora's Mask came back as `RC_UNKNOWN_CHECK` and the hint read "an Isolated Place".

This change places those twelve hints in the combo generator instead (`CrossHints.h`), same as the two-game placement list the Ganondorf and altar hints already used, with the same templates, color encoding and area text, so a cross-placed item now names its MM region (e.g. "Snowhead Temple").

<!--- section:artifacts:start -->
### Build Artifacts
  - [ComboShip-windows.zip](https://nightly.link/Varuuna/ComboShip/actions/artifacts/9948358016.zip)
<!--- section:artifacts:end -->